### PR TITLE
Release v0.4.3 locale metadata APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.3
+
+- Adds locale resolver helpers for embedding consumers: `resolve_locale_code()` and `resolve_locale_code_or()`.
+- Adds localized rule metadata helpers via `localized_rule_description()` and `RuleMeta::localized_description()`.
+- Documents that consumers should use resolver helpers for UI language codes instead of duplicating kml fallback policy.
+- Keeps `Locale` source-compatible in the v0.4 patch line while recording broader i18n expansion for v0.6.0.
+- Closes issue #4.
+
 ## v0.4.2
 
 - Adds `MarkdownLintConfig::to_lint_options()` so embedding applications can load `.markdownlint.json` and run `lint` without duplicating CLI conversion logic.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,18 @@ Use the crate directly when embedding linting into another Rust application.
 - `available_rules()`
 - `implemented_rules()`
 - `missing_rules()`
+- `resolve_locale_code(language_code)`
+- `resolve_locale_code_or(language_code, fallback)`
+- `localized_rule_description(rule_id, fallback_description, language_code)`
 - `MarkdownLintConfig`
 - `MarkdownLintConfig::to_lint_options()`
+
+`available_rules()` returns canonical English metadata. For user-facing rule
+catalogs, call `RuleMeta::localized_description(language_code)` or
+`localized_rule_description(...)` so applications can pass UI language codes
+without reimplementing kml's fallback policy. `Locale` remains source-compatible
+in v0.4.x; consumers should prefer resolver helpers instead of exhaustive
+fallback matches.
 
 Minimal embedding examples are available under [`examples/`](examples/):
 

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,4 +1,7 @@
-use katana_markdown_linter::{available_rules, fix, lint, LintOptions, MarkdownLintConfig};
+use katana_markdown_linter::{
+    available_rules, fix, lint, localized_rule_description, resolve_locale_code_or, LintOptions,
+    Locale, MarkdownLintConfig,
+};
 use std::fs;
 use std::path::Path;
 
@@ -24,6 +27,18 @@ fn main() -> Result<(), DynError> {
 
     let rules = available_rules();
     println!("available rules: {}", rules.len());
+    let locale = resolve_locale_code_or("ja-JP", Locale::En);
+    println!("resolved locale: {locale:?}");
+    if let Some(rule) = rules.iter().find(|rule| rule.id == "MD003") {
+        println!(
+            "localized MD003 description: {}",
+            rule.localized_description("ja-JP")
+        );
+    }
+    println!(
+        "localized fallback: {}",
+        localized_rule_description("MD999", "Custom rule description", "ja-JP")
+    );
 
     Ok(())
 }

--- a/openspec/changes/v0-4-3-locale-aware-metadata-api/.openspec.yaml
+++ b/openspec/changes/v0-4-3-locale-aware-metadata-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/v0-4-3-locale-aware-metadata-api/design.md
+++ b/openspec/changes/v0-4-3-locale-aware-metadata-api/design.md
@@ -1,0 +1,90 @@
+## Design
+
+The v0.4.3 API should expose stable helpers over the existing locale and message
+catalog implementation without changing the CLI resolution contract.
+
+## Public API
+
+Add the following public API at the crate root:
+
+- `resolve_locale_code(language_code: &str) -> Locale`
+
+- `resolve_locale_code_or(language_code: &str, fallback: Locale) -> Locale`
+
+- `localized_rule_description(rule_id: &str, fallback_description: &str, language_code: &str) -> String`
+
+Add a convenience method:
+
+- `RuleMeta::localized_description(&self, language_code: &str) -> String`
+
+`resolve_locale_code` returns English when the input is blank or unsupported.
+`resolve_locale_code_or` returns the provided fallback when the input is blank or
+unsupported. Both helpers normalize case, `_` vs `-`, charset suffixes, and
+primary-language fallback in the same way as existing `Locale::parse`.
+
+## Locale Compatibility
+
+Do not change `Locale::resolve(explicit)` CLI semantics:
+
+- explicit unsupported CLI locale remains an error
+
+- OS locale fallback remains English when unsupported
+
+- parser support for `en`, `en-US`, `ja`, `ja-JP`, and underscore variants is
+  preserved
+
+The new resolver helpers are for embedding consumers that want lenient fallback
+instead of CLI-style errors.
+
+## Rule Description Localization
+
+The implementation should reuse existing catalog rendering rather than
+duplicating translations:
+
+- use `rule.generic` with `rule_id`, empty `rule_name`, and fallback description
+
+- use the resolved locale from the language code helper
+
+- return the fallback description unchanged for English
+
+- return the existing Japanese rule message for supported rule ids in Japanese
+
+- return a safe fallback string for unknown rule ids
+
+This keeps rule metadata localization consistent with diagnostic localization
+without requiring callers to construct `MessageParams` manually.
+
+## Documentation
+
+README and embedding examples should show the API boundary:
+
+- `available_rules()` remains English metadata
+
+- `RuleMeta::localized_description("ja-JP")` is the localized presentation helper
+
+- downstream consumers should prefer resolver helpers for user language codes
+
+- downstream consumers should not rely on exhaustive `Locale` matches for
+  fallback policy
+
+## Tests
+
+Add unit tests that cover:
+
+- `resolve_locale_code` accepts `en`, `en-US`, `ja`, `ja-JP`, underscore variants,
+  and charset suffixes
+
+- unsupported locale codes fall back to English or the caller-provided fallback
+
+- localized rule descriptions return Japanese for known rule ids
+
+- unknown rule ids preserve a useful fallback
+
+- `RuleMeta::localized_description` matches the standalone helper
+
+- public API surface AST lint includes the new additive exports
+
+## Release Notes
+
+The v0.4.3 changelog entry should mention issue #4 and call out that this is an
+additive embedding API improvement.

