### PR TITLE
fix: expose config to lint options API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.2
+
+- Adds `MarkdownLintConfig::to_lint_options()` so embedding applications can load `.markdownlint.json` and run `lint` without duplicating CLI conversion logic.
+- Routes CLI config handling through the same public conversion API to keep embedded and CLI behavior aligned.
+- Updates the embedding example and README to show config-to-options conversion.
+
 ## v0.4.1
 
 - Fixes the locale CLI option spelling by adding `--locale` as the canonical long flag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Use the crate directly when embedding linting into another Rust application.
 - `implemented_rules()`
 - `missing_rules()`
 - `MarkdownLintConfig`
+- `MarkdownLintConfig::to_lint_options()`
 
 Minimal embedding examples are available under [`examples/`](examples/):
 
-- `embedding.rs`: string checks, file tree checks, string fixes, config loading
+- `embedding.rs`: string checks, file tree checks, string fixes, config loading and config-to-options conversion
 
 ## CLI Install
 

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -16,9 +16,10 @@ fn main() -> Result<(), DynError> {
     println!("applied fixes: {}", fixed.applied_fixes);
 
     let config = MarkdownLintConfig::load(Path::new(".markdownlint.json"))?;
+    let configured_options = config.to_lint_options();
     println!("loaded config: {}", config.raw);
 
-    let markdown_files = lint_markdown_tree(Path::new("."), &options)?;
+    let markdown_files = lint_markdown_tree(Path::new("."), &configured_options)?;
     println!("checked markdown files: {markdown_files}");
 
     let rules = available_rules();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::i18n::{Locale, LocalizedDiagnostic, MessageParams};
-use crate::{fix_with_results, lint, LintOptions, MarkdownLintConfig, RuleConfig};
+use crate::{fix_with_results, lint, LintOptions, MarkdownLintConfig};
 use glob::{glob, Pattern};
 use ignore::{WalkBuilder, WalkState};
 use serde::Serialize;
@@ -158,7 +158,7 @@ fn run_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32, Stri
             continue;
         }
 
-        let options = options_from_config(&config);
+        let options = config.to_lint_options();
         let results = match lint(&content, &options) {
             Ok(results) => results,
             Err(err) => {
@@ -233,7 +233,7 @@ fn run_stdin_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32
             return Ok(2);
         }
     };
-    let options = options_from_config(&config);
+    let options = config.to_lint_options();
     if fix_mode {
         let results = lint(&content, &options).map_err(|err| err.to_string())?;
         let fixed = apply_fixes_until_stable(&content, results, &options)?;
@@ -532,63 +532,6 @@ fn plural(count: usize) -> &'static str {
     } else {
         "s"
     }