--- a/openspec/changes/v0-4-3-locale-aware-metadata-api/proposal.md
+++ b/openspec/changes/v0-4-3-locale-aware-metadata-api/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+Issue #4 reports that embedding consumers currently need to know kml's concrete
+`Locale` enum and duplicate fallback logic when they receive UI locale strings
+such as `en`, `en-US`, `ja`, `ja-JP`, `fr`, or `zh-CN`.
+
+The CLI already resolves locale for diagnostic rendering, but the library API
+does not expose a stable helper for generic language code input. Rule metadata
+also exposes English descriptions only, so settings UIs and MCP rule metadata
+tools cannot reuse kml's existing localized rule messages without manually
+constructing diagnostic-like parameters.
+
+This is a small additive API gap and should be handled as v0.4.3 rather than
+waiting for the broader v0.6.0 i18n expansion.
+
+## What Changes
+
+- Add a public locale resolver that accepts arbitrary language or locale code
+  strings and returns the best supported kml locale.
+
+- Add a resolver variant that lets callers specify their own fallback locale.
+
+- Add a public helper for localized rule descriptions by rule id, fallback
+  description, and language code string.
+
+- Add a `RuleMeta` convenience method that returns the localized description for
+  that rule using the same resolver.
+
+- Re-export the relevant locale and localized metadata helpers from the crate
+  root so embedding users do not need to depend on internal module layout.
+
+- Document that downstream consumers should call resolver APIs instead of
+  exhaustively matching `Locale` for fallback behavior.
+
+## Impact
+
+- Rust embedding users can pass UI language codes directly to kml without
+  duplicating fallback policy.
+
+- CLI and MCP rule metadata paths can reuse the same localized rule metadata
+  behavior when exposing catalog output.
+
+- Existing `RuleMeta.description` remains English for source compatibility.
+
+- Existing `Locale` enum is not marked `#[non_exhaustive]` in v0.4.3 because
+  doing so can break downstream exhaustive matches in a patch release.
+
+## User Decisions
+
+- v0.4.3 is the patch release target for issue #4.
+
+- v0.6.0 should become the broader i18n expansion line, but this change should
+  stay narrow and additive.
+
+## Non-Goals
+
+- Adding new supported locales beyond English and Japanese.
+
+- Translating every CLI command surface beyond the existing diagnostic catalog.
+
+- Changing CLI behavior for explicit unsupported `--locale` values.
+
+- Marking `Locale` as `#[non_exhaustive]` in v0.4.3.
+
+- Introducing ICU, Fluent, gettext, or runtime translation dependencies.