-}
-
-fn options_from_config(config: &MarkdownLintConfig) -> LintOptions {
-    let mut options = LintOptions::default();
-    let default_enabled = config
-        .raw
-        .as_object()
-        .and_then(|root| root.get("default"))
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(true);
-
-    for rule in crate::rules::markdown::MarkdownLinterOps::user_configurable_rules() {
-        if let Some(meta) = rule.official_meta() {
-            options.rules.insert(
-                meta.code.to_string(),
-                RuleConfig {
-                    enabled: default_enabled,
-                    properties: std::collections::HashMap::new(),
-                },
-            );
-        }
-    }
-
-    let Some(root) = config.raw.as_object() else {
-        return options;
-    };
-
-    for (key, value) in root {
-        if key == "default" {
-            continue;
-        }
-        let enabled = match value {
-            serde_json::Value::Bool(enabled) => *enabled,
-            serde_json::Value::Object(properties) => properties
-                .get("enabled")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(default_enabled),
-            _ => default_enabled,
-        };
-        let entry = options.rules.entry(key.clone()).or_default();
-        entry.enabled = enabled;
-        if let serde_json::Value::Object(properties) = value {
-            entry.properties = properties
-                .iter()
-                .filter(|(property, _)| property.as_str() != "enabled")
-                .map(|(property, value)| {
-                    let value = value
-                        .as_str()
-                        .map(ToOwned::to_owned)
-                        .unwrap_or_else(|| value.to_string());
-                    (property.clone(), value)
-                })
-                .collect();
-        }
-    }
-
-    options
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/rules/markdown/config.rs
+++ b/src/rules/markdown/config.rs
@@ -1,5 +1,5 @@
 use crate::rules::markdown::{MarkdownRule, RulePropertyType};
-use crate::Error;
+use crate::{Error, LintOptions, RuleConfig};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fmt;
@@ -55,6 +55,63 @@ impl MarkdownLintConfig {
 
     pub fn create_default() -> Self {
         Self::default()
+    }
+
+    pub fn to_lint_options(&self) -> LintOptions {
+        let mut options = LintOptions::default();
+        let default_enabled = self
+            .raw
+            .as_object()
+            .and_then(|root| root.get("default"))
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        for rule in crate::rules::markdown::MarkdownLinterOps::user_configurable_rules() {
+            if let Some(meta) = rule.official_meta() {
+                options.rules.insert(
+                    meta.code.to_string(),
+                    RuleConfig {
+                        enabled: default_enabled,
+                        properties: HashMap::new(),
+                    },
+                );
+            }
+        }
+
+        let Some(root) = self.raw.as_object() else {
+            return options;
+        };
+
+        for (key, value) in root {
+            if key == "default" {
+                continue;
+            }
+            let enabled = match value {
+                Value::Bool(enabled) => *enabled,
+                Value::Object(properties) => properties
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(default_enabled),
+                _ => default_enabled,
+            };
+            let entry = options.rules.entry(key.clone()).or_default();
+            entry.enabled = enabled;
+            if let Value::Object(properties) = value {
+                entry.properties = properties
+                    .iter()
+                    .filter(|(property, _)| property.as_str() != "enabled")
+                    .map(|(property, value)| {
+                        let value = value
+                            .as_str()
+                            .map(ToOwned::to_owned)
+                            .unwrap_or_else(|| value.to_string());
+                        (property.clone(), value)
+                    })
+                    .collect();
+            }
+        }
+
+        options
     }
 
     pub fn set_rule_enabled(&mut self, rule_id: &str, enabled: bool) {
@@ -612,6 +669,59 @@ mod tests {
                     }
                 )
         }));
+    }
+
+    #[test]
+    fn to_lint_options_matches_markdownlint_config_semantics() {
+        let config = MarkdownLintConfig {
+            raw: json!({
+                "default": false,
+                "MD003": {
+                    "enabled": false,
+                    "style": "atx"
+                },
+                "MD007": {
+                    "enabled": true,
+                    "indent": 4,
+                    "start_indented": false
+                },
+                "MD013": true,
+                "MD033": {
+                    "enabled": true,
+                    "allowed_elements": ["br"]
+                }
+            }),
+        };
+
+        let options = config.to_lint_options();
+
+        assert_eq!(
+            options.rules.get("MD001").map(|rule| rule.enabled),
+            Some(false)
+        );
+        assert_eq!(
+            options.rules.get("MD013").map(|rule| rule.enabled),
+            Some(true)
+        );
+
+        let md003 = options.rules.get("MD003").expect("MD003 should exist");
+        assert!(!md003.enabled);
+        assert_eq!(md003.properties.get("style"), Some(&"atx".to_string()));
+
+        let md007 = options.rules.get("MD007").expect("MD007 should exist");
+        assert!(md007.enabled);
+        assert_eq!(md007.properties.get("indent"), Some(&"4".to_string()));
+        assert_eq!(
+            md007.properties.get("start_indented"),
+            Some(&"false".to_string())
+        );
+        assert!(!md007.properties.contains_key("enabled"));
+
+        let md033 = options.rules.get("MD033").expect("MD033 should exist");
+        assert_eq!(
+            md033.properties.get("allowed_elements"),
+            Some(&"[\"br\"]".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Expose `MarkdownLintConfig::to_lint_options()` as a public embedding API.
- Route CLI config conversion through the same public API.
- Document the API and update the embedding example.

## Verification
- `cargo test to_lint_options --locked`
- `cargo test explicit_config_can_disable_default_rules --locked`
- `cargo build --examples --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `make release-check VERSION=v0.4.2`

Closes #2