--- a/openspec/changes/v0-4-3-locale-aware-metadata-api/specs/i18n-api/spec.md
+++ b/openspec/changes/v0-4-3-locale-aware-metadata-api/specs/i18n-api/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: library SHALL resolve arbitrary locale code strings for embedding consumers
+
+Library API は、consumer application から受け取る任意の language / locale code string を kml が対応する locale に解決できなければならない（SHALL）。
+
+#### Scenario: supported locale code を解決する
+
+- **WHEN** consumer が `en`, `en-US`, `ja`, `ja-JP`, `en_US.UTF-8`, または `ja_JP.UTF-8` を resolver に渡す
+- **THEN** system は対応する supported locale を返す
+- **THEN** system は大文字小文字、hyphen / underscore、charset suffix の違いを吸収する
+
+#### Scenario: unsupported locale code を解決する
+
+- **WHEN** consumer が unsupported locale code を default resolver に渡す
+- **THEN** system は English locale を返す
+- **WHEN** consumer が unsupported locale code を fallback 指定 resolver に渡す
+- **THEN** system は consumer が指定した fallback locale を返す
+
+### Requirement: library SHALL expose localized rule metadata descriptions
+
+Library API は、rule metadata の description を caller が指定した locale code に基づいて描画できなければならない（SHALL）。
+
+#### Scenario: known rule description を localized 表示する
+
+- **WHEN** consumer が known rule id、English fallback description、Japanese locale code を渡す
+- **THEN** system はその rule の Japanese description を返す
+- **THEN** consumer は diagnostic-specific helper を直接使う必要がない
+
+#### Scenario: unsupported locale の rule description を表示する
+
+- **WHEN** consumer が unsupported locale code を渡す
+- **THEN** system は English fallback description を返す
+- **THEN** system は `RuleMeta.description` の existing value を変更しない
+
+### Requirement: v0.4.3 locale metadata API SHALL remain source-compatible
+
+v0.4.3 の locale metadata API は patch release として既存 public API を壊してはならない（SHALL）。
+
+#### Scenario: existing consumer を compile する
+
+- **WHEN** existing consumer が `RuleMeta.description` または existing `Locale` API を利用している
+- **THEN** system は existing field と behavior を維持する
+- **THEN** system は `Locale` を patch release で non-exhaustive に変更しない
+- **THEN** system は new helper を additive API として提供する

--- a/openspec/changes/v0-4-3-locale-aware-metadata-api/tasks.md
+++ b/openspec/changes/v0-4-3-locale-aware-metadata-api/tasks.md
@@ -1,0 +1,57 @@
+## Definition of Ready
+
+- [x] Issue #4 has been reviewed and referenced in the implementation notes
+- [x] v0.4.2 is the latest published release and v0.4.3 is available as the next patch version
+- [x] The current implementation branch is based on `origin/main` and isolated from unrelated v0.5.0 work
+- [x] Public API additions are confirmed additive and source-compatible
+- [x] v0.6.0 broader i18n work is split into a separate draft change
+
+## 1. Public Locale Resolver API
+
+- [x] 1.1 Add `resolve_locale_code(language_code: &str) -> Locale`
+- [x] 1.2 Add `resolve_locale_code_or(language_code: &str, fallback: Locale) -> Locale`
+- [x] 1.3 Re-export `Locale`, `LocaleError`, and resolver helpers from the crate root
+- [x] 1.4 Preserve existing `Locale::resolve(explicit)` CLI error behavior
+- [x] 1.5 Add tests for primary language, region, underscore, charset suffix, blank input, and unsupported locale codes
+
+## 2. Localized Rule Metadata API
+
+- [x] 2.1 Add `localized_rule_description(rule_id, fallback_description, language_code)`
+- [x] 2.2 Add `RuleMeta::localized_description(&self, language_code)`
+- [x] 2.3 Reuse the existing diagnostic message catalog instead of duplicating translations
+- [x] 2.4 Keep `RuleMeta.description` as the English canonical description
+- [x] 2.5 Add tests for known Japanese rule descriptions, English fallback, and unknown rule ids
+
+## 3. Documentation And Examples
+
+- [x] 3.1 Update README library API list with locale resolver and localized metadata helpers
+- [x] 3.2 Update `examples/embedding.rs` or add a small example section showing localized rule descriptions
+- [x] 3.3 Document that consumers should use resolver helpers instead of implementing locale fallback matches
+- [x] 3.4 Document why `Locale` is not made non-exhaustive in v0.4.3
+- [x] 3.5 Add a v0.4.3 changelog entry referencing issue #4
+
+## 4. Release Preparation
+
+- [x] 4.1 Bump crate version to 0.4.3
+- [x] 4.2 Ensure Cargo.lock reflects the version bump
+- [x] 4.3 Run local release preflight for a patch release
+- [x] 4.4 Confirm issue #4 acceptance criteria are covered before release
+
+## Verification
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test --workspace --locked`
+- [x] `cargo test --test ast_linter --locked`
+- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
+- [x] `make dogfood`
+- [x] `make release-check VERSION=v0.4.3`
+- [x] `git diff --check`
+
+## Definition of Done
+
+- [x] Consumers can pass arbitrary language or locale code strings and receive kml's supported fallback consistently
+- [x] Consumers can render localized rule descriptions without constructing diagnostic message parameters
+- [x] CLI explicit unsupported locale behavior remains unchanged
+- [x] Existing public fields and existing API behavior remain source-compatible
+- [x] Documentation explains the resolver API and v0.4.3 enum compatibility decision
+- [x] Issue #4 can be closed after v0.4.3 release

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/.openspec.yaml
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/proposal.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+Issue #4 shows that localization is not just a CLI presentation concern.
+Embedding consumers, MCP tools, settings screens, rule catalogs, and future
+editor integrations need a consistent i18n boundary broader than diagnostic
+message rendering.
+
+v0.4.3 should close the immediate API gap with additive locale resolver and
+localized rule metadata helpers. v0.6.0 should then treat i18n as a product
+surface and define the next durable contract.
+
+## Draft Scope
+
+v0.6.0 should investigate and plan:
+
+- locale support policy beyond English and Japanese
+
+- whether `Locale` should become non-exhaustive in a semver-minor release
+
+- localized rule catalog output for CLI and MCP
+
+- localized config validation errors with stable error ids and parameters
+
+- translation coverage tooling for rule descriptions, config errors, CLI text,
+  MCP metadata, and docs snippets
+
+- fallback policy for explicit user locale vs OS locale vs API-provided locale
+
+- whether message catalogs should stay Rust-native or move to data files
+
+- public API stability rules for adding future locales
+
+## Candidate Deliverables
+
+- A detailed design for kml-wide i18n boundaries across library, CLI, and MCP
+
+- A locale support matrix and fallback policy
+
+- A translation catalog coverage gate
+
+- Localized `kml rule` / MCP `rule_list` output if product value is confirmed
+
+- A migration note for consumers currently matching `Locale` exhaustively
+
+## Out of Scope For The Draft
+
+- Implementing new locales immediately
+
+- Rewriting the current message catalog before v0.4.3 is released
+
+- Coupling i18n behavior to any specific consuming application
+
+- Blocking v0.5.0 DocumentContext / AST work
+
+## Open Questions For Kickoff
+
+- Which additional locales are worth supporting first?
+
+- Should CLI explicit unsupported locale remain a hard error for all commands?
+
+- Should library resolver behavior stay lenient while CLI behavior stays strict?
+
+- Does MCP need localized metadata by default, or should clients request locale
+  explicitly?
+
+- Do rule descriptions need per-rule translation files, or is a single catalog
+  sufficient for the next minor release?
+
+## Readiness Notes
+
+When the draft is promoted to implementation planning, create or expand:
+
+- `design.md` with final API and catalog architecture
+
+- `tasks.md` with DoR, DoD, and rule-by-rule / surface-by-surface progress
+
+- delta specs for library i18n API, CLI localized catalog output, and MCP
+  metadata localization if those surfaces are included

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -49,6 +49,14 @@ impl Locale {
             _ => None,
         }
     }
+
+    pub fn resolve_code(value: &str) -> Self {
+        Self::resolve_code_or(value, Self::En)
+    }
+
+    pub fn resolve_code_or(value: &str, fallback: Self) -> Self {
+        Self::parse(value).unwrap_or(fallback)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,6 +108,31 @@ impl LocalizedDiagnostic {
             fix: localized.fix,
         }
     }
+}
+
+pub fn resolve_locale_code(language_code: &str) -> Locale {
+    Locale::resolve_code(language_code)
+}
+
+pub fn resolve_locale_code_or(language_code: &str, fallback: Locale) -> Locale {
+    Locale::resolve_code_or(language_code, fallback)
+}
+
+pub fn localized_rule_description(
+    rule_id: &str,
+    fallback_description: &str,
+    language_code: &str,
+) -> String {
+    let mut params = MessageParams::new();
+    params.insert("rule_id".to_string(), rule_id.to_string());
+    params.insert("rule_name".to_string(), String::new());
+    params.insert("message".to_string(), fallback_description.to_string());
+    render_message(
+        resolve_locale_code(language_code),
+        "rule.generic",
+        &params,
+        fallback_description,
+    )
 }
 
 pub fn diagnostic_message_id(rule_id: &str, message: &str) -> String {
@@ -271,6 +304,17 @@ mod tests {
     }
 
     #[test]
+    fn public_locale_resolvers_accept_ui_language_codes() {
+        assert_eq!(resolve_locale_code("en"), Locale::En);
+        assert_eq!(resolve_locale_code("EN_us.UTF-8"), Locale::En);
+        assert_eq!(resolve_locale_code("ja"), Locale::Ja);
+        assert_eq!(resolve_locale_code("ja-JP"), Locale::Ja);
+        assert_eq!(resolve_locale_code(""), Locale::En);
+        assert_eq!(resolve_locale_code("fr"), Locale::En);
+        assert_eq!(resolve_locale_code_or("fr", Locale::Ja), Locale::Ja);
+    }
+
+    #[test]
     fn explicit_locale_overrides_os_locale_and_unsupported_os_falls_back_to_english() {
         assert_eq!(
             Locale::resolve_with(Some("en"), |_| Some("ja_JP.UTF-8".to_string())),
@@ -309,5 +353,19 @@ mod tests {
         );
         assert_eq!(params["expected"], "h2");
         assert_eq!(params["actual"], "h4");
+    }
+
+    #[test]
+    fn localized_rule_description_uses_catalog_without_diagnostic_params() {
+        assert_eq!(
+            localized_rule_description("MD003", "Heading style should be consistent", "ja-JP"),
+            "見出しのスタイルを統一してください"
+        );
+        assert_eq!(
+            localized_rule_description("MD003", "Heading style should be consistent", "fr"),
+            "Heading style should be consistent"
+        );
+        assert!(localized_rule_description("MD999", "Custom fallback", "ja")
+            .contains("Custom fallback"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@ pub mod types;
 pub mod upstream;
 
 pub use config::{ConfigError, ConfigErrorKind, MarkdownLintConfig};
+pub use i18n::{
+    localized_rule_description, resolve_locale_code, resolve_locale_code_or, Locale, LocaleError,
+    LocalizedDiagnostic,
+};
 pub use types::{Fix, FixResult, LintOptions, LintResult, Range, RuleConfig, RuleMeta, Severity};
 
 use std::path::Path;
@@ -209,6 +213,20 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(ids, sorted);
+    }
+
+    #[test]
+    fn rule_meta_exposes_localized_description_helper() {
+        let rule = available_rules()
+            .into_iter()
+            .find(|rule| rule.id == "MD003")
+            .expect("MD003 should be in public catalog");
+
+        assert_eq!(
+            rule.localized_description("ja-JP"),
+            "見出しのスタイルを統一してください"
+        );
+        assert_eq!(resolve_locale_code_or("fr", Locale::Ja), Locale::Ja);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,3 +64,9 @@ pub struct RuleMeta {
     pub docs_url: String,
     pub fixable: bool,
 }
+
+impl RuleMeta {
+    pub fn localized_description(&self, language_code: &str) -> String {
+        crate::i18n::localized_rule_description(&self.id, &self.description, language_code)
+    }
+}

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -318,6 +318,12 @@ fn ast_linter_public_api_surface_is_explicit() {
         "pub fn missing_rules() -> Vec<RuleMeta>",
         "pub fn rule_catalog() -> catalog::RuleCatalog",
         "pub use config::{ConfigError, ConfigErrorKind, MarkdownLintConfig};",
+        "pub use i18n::{",
+        "localized_rule_description",
+        "resolve_locale_code",
+        "resolve_locale_code_or",
+        "Locale, LocaleError",
+        "LocalizedDiagnostic",
         "pub use types::{Fix, FixResult, LintOptions, LintResult, Range, RuleConfig, RuleMeta, Severity};",
     ];
     let mut violations = required


### PR DESCRIPTION
## Summary
- add lenient locale resolver APIs for embedding consumers
- add localized rule description helpers for RuleMeta and standalone calls
- document v0.4.3 compatibility decision and add v0.6.0 i18n draft

## Verification
- cargo fmt --all -- --check
- cargo test --workspace --locked
- cargo test --test ast_linter --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- make dogfood
- make release-check VERSION=v0.4.3
- git diff --check

Closes #4