### PR TITLE
Release v0.5.0 document context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.5.0
+
+- Adds source-preserving `DocumentContext` for shared line, heading, code block, reference, table, and lazy AST structure.
+- Adds context-based rule evaluation while keeping existing `lint` and `fix` API compatibility.
+- Migrates `MD001` and `MD060` to context-backed evaluation and safe source-range fixes.
+- Expands `MD060` table column style check/fix coverage, including aligned, compact, and tight table styles.
+- Improves fix application by selecting non-overlapping edits before constructing the output.
+- Adds v0.5.0 performance snapshots for context construction and migrated rule paths.
+- Fixes an `MD003` false positive where standalone horizontal rules or front matter delimiters were treated as setext headings.
+
 ## v0.4.3
 
 - Adds locale resolver helpers for embedding consumers: `resolve_locale_code()` and `resolve_locale_code_or()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ violation form automatically; rules marked `no` still report diagnostics.
 | `MD022` | yes |
 | `MD023` | yes |
 | `MD024` | no |
-| `MD025` | no |
+| `MD025` | yes |
 | `MD026` | yes |
 | `MD027` | yes |
 | `MD028` | no |
@@ -137,7 +137,7 @@ violation form automatically; rules marked `no` still report diagnostics.
 | `MD056` | no |
 | `MD058` | yes |
 | `MD059` | no |
-| `MD060` | no |
+| `MD060` | yes |
 
 ## Configuration
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -51,6 +51,9 @@ make bench PERF_ITERATIONS=30 PERF_SAMPLES=7 PERF_WARMUP=2
 | `api_lint_clean_large_document` | Measures full-rule lint cost on a clean generated document. |
 | `api_fix_large_document` | Measures fix orchestration cost on the diagnostics-heavy document. |
 | `api_lint_many_small_documents` | Measures repeated API calls for many small documents. |
+| `context_build_large_document` | Measures source-preserving line and fence context construction. |
+| `context_heading_index_large_document` | Measures lazy heading index construction. |
+| `context_table_index_large_document` | Measures lazy table index construction. |
 | `cli_check_many_small_files` | Measures CLI directory check cost for a synthetic workspace. |
 | `config_validate_representative` | Measures config load and validation cost. |
 | `api_rule_catalog` | Measures rule catalog construction cost. |
@@ -133,3 +136,30 @@ The optimization is intentionally narrow:
 - CLI fix mode still lints the fixed content before deciding the exit code.
 - The helper exists only to avoid duplicate original-content lint evaluation
   when diagnostics are already available.
+
+## v0.5.0 DocumentContext Snapshot
+
+`source-preserving-document-context` adds a shared document context and migrates
+`MD001` and `MD060` to context-based evaluation. The context indexes are lazy so
+line-only paths do not pay for heading or table extraction unless a migrated rule
+needs them.
+
+Local `make perf-check` snapshot after the migration:
+
+| Case | Median |
+| --- | ---: |
+| `api_lint_large_document` | 9.884 ms |
+| `api_lint_clean_large_document` | 6.585 ms |
+| `api_fix_large_document` | 206.701 ms |
+| `api_lint_many_small_documents` | 2.360 ms |
+| `context_build_large_document` | 0.077 ms |
+| `context_heading_index_large_document` | 1.087 ms |
+| `context_table_index_large_document` | 1.133 ms |
+| `cli_check_many_small_files` | 9.714 ms |
+
+The context-specific costs are small relative to full lint execution. The
+remaining `api_fix_large_document` regression is explained by multi-pass safe
+fix convergence over a diagnostics-heavy synthetic corpus that now applies 4200
+fixes per measured operation. `fix::apply` now builds the edited output in one
+linear pass after overlap resolution, but reducing multi-pass convergence cost
+requires a separate fix-planning change.

--- a/docs/rule-coverage-dashboard.md
+++ b/docs/rule-coverage-dashboard.md
@@ -5,7 +5,7 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | Rule | Check | Safe Fix | Config | Edge | Golden | Known Delta | Manual Required |
 | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
 | MD001 | 2 | 0 | 4 | 1 | baseline | no | - |
-| MD003 | 2 | 0 | 4 | 0 | pending: not locked | no | - |
+| MD003 | 2 | 0 | 4 | 2 | pending: not locked | no | - |
 | MD004 | 2 | 1 | 4 | 0 | pending: not locked | no | - |
 | MD005 | 2 | 1 | 2 | 1 | baseline | no | - |
 | MD007 | 2 | 1 | 8 | 0 | pending: not locked | no | - |

--- a/docs/rule-coverage-dashboard.md
+++ b/docs/rule-coverage-dashboard.md
@@ -56,4 +56,12 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | MD056 | 2 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD058 | 2 | 1 | 2 | 0 | pending: not locked | no | - |
 | MD059 | 2 | 0 | 4 | 0 | pending: not locked | no | - |
-| MD060 | 2 | 0 | 8 | 2 | pending: not locked | no | fix unsupported: table column style requires strategy-aware table formatting before safe fix can be locked |
+| MD060 | 4 | 3 | 8 | 3 | pending: not locked | no | - |
+
+## Fix Safety Notes
+
+- Line-local safe fixes remain the default for whitespace, heading spacing, list marker, emphasis, and similar rules.
+
+- Structural safe fixes currently include `MD060`, which uses one whole-table source range from `DocumentContext`.
+
+- Unsafe rewrites remain out of default fix mode.

--- a/examples/perf_benchmark.rs
+++ b/examples/perf_benchmark.rs
@@ -1,4 +1,5 @@
 use katana_markdown_linter::cli::{run, Cli, Command, OutputFormat};
+use katana_markdown_linter::rules::markdown::DocumentContext;
 use katana_markdown_linter::{available_rules, fix, lint, LintOptions, MarkdownLintConfig};
 use serde::Serialize;
 use std::fs;
@@ -56,6 +57,36 @@ fn main() -> BenchResult<()> {
                 diagnostics += lint(black_box(document), black_box(&options))?.len();
             }
             Ok(diagnostics)
+        },
+    )?);
+    cases.push(measure(
+        "context_build_large_document",
+        &args,
+        large_document.lines().count(),
+        "lines",
+        || {
+            let ctx = DocumentContext::new(Path::new("<bench>"), black_box(&large_document));
+            Ok(ctx.lines().len())
+        },
+    )?);
+    cases.push(measure(
+        "context_heading_index_large_document",
+        &args,
+        large_document.lines().count(),
+        "lines",
+        || {
+            let ctx = DocumentContext::new(Path::new("<bench>"), black_box(&large_document));
+            Ok(ctx.headings().len())
+        },
+    )?);
+    cases.push(measure(
+        "context_table_index_large_document",
+        &args,
+        large_document.lines().count(),
+        "lines",
+        || {
+            let ctx = DocumentContext::new(Path::new("<bench>"), black_box(&large_document));
+            Ok(ctx.tables().len())
         },
     )?);
     cases.push(measure(

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -1,0 +1,38 @@
+# Active Roadmap
+
+This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
+
+## Version Direction
+
+- `v0.4.0`: check/fix 拡充を優先する。default fix は safe subset のみを対象にする。
+- `v0.5.0`: `DocumentContext` 主体の AST 部分導入を優先する。unsafe fix mode は別 change として扱い、default safe fix には混ぜない。
+
+| Priority | Work Area | Change | Why Now |
+| --- | --- | --- | --- |
+| Done | Golden and edge coverage for `v0.4.0` | `golden-edge-coverage-expansion` | Completed for `v0.4.0`; dashboard now derives golden status from the locked baseline and records edge coverage. |
+| Done | Safe check/fix expansion for `v0.4.0` | `safe-fix-strategy-expansion` | Completed for `v0.4.0`; `MD005` and `MD030` safe subsets are locked, while `MD060` remains diagnostic/manual-required because official metadata marks it non-fixable. |
+| Done | Table strategy for `v0.5.0` | `v0-5-0-table-strategy-md060` | Completed for `v0.5.0`; `MD060` now has table-block parsing, official style checks, and safe fix subsets. |
+| Done | Source-preserving document context for `v0.5.0` | `source-preserving-document-context` | Completed for `v0.5.0`; `DocumentContext` now shares source-preserving structure across migrated rule families. |
+| P2 | Unsafe fix mode for `v0.5.0` | `unsafe-fix-mode-and-confirmation` | Unsafe fix requires explicit user opt-in, CLI confirmation, and automation guardrails. |
+| P2 | MCP productization | `mcp-workspace-tools-productization` | Current MCP server is experimental and text-first only. |
+| Done | Performance hot path work | `performance-hotpath-competition` | Completed; docs now include baseline, profile summary, before/after, and local regression guidance. |
+
+Archived `v0.4.0` changes:
+
+- `golden-edge-coverage-expansion` -> `openspec/changes/archive/2026-04-25-golden-edge-coverage-expansion`
+- `safe-fix-strategy-expansion` -> `openspec/changes/archive/2026-04-25-safe-fix-strategy-expansion`
+- `v0-5-0-table-strategy-md060` -> `openspec/changes/archive/2026-04-25-v0-5-0-table-strategy-md060`
+- `performance-hotpath-competition` -> `openspec/changes/archive/2026-04-25-performance-hotpath-competition`
+
+## Suggested Order
+
+1. Apply `mcp-workspace-tools-productization` when MCP usage is prioritized.
+2. Apply `unsafe-fix-mode-and-confirmation` after default safe context-based behavior is stable.
+3. Use `source-preserving-document-context` as the baseline for later structural fix work.
+
+## Repository Guardrails
+
+- New OpenSpec change files are ignored by the current `.gitignore`; commit them with explicit `git add -f openspec/changes/<change>` when they should be tracked.
+- `check-diagnostic-i18n` was archived as `openspec/changes/archive/2026-04-25-check-diagnostic-i18n`.
+- Keep one implementation change active at a time unless the write sets are disjoint and the roadmap is updated to show the parallelism.
+- `unsafe-fix-mode-and-confirmation` must not be mixed into `v0.4.0`; it changes CLI safety semantics and belongs to a later release.

--- a/openspec/changes/source-preserving-document-context/.openspec.yaml
+++ b/openspec/changes/source-preserving-document-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/source-preserving-document-context/design.md
+++ b/openspec/changes/source-preserving-document-context/design.md
@@ -1,0 +1,103 @@
+## Design
+
+## Architecture
+
+`DocumentContext` を rule execution の中心に置く。content は `DocumentContext` に変換され、rule check/fix と optional AST cache が同じ source-preserving context を共有する。
+
+AST は source-preserving context の一部であり、主役ではない。rule は AST だけを信頼せず、fix range を作る時は line offsets と original source slice を使う。
+
+## Design Decisions
+
+- Eager に構築するのは line offsets、line info、front matter、fenced code block ranges までを初期値とする
+- Headings、references、tables は rule family の移行に合わせて eager または once-cell style lazy cache のどちらかを計測して決める
+- v0.5.0 初期実装では外部 parser dependency を追加せず、`DocumentContext` の structural indexes から lightweight block AST を lazy に構築する
+- Optional AST は public API に露出しない
+- `DocumentContext` は単一 file content の責務に閉じる。directory traversal、ignore、parallelism は CLI layer の責務として維持する
+- `LintOptions` / config resolution は既存 API を維持し、rule enablement は context 生成とは分離する
+
+## DocumentContext Shape
+
+Initial context fields:
+
+- `content: &str`
+- `file_path: &Path`
+- `lines: Vec<LineInfo>`
+- `line_offsets: Vec<usize>`
+- `front_matter: Option<Range<usize>>`
+- `code_blocks: Vec<BlockRange>`
+- `headings: Vec<Heading>`
+- `references: Vec<Reference>`
+- `tables: Vec<TableBlock>`
+- lazy inline code spans
+- lazy emphasis spans
+- optional/lazy AST
+
+All ranges SHALL be source-preserving. Byte ranges are used internally; public diagnostics remain line/column based.
+
+## Rule API Migration
+
+Add a context-based interface while preserving the current trait behavior.
+
+The trait keeps `evaluate(file_path, content)` and adds `evaluate_context(ctx, config)` as the migration entrypoint.
+
+Default `evaluate_context` can delegate to `evaluate` during migration. New or migrated rules use context directly.
+
+## First Migration Set
+
+Prioritize rules whose shared structure improves correctness or speed:
+
+- heading: `MD001`, `MD003`, `MD018`, `MD019`, `MD020`, `MD021`
+- code fence: `MD031`, `MD040`, `MD046`, `MD048`
+- reference: `MD051`, `MD052`, `MD053`, `MD054`
+- table: `MD055`, `MD056`, `MD058`, `MD060`
+
+This change does not require all listed rules to be fully migrated before landing. It requires the migration path, context contract, and at least one representative rule family to be complete.
+
+## Fix Safety
+
+Safe fix generation MUST use original source ranges from `DocumentContext`.
+
+Rules MUST NOT generate fixes from AST-normalized text when doing so would lose source formatting, comments, spacing, or table alignment.
+
+## Performance
+
+The context builder must avoid duplicate full-document scans when practical. Expensive substructures should be lazy when only a subset of rules needs them.
+
+Benchmarks must include:
+
+- API lint large document
+- API fix large document
+- CLI many small files
+- rule family microbenchmarks for migrated families
+
+Performance acceptance:
+
+- No unexplained regression is allowed in `make perf-check`
+- If a migrated rule becomes slower, the change must document the reason and the correctness tradeoff
+- A context index may be reverted to lazy construction if eager construction hurts many-small-file CLI behavior
+
+## Compatibility
+
+Public `lint(content, &LintOptions)` and `fix(content, &LintOptions)` remain stable.
+
+CLI output order and JSON shape remain stable.
+
+## Implementation Order
+
+1. Add data model and source range helpers without changing rule behavior
+2. Wire context-based API behind legacy-compatible adapters
+3. Migrate one heading family and one reference/table/fence family
+4. Add parity and benchmark gates for migrated families
+5. Only then consider wider rule migration in follow-up changes
+
+## Risks
+
+- Context construction can become slower than current rule-local scans if too many structures are eager.
+- AST parser behavior may not match markdownlint edge cases exactly.
+- Migrating too many rules at once can obscure behavior regressions.
+
+Mitigation:
+
+- Start with a minimal eager context and lazy expensive fields.
+- Keep upstream golden fixtures as the behavior gate.
+- Migrate rule families incrementally.

--- a/openspec/changes/source-preserving-document-context/proposal.md
+++ b/openspec/changes/source-preserving-document-context/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`mado` は速く安定して見えるが、その理由は AST 採用だけではない。check 中心の狭い責務、parse once、parallel walk、静的な rule dispatch、release profile まで含めた設計で成り立っている。
+
+`kml` は library-first で check と fix の両方を提供するため、AST を全面導入するだけでは source range、空白、改行、table alignment を安全に扱えない。fix 精度と性能を同時に上げるには、source-preserving な document context を一度構築し、rule がそれを共有する必要がある。
+
+## What Changes
+
+- `MarkdownDocument` / `DocumentContext` を追加し、line offsets、lines、code block ranges、headings、references、tables を一度だけ構築する
+- AST は `DocumentContext` の optional/lazy component として部分導入する
+- context-based rule API を追加し、既存 `evaluate(file_path, content)` は adapter で互換維持する
+- heading / reference / code fence / table 系 rule の一部を context-based に移行する
+- CLI directory processing と library API の責務境界を維持し、library API は caller が並列制御できる形を保つ
+- benchmark と fixture で before/after と behavior parity を固定する
+
+## Selected Direction
+
+- `DocumentContext` を主軸にする。AST は補助情報として lazy に構築し、fix range の主根拠にはしない
+- `mado` / `rumdl` は設計上の参考に留め、実装や behavior をコピーしない
+- v0.5.0 の完了条件は full AST 化ではなく、source-preserving context の導入と代表 rule family の移行である
+- unsafe fix mode、MCP productization、全 rule 一括 rewrite は別 change に分離する
+
+## Impact
+
+- rule ごとの hand-rolled scan を減らし、check/fix の判断材料を共有できる
+- MD051/MD060 など構文依存 rule の精度改善がしやすくなる
+- 将来の unsafe fix mode や workspace index の土台になる
+- 旧 public API は互換維持されるため、既存 embedding user は壊れない
+
+## Non-Goals
+
+- `comrak` または `pulldown-cmark` への全面移行
+- 全 rule の一括 rewrite
+- unsafe fix mode の実装
+- MCP tool productization

--- a/openspec/changes/source-preserving-document-context/specs/document-context/spec.md
+++ b/openspec/changes/source-preserving-document-context/specs/document-context/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: system SHALL build a source-preserving document context
+
+システムは、Markdown 文書の元ソースを保持したまま rule execution で共有できる document context を構築しなければならない（SHALL）。
+
+#### Scenario: context を構築する
+
+- **WHEN** system が Markdown content と file path を受け取る
+- **THEN** system は original content への参照を保持する
+- **THEN** system は line offsets と line/column conversion helper を提供する
+- **THEN** system は diagnostics と fixes を original source byte range から line/column に変換できる
+- **THEN** system は empty input、末尾改行なし、CRLF、Unicode を正しく扱う
+
+### Requirement: system SHALL expose structural indexes through document context
+
+システムは、rule family が重複 scan を避けられるように構造 index を document context から参照できなければならない（SHALL）。
+
+#### Scenario: structural index を利用する
+
+- **WHEN** heading、reference、code fence、table 系 rule が document context を利用する
+- **THEN** system は code block ranges、heading entries、reference entries、table block entries を共有できる
+- **THEN** system は fenced code block 内の Markdown 構文を通常本文と誤認しない
+- **THEN** system は source range を original content の byte range として保持する
+
+### Requirement: rule evaluation SHALL support context-based execution without breaking legacy APIs
+
+rule evaluation は、context-based execution をサポートしつつ既存 public API を壊してはならない（SHALL）。
+
+#### Scenario: 既存 API から lint する
+
+- **WHEN** caller が既存の `lint(content, &LintOptions)` または `fix(content, &LintOptions)` を呼び出す
+- **THEN** system は source-compatible な API を維持する
+- **THEN** system は内部で必要に応じて document context を構築できる
+- **THEN** system は CLI JSON shape、text output ordering、exit code contract を維持する
+
+#### Scenario: rule を context-based に移行する
+
+- **WHEN** migrated rule が document context を利用して diagnostics または fixes を生成する
+- **THEN** system は legacy rule path と同じ rule enablement と config resolution を適用する
+- **THEN** system は upstream golden comparison と fixture matrix で unexplained behavior delta を出さない
+
+### Requirement: AST support SHALL be optional and lazy
+
+AST support は optional かつ lazy でなければならず、fix range の唯一の根拠になってはならない（SHALL）。
+
+#### Scenario: AST を必要としない rule を実行する
+
+- **WHEN** line-local rule または既存 scan で十分な rule が実行される
+- **THEN** system は AST parser を必須にしない
+- **THEN** system は AST construction cost を全 rule に強制しない
+
+#### Scenario: AST と markdownlint semantics が乖離する
+
+- **WHEN** AST parser の解釈が markdownlint-compatible behavior と異なる
+- **THEN** system は markdownlint-compatible behavior を優先する
+- **THEN** system は乖離を known delta または implementation note として記録する
+- **THEN** system は AST-normalized text から unsafe な fix range を生成しない
+
+### Requirement: context migration SHALL include representative rule families
+
+context migration は、v0.5.0 の範囲で少なくとも代表 rule family を移行しなければならない（SHALL）。
+
+#### Scenario: v0.5.0 migration を完了する
+
+- **WHEN** v0.5.0 の source-preserving document context change が完了する
+- **THEN** system は少なくとも heading family の 1 つを context-based evaluation に移行する
+- **THEN** system は少なくとも reference、table、または code fence family の 1 つを context-based evaluation に移行する
+- **THEN** system は移行済み rule の check と safe fix が original source range を使うことを test で固定する
+
+### Requirement: context migration SHALL be performance-gated
+
+context migration は、performance baseline と behavior gates を通して評価されなければならない（SHALL）。
+
+#### Scenario: migration performance を検証する
+
+- **WHEN** developer が `make perf-check` を実行する
+- **THEN** system は context migration 後の report を baseline と比較する
+- **THEN** system は unexplained regression を failure または documented blocker として扱う
+- **THEN** system は large document API lint、large document API fix、CLI many-small-files path を確認対象に含める
+
+#### Scenario: migration behavior を検証する
+
+- **WHEN** developer が verification suite を実行する
+- **THEN** system は upstream golden comparison を通す
+- **THEN** system は rule fixture harness を通す
+- **THEN** system は dogfood を通し、baseline diagnostics の意図しない増加を許さない

--- a/openspec/changes/source-preserving-document-context/tasks.md
+++ b/openspec/changes/source-preserving-document-context/tasks.md
@@ -1,0 +1,79 @@
+## Definition of Ready
+
+- [x] `v0-5-0-table-strategy-md060` is archived or otherwise confirmed complete
+- [x] `performance-hotpath-competition` is archived or otherwise confirmed complete
+- [x] mado/rumdl architecture findings have been reviewed and the selected direction is `DocumentContext` first, AST partial/lazy second
+- [x] Current benchmark baseline is available via `make bench` / `make perf-check`
+- [x] Current upstream golden and fixture matrix gates are passing or known failures are documented
+
+## 0. Planning Contract
+
+- [x] 0.1 Add delta spec requirements for `DocumentContext`, partial AST, compatibility, and performance gates
+- [x] 0.2 Confirm implementation excludes unsafe fix mode and MCP productization
+- [x] 0.3 Confirm dirty main worktree changes are isolated before implementation starts
+
+## 1. Context Contract
+
+- [x] 1.1 Define `DocumentContext` / `MarkdownDocument` data model
+- [x] 1.2 Define line offset and line/column conversion helpers
+- [x] 1.3 Define source-preserving range types for internal use
+- [x] 1.4 Define eager vs lazy fields and document why each field is eager or lazy
+- [x] 1.5 Add unit tests for empty input, no trailing newline, CRLF, Unicode, and mixed Markdown constructs
+
+## 2. Structural Indexes
+
+- [x] 2.1 Implement heading extraction
+- [x] 2.2 Implement code block and code fence range extraction
+- [x] 2.3 Implement reference extraction
+- [x] 2.4 Implement table block extraction
+- [x] 2.5 Add fixture tests that compare extracted structures with expected source ranges
+
+## 3. AST Partial Introduction
+
+- [x] 3.1 Choose parser dependency and feature shape based on measured need
+- [x] 3.2 Add optional/lazy AST construction behind `DocumentContext`
+- [x] 3.3 Prove AST construction is not required for simple line-only rules
+- [x] 3.4 Document mismatch policy when AST interpretation differs from markdownlint expectations
+- [x] 3.5 Keep AST structures out of the public API unless a follow-up change explicitly accepts that contract
+
+## 4. Rule API Migration
+
+- [x] 4.1 Add context-based rule evaluation API with legacy adapter
+- [x] 4.2 Migrate one heading rule family to context-based evaluation
+- [x] 4.3 Migrate one reference or table rule family to context-based evaluation
+- [x] 4.4 Ensure configured rule evaluation uses the same context path
+- [x] 4.5 Keep public `lint` and `fix` API backward compatible
+
+## 5. Fix Safety And Convergence
+
+- [x] 5.1 Ensure migrated rules generate fixes from original source ranges
+- [x] 5.2 Add regression tests for overlapping fixes across migrated rule families
+- [x] 5.3 Record which fixes remain line-local and which require structural context
+- [x] 5.4 Leave unsafe fix mode to `unsafe-fix-mode-and-confirmation`
+
+## 6. Performance And Verification
+
+- [x] 6.1 Capture before/after benchmark report
+- [x] 6.2 Add microbenchmarks for migrated rule families
+- [x] 6.3 Run upstream golden comparison
+- [x] 6.4 Run rule fixture harness
+- [x] 6.5 Run dogfood
+
+## Verification
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test --workspace --locked`
+- [x] `cargo test --test ast_linter --locked`
+- [x] `cargo test --test rule_fixture_harness --locked`
+- [x] `cargo test --test upstream_golden_comparison --locked`
+- [x] `make dogfood`
+- [x] `make perf-check`
+- [x] `git diff --check`
+
+## Definition of Done
+
+- [x] `DocumentContext` is the preferred internal rule input for migrated rules
+- [x] AST is introduced only as optional/lazy support, not as the sole source of fix ranges
+- [x] At least one heading family and one reference/table/fence family use context-based evaluation
+- [x] Existing public library APIs remain source-compatible
+- [x] Benchmarks and golden fixtures show no unexplained regression

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -17,19 +17,29 @@ pub fn apply(results: &[LintResult], content: &str) -> FixResult {
 
     edits.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| right.1.cmp(&left.1)));
 
-    let mut content = content.to_string();
+    let mut accepted = Vec::new();
     let mut previous_start = content.len();
     for (start, end, replacement) in edits {
         if end > previous_start {
             continue;
         }
-        content.replace_range(start..end, replacement);
         previous_start = start;
+        accepted.push((start, end, replacement));
         applied_fixes += 1;
     }
+    accepted.reverse();
+
+    let mut fixed = String::with_capacity(content.len());
+    let mut cursor = 0;
+    for (start, end, replacement) in accepted {
+        fixed.push_str(&content[cursor..start]);
+        fixed.push_str(replacement);
+        cursor = end;
+    }
+    fixed.push_str(&content[cursor..]);
 
     FixResult {
-        content,
+        content: fixed,
         applied_fixes,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,20 @@ pub fn fix(content: &str, options: &LintOptions) -> Result<FixResult, Error> {
 
     let mut content = content.to_string();
     let mut applied_fixes = 0;
+    let severity_map = build_fix_severity_map(options);
 
     for _ in 0..MAX_FIX_PASSES {
-        let results = lint(&content, options)?;
+        let diags = rules::markdown::MarkdownLinterOps::evaluate_all(
+            Path::new("<memory>"),
+            &content,
+            true,
+            &severity_map,
+            &options.rules,
+        );
+        let results = diags
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<LintResult>>();
         if !results.iter().any(|result| result.fix.is_some()) {
             break;
         }
@@ -191,6 +202,72 @@ fn build_severity_map(
             (rule_id.clone(), severity)
         })
         .collect()
+}
+
+fn build_fix_severity_map(
+    options: &LintOptions,
+) -> std::collections::HashMap<String, Option<rules::markdown::DiagnosticSeverity>> {
+    rules::markdown::MarkdownLinterOps::official_rules()
+        .iter()
+        .map(|rule| {
+            let severity = if is_safe_fix_rule(rule.id()) {
+                options
+                    .rules
+                    .get(rule.id())
+                    .map(|rule_config| rule_config.enabled)
+                    .unwrap_or(true)
+                    .then_some(match options.default_severity {
+                        Severity::Error => rules::markdown::DiagnosticSeverity::Error,
+                        Severity::Warning => rules::markdown::DiagnosticSeverity::Warning,
+                        Severity::Info => rules::markdown::DiagnosticSeverity::Info,
+                    })
+            } else {
+                None
+            };
+            (rule.id().to_string(), severity)
+        })
+        .collect()
+}
+
+fn is_safe_fix_rule(rule_id: &str) -> bool {
+    matches!(
+        rule_id,
+        "MD004"
+            | "MD005"
+            | "MD007"
+            | "MD009"
+            | "MD010"
+            | "MD011"
+            | "MD012"
+            | "MD014"
+            | "MD018"
+            | "MD019"
+            | "MD020"
+            | "MD021"
+            | "MD022"
+            | "MD023"
+            | "MD025"
+            | "MD026"
+            | "MD027"
+            | "MD029"
+            | "MD030"
+            | "MD031"
+            | "MD032"
+            | "MD034"
+            | "MD037"
+            | "MD038"
+            | "MD039"
+            | "MD040"
+            | "MD044"
+            | "MD047"
+            | "MD049"
+            | "MD050"
+            | "MD051"
+            | "MD053"
+            | "MD054"
+            | "MD058"
+            | "MD060"
+    )
 }
 
 #[cfg(test)]
@@ -392,7 +469,7 @@ mod tests {
 
     #[test]
     fn lint_reports_table_rules() {
-        let content = "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 | 3 |\nclick here";
+        let content = "Intro\n| a | b |\n| --- | --- |\n| 1 | 2 | 3 |\n\n|x| y |\n|---|---|\n| z | q |\nclick here";
         let options = LintOptions::default();
         let results = lint(content, &options).expect("lint should succeed");
         assert!(results.iter().any(|result| result.rule_id == "MD056"));

--- a/src/rules/markdown/document.rs
+++ b/src/rules/markdown/document.rs
@@ -1,0 +1,599 @@
+use crate::rules::markdown::DiagnosticRange;
+use std::path::Path;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FenceKind {
+    Backtick,
+    Tilde,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineInfo<'a> {
+    pub number: usize,
+    pub text: &'a str,
+    pub content_range: SourceRange,
+    pub full_range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockRange {
+    pub start_line: usize,
+    pub end_line: usize,
+    pub range: SourceRange,
+    pub fence: FenceKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Heading<'a> {
+    pub line: usize,
+    pub level: usize,
+    pub text: &'a str,
+    pub marker_range: SourceRange,
+    pub text_range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Link<'a> {
+    pub line: usize,
+    pub text: &'a str,
+    pub destination: &'a str,
+    pub text_range: SourceRange,
+    pub destination_range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableCell<'a> {
+    pub text: &'a str,
+    pub range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableRow<'a> {
+    pub line: usize,
+    pub cells: Vec<TableCell<'a>>,
+    pub leading_pipe: bool,
+    pub trailing_pipe: bool,
+    pub delimiter: bool,
+    pub safe_to_fix: bool,
+    pub range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableBlock<'a> {
+    pub start_line: usize,
+    pub end_line: usize,
+    pub rows: Vec<TableRow<'a>>,
+    pub range: SourceRange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum AstBlock<'a> {
+    Heading(Heading<'a>),
+    CodeBlock(BlockRange),
+    Table(TableBlock<'a>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct MarkdownAst<'a> {
+    pub(crate) blocks: Vec<AstBlock<'a>>,
+}
+
+pub struct DocumentContext<'a> {
+    content: &'a str,
+    file_path: &'a Path,
+    lines: Vec<LineInfo<'a>>,
+    line_offsets: Vec<usize>,
+    front_matter: Option<SourceRange>,
+    code_blocks: Vec<BlockRange>,
+    headings: OnceLock<Vec<Heading<'a>>>,
+    links: OnceLock<Vec<Link<'a>>>,
+    tables: OnceLock<Vec<TableBlock<'a>>>,
+    #[allow(dead_code)]
+    ast: OnceLock<MarkdownAst<'a>>,
+}
+
+impl<'a> DocumentContext<'a> {
+    pub fn new(file_path: &'a Path, content: &'a str) -> Self {
+        let lines = split_lines(content);
+        let line_offsets = if lines.is_empty() {
+            vec![0]
+        } else {
+            lines.iter().map(|line| line.content_range.start).collect()
+        };
+        let front_matter = extract_front_matter(&lines);
+        let code_blocks = extract_code_blocks(&lines);
+        Self {
+            content,
+            file_path,
+            lines,
+            line_offsets,
+            front_matter,
+            code_blocks,
+            headings: OnceLock::new(),
+            links: OnceLock::new(),
+            tables: OnceLock::new(),
+            ast: OnceLock::new(),
+        }
+    }
+
+    pub fn content(&self) -> &'a str {
+        self.content
+    }
+
+    pub fn file_path(&self) -> &'a Path {
+        self.file_path
+    }
+
+    pub fn lines(&self) -> &[LineInfo<'a>] {
+        &self.lines
+    }
+
+    pub fn line_offsets(&self) -> &[usize] {
+        &self.line_offsets
+    }
+
+    pub fn front_matter(&self) -> Option<SourceRange> {
+        self.front_matter
+    }
+
+    pub fn code_blocks(&self) -> &[BlockRange] {
+        &self.code_blocks
+    }
+
+    pub fn headings(&self) -> &[Heading<'a>] {
+        self.headings
+            .get_or_init(|| extract_headings(&self.lines, &self.code_blocks))
+            .as_slice()
+    }
+
+    pub fn links(&self) -> &[Link<'a>] {
+        self.links
+            .get_or_init(|| extract_links(&self.lines, &self.code_blocks))
+            .as_slice()
+    }
+
+    pub fn tables(&self) -> &[TableBlock<'a>] {
+        self.tables
+            .get_or_init(|| extract_tables(&self.lines, &self.code_blocks))
+            .as_slice()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn markdown_ast(&self) -> &MarkdownAst<'a> {
+        self.ast.get_or_init(|| {
+            let mut blocks = Vec::new();
+            blocks.extend(self.headings().iter().cloned().map(AstBlock::Heading));
+            blocks.extend(self.code_blocks.iter().cloned().map(AstBlock::CodeBlock));
+            blocks.extend(self.tables().iter().cloned().map(AstBlock::Table));
+            blocks.sort_by_key(|block| match block {
+                AstBlock::Heading(heading) => heading.marker_range.start,
+                AstBlock::CodeBlock(block) => block.range.start,
+                AstBlock::Table(table) => table.range.start,
+            });
+            MarkdownAst { blocks }
+        })
+    }
+
+    pub fn offset_to_position(&self, offset: usize) -> (usize, usize) {
+        if self.lines.is_empty() {
+            return (1, 1);
+        }
+        let offset = offset.min(self.content.len());
+        if offset == self.content.len() && self.content.ends_with('\n') {
+            return (self.lines.len() + 1, 1);
+        }
+        let index = self
+            .line_offsets
+            .partition_point(|line_start| *line_start <= offset)
+            .saturating_sub(1);
+        let line = &self.lines[index.min(self.lines.len() - 1)];
+        (
+            line.number,
+            offset.saturating_sub(line.content_range.start) + 1,
+        )
+    }
+
+    pub fn diagnostic_range(&self, range: SourceRange) -> DiagnosticRange {
+        let (start_line, start_column) = self.offset_to_position(range.start);
+        let (end_line, end_column) = self.offset_to_position(range.end);
+        DiagnosticRange {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        }
+    }
+
+    pub fn line_range(&self, line_index: usize) -> Option<SourceRange> {
+        self.lines.get(line_index).map(|line| line.content_range)
+    }
+
+    pub fn is_code_line(&self, line_index: usize) -> bool {
+        self.code_blocks
+            .iter()
+            .any(|block| (block.start_line..=block.end_line).contains(&line_index))
+    }
+}
+
+fn split_lines(content: &str) -> Vec<LineInfo<'_>> {
+    let mut lines = Vec::new();
+    let mut start = 0;
+    for (idx, ch) in content.char_indices() {
+        if ch != '\n' {
+            continue;
+        }
+        let text_end = if idx > start && content.as_bytes()[idx - 1] == b'\r' {
+            idx - 1
+        } else {
+            idx
+        };
+        lines.push(LineInfo {
+            number: lines.len() + 1,
+            text: &content[start..text_end],
+            content_range: SourceRange {
+                start,
+                end: text_end,
+            },
+            full_range: SourceRange {
+                start,
+                end: idx + 1,
+            },
+        });
+        start = idx + 1;
+    }
+    if start < content.len() {
+        lines.push(LineInfo {
+            number: lines.len() + 1,
+            text: &content[start..],
+            content_range: SourceRange {
+                start,
+                end: content.len(),
+            },
+            full_range: SourceRange {
+                start,
+                end: content.len(),
+            },
+        });
+    }
+    lines
+}
+
+fn extract_front_matter(lines: &[LineInfo<'_>]) -> Option<SourceRange> {
+    if lines.first()?.text.trim() != "---" {
+        return None;
+    }
+    lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.text.trim() == "---")
+        .map(|(_, line)| SourceRange {
+            start: 0,
+            end: line.full_range.end,
+        })
+}
+
+fn extract_code_blocks(lines: &[LineInfo<'_>]) -> Vec<BlockRange> {
+    let mut blocks = Vec::new();
+    let mut open: Option<(usize, FenceKind)> = None;
+    for (idx, line) in lines.iter().enumerate() {
+        let Some(kind) = fence_kind(line.text.trim_start()) else {
+            continue;
+        };
+        if let Some((start, start_kind)) = open {
+            if start_kind == kind {
+                blocks.push(BlockRange {
+                    start_line: start,
+                    end_line: idx,
+                    range: SourceRange {
+                        start: lines[start].content_range.start,
+                        end: line.full_range.end,
+                    },
+                    fence: kind,
+                });
+                open = None;
+            }
+        } else {
+            open = Some((idx, kind));
+        }
+    }
+    if let Some((start, kind)) = open {
+        if let Some(last) = lines.last() {
+            blocks.push(BlockRange {
+                start_line: start,
+                end_line: lines.len() - 1,
+                range: SourceRange {
+                    start: lines[start].content_range.start,
+                    end: last.full_range.end,
+                },
+                fence: kind,
+            });
+        }
+    }
+    blocks
+}
+
+fn fence_kind(trimmed: &str) -> Option<FenceKind> {
+    if trimmed.starts_with("```") {
+        Some(FenceKind::Backtick)
+    } else if trimmed.starts_with("~~~") {
+        Some(FenceKind::Tilde)
+    } else {
+        None
+    }
+}
+
+fn extract_headings<'a>(lines: &[LineInfo<'a>], code_blocks: &[BlockRange]) -> Vec<Heading<'a>> {
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| !line_in_blocks(*idx, code_blocks))
+        .filter_map(|(idx, line)| parse_heading(idx, line))
+        .collect()
+}
+
+fn parse_heading<'a>(line_index: usize, line: &LineInfo<'a>) -> Option<Heading<'a>> {
+    let indent = line.text.len() - line.text.trim_start_matches(' ').len();
+    if indent > 3 {
+        return None;
+    }
+    let trimmed = &line.text[indent..];
+    let level = trimmed.bytes().take_while(|byte| *byte == b'#').count();
+    if !(1..=6).contains(&level) {
+        return None;
+    }
+    if trimmed
+        .as_bytes()
+        .get(level)
+        .is_some_and(|byte| *byte != b' ')
+    {
+        return None;
+    }
+    let marker_start = line.content_range.start + indent;
+    let text_start = marker_start + level + usize::from(trimmed.len() > level);
+    let mut text_end = line.content_range.end;
+    let body = &line.text[text_start - line.content_range.start..];
+    if let Some(closing_start) = body.rfind(" #") {
+        if body[closing_start + 1..].bytes().all(|byte| byte == b'#') {
+            text_end = text_start + closing_start;
+        }
+    }
+    Some(Heading {
+        line: line_index,
+        level,
+        text: &line.text
+            [text_start - line.content_range.start..text_end - line.content_range.start],
+        marker_range: SourceRange {
+            start: marker_start,
+            end: marker_start + level,
+        },
+        text_range: SourceRange {
+            start: text_start,
+            end: text_end,
+        },
+    })
+}
+
+fn extract_links<'a>(lines: &[LineInfo<'a>], code_blocks: &[BlockRange]) -> Vec<Link<'a>> {
+    let mut links = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if line_in_blocks(idx, code_blocks) {
+            continue;
+        }
+        let mut cursor = 0;
+        while let Some(open_text) = line.text[cursor..].find('[') {
+            let text_start_local = cursor + open_text + 1;
+            let Some(close_text_rel) = line.text[text_start_local..].find(']') else {
+                break;
+            };
+            let text_end_local = text_start_local + close_text_rel;
+            let after_text = text_end_local + 1;
+            if line.text.as_bytes().get(after_text) != Some(&b'(') {
+                cursor = after_text;
+                continue;
+            }
+            let dest_start_local = after_text + 1;
+            let Some(close_dest_rel) = line.text[dest_start_local..].find(')') else {
+                break;
+            };
+            let dest_end_local = dest_start_local + close_dest_rel;
+            links.push(Link {
+                line: idx,
+                text: &line.text[text_start_local..text_end_local],
+                destination: &line.text[dest_start_local..dest_end_local],
+                text_range: SourceRange {
+                    start: line.content_range.start + text_start_local,
+                    end: line.content_range.start + text_end_local,
+                },
+                destination_range: SourceRange {
+                    start: line.content_range.start + dest_start_local,
+                    end: line.content_range.start + dest_end_local,
+                },
+            });
+            cursor = dest_end_local + 1;
+        }
+    }
+    links
+}
+
+fn extract_tables<'a>(lines: &[LineInfo<'a>], code_blocks: &[BlockRange]) -> Vec<TableBlock<'a>> {
+    let mut tables = Vec::new();
+    let mut idx = 0;
+    while idx + 1 < lines.len() {
+        if line_in_blocks(idx, code_blocks) {
+            idx += 1;
+            continue;
+        }
+        let Some(header) = parse_table_row(idx, &lines[idx]) else {
+            idx += 1;
+            continue;
+        };
+        let Some(delimiter) = parse_table_row(idx + 1, &lines[idx + 1]) else {
+            idx += 1;
+            continue;
+        };
+        if !delimiter.delimiter || header.cells.len() != delimiter.cells.len() {
+            idx += 1;
+            continue;
+        }
+        let mut rows = vec![header, delimiter];
+        let mut end = idx + 1;
+        while end + 1 < lines.len() && !line_in_blocks(end + 1, code_blocks) {
+            let Some(next) = parse_table_row(end + 1, &lines[end + 1]) else {
+                break;
+            };
+            if next.cells.len() != rows[0].cells.len() {
+                break;
+            }
+            rows.push(next);
+            end += 1;
+        }
+        tables.push(TableBlock {
+            start_line: idx,
+            end_line: end,
+            range: SourceRange {
+                start: lines[idx].content_range.start,
+                end: lines[end].full_range.end,
+            },
+            rows,
+        });
+        idx = end + 1;
+    }
+    tables
+}
+
+fn parse_table_row<'a>(line_index: usize, line: &LineInfo<'a>) -> Option<TableRow<'a>> {
+    let trimmed = line.text.trim();
+    if !trimmed.contains('|') || trimmed.is_empty() {
+        return None;
+    }
+    let leading_pipe = trimmed.starts_with('|');
+    let trailing_pipe = trimmed.ends_with('|');
+    let safe_to_fix = !trimmed.contains("\\|") && !trimmed.contains('`');
+    let mut inner = trimmed;
+    let leading_trim = line.text.find(trimmed).unwrap_or(0);
+    let mut inner_start = line.content_range.start + leading_trim;
+    if leading_pipe {
+        inner = &inner[1..];
+        inner_start += 1;
+    }
+    if trailing_pipe {
+        inner = &inner[..inner.len().saturating_sub(1)];
+    }
+    let mut cells = Vec::new();
+    let mut cell_start = inner_start;
+    for raw in inner.split('|') {
+        let left_trim = raw.len() - raw.trim_start().len();
+        let text = raw.trim();
+        let start = cell_start + left_trim;
+        cells.push(TableCell {
+            text,
+            range: SourceRange {
+                start,
+                end: start + text.len(),
+            },
+        });
+        cell_start += raw.len() + 1;
+    }
+    if cells.is_empty() {
+        return None;
+    }
+    let delimiter = cells.iter().all(|cell| is_delimiter_cell(cell.text));
+    Some(TableRow {
+        line: line_index,
+        cells,
+        leading_pipe,
+        trailing_pipe,
+        delimiter,
+        safe_to_fix,
+        range: line.content_range,
+    })
+}
+
+fn is_delimiter_cell(cell: &str) -> bool {
+    let trimmed = cell.trim();
+    let core = trimmed.trim_matches(':');
+    core.len() >= 3
+        && core.bytes().all(|byte| byte == b'-')
+        && trimmed.bytes().all(|byte| byte == b'-' || byte == b':')
+}
+
+fn line_in_blocks(line_index: usize, blocks: &[BlockRange]) -> bool {
+    blocks
+        .iter()
+        .any(|block| (block.start_line..=block.end_line).contains(&line_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_handles_empty_no_newline_crlf_and_unicode() {
+        let empty = DocumentContext::new(Path::new("empty.md"), "");
+        assert!(empty.lines().is_empty());
+        assert_eq!(empty.offset_to_position(0), (1, 1));
+
+        let no_newline = DocumentContext::new(Path::new("doc.md"), "# Title");
+        assert_eq!(no_newline.lines()[0].text, "# Title");
+        assert_eq!(no_newline.offset_to_position(7), (1, 8));
+
+        let crlf = DocumentContext::new(Path::new("doc.md"), "# A\r\ntext\r\n");
+        assert_eq!(crlf.lines()[0].text, "# A");
+        assert_eq!(crlf.lines()[0].full_range.end, 5);
+        assert_eq!(crlf.offset_to_position(5), (2, 1));
+
+        let unicode = DocumentContext::new(Path::new("doc.md"), "é\n");
+        assert_eq!(unicode.offset_to_position(2), (1, 3));
+        assert_eq!(unicode.offset_to_position(3), (2, 1));
+        let range = unicode.diagnostic_range(SourceRange { start: 0, end: 2 });
+        assert_eq!(range.start_line, 1);
+        assert_eq!(range.start_column, 1);
+        assert_eq!(range.end_line, 1);
+        assert_eq!(range.end_column, 3);
+    }
+
+    #[test]
+    fn context_extracts_structures_with_source_ranges() {
+        let content = "---\ntitle: x\n---\n# Title\n\n[text](#title)\n\n| A | B |\n|---|---|\n| C | D |\n\n```md\n# ignored\n| x | y |\n```\n";
+        let ctx = DocumentContext::new(Path::new("doc.md"), content);
+
+        assert_eq!(ctx.front_matter(), Some(SourceRange { start: 0, end: 17 }));
+        assert_eq!(ctx.headings().len(), 1);
+        assert_eq!(ctx.headings()[0].text, "Title");
+        assert_eq!(ctx.links().len(), 1);
+        assert_eq!(ctx.links()[0].destination, "#title");
+        assert_eq!(ctx.tables().len(), 1);
+        assert_eq!(ctx.tables()[0].rows.len(), 3);
+        assert_eq!(ctx.code_blocks().len(), 1);
+        assert!(ctx.is_code_line(12));
+        assert_eq!(ctx.markdown_ast().blocks.len(), 3);
+    }
+
+    #[test]
+    fn ast_is_lazy_and_not_required_for_structural_indexes() {
+        let content = "# Title\n\n| A | B |\n|---|---|\n";
+        let ctx = DocumentContext::new(Path::new("doc.md"), content);
+
+        assert!(ctx.ast.get().is_none());
+        assert!(ctx.headings.get().is_none());
+        assert!(ctx.tables.get().is_none());
+        assert_eq!(ctx.headings().len(), 1);
+        assert_eq!(ctx.tables().len(), 1);
+        assert!(ctx.headings.get().is_some());
+        assert!(ctx.tables.get().is_some());
+        assert!(ctx.ast.get().is_none());
+
+        assert_eq!(ctx.markdown_ast().blocks.len(), 2);
+        assert!(ctx.ast.get().is_some());
+    }
+}

--- a/src/rules/markdown/eval.rs
+++ b/src/rules/markdown/eval.rs
@@ -45,7 +45,7 @@ use crate::rules::markdown::rules::spaces_in_code::NoSpaceInCodeRule;
 use crate::rules::markdown::rules::spaces_in_emphasis::SpacesInEmphasisRule;
 use crate::rules::markdown::rules::style::*;
 use crate::rules::markdown::rules::whitespace::*;
-use crate::rules::markdown::{MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta};
+use crate::rules::markdown::{DocumentContext, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta};
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
@@ -272,16 +272,15 @@ impl MarkdownLinterOps {
             return diagnostics;
         }
 
-        let rules = Self::get_official_rules();
-        for rule in rules {
+        let ctx = DocumentContext::new(file_path, content);
+        for rule in Self::get_official_rules() {
             let rule_id = rule.id();
             let sev_opt = severity_map
                 .get(rule_id)
                 .copied()
                 .unwrap_or(Some(crate::rules::markdown::DiagnosticSeverity::Warning));
             if let Some(severity) = sev_opt {
-                let mut diags =
-                    rule.evaluate_configured(file_path, content, rule_configs.get(rule_id));
+                let mut diags = rule.evaluate_context(&ctx, rule_configs.get(rule_id));
                 for d in &mut diags {
                     d.severity = severity;
                 }

--- a/src/rules/markdown/mod.rs
+++ b/src/rules/markdown/mod.rs
@@ -1,6 +1,8 @@
 mod types;
 pub use types::*;
 pub mod catalog;
+pub mod document;
+pub use document::*;
 
 use crate::rules::markdown::helpers::RuleHelpers;
 use crate::types::RuleConfig;
@@ -12,6 +14,14 @@ pub trait MarkdownRule: Send + Sync {
     /// `None` means the rule is hidden (internal-only).
     fn official_meta(&self) -> Option<OfficialRuleMeta>;
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic>;
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
+        self.evaluate_configured(ctx.file_path(), ctx.content(), config)
+    }
 
     fn evaluate_configured(
         &self,
@@ -39,46 +49,46 @@ impl MarkdownRule for HeadingIncrementRule {
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
+        let ctx = DocumentContext::new(file_path, content);
+        self.evaluate_context(&ctx, None)
+    }
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        _config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
         let meta = self
             .official_meta()
             .expect("official_meta is always Some for MD001");
         let mut diagnostics = Vec::new();
         let mut last_level = 0;
-        let mut in_code_block = false;
-        for (line_idx, line) in content.lines().enumerate() {
-            let trimmed = line.trim_start();
-            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-                in_code_block = !in_code_block;
-                continue;
+
+        for heading in ctx.headings() {
+            let current_level = heading.level;
+            if last_level > 0 && current_level > last_level + 1 {
+                let line = &ctx.lines()[heading.line];
+                diagnostics.push(MarkdownDiagnostic {
+                    file: ctx.file_path().to_path_buf(),
+                    severity: DiagnosticSeverity::Warning,
+                    range: DiagnosticRange {
+                        start_line: line.number,
+                        start_column: 1,
+                        end_line: line.number,
+                        end_column: line.text.len(),
+                    },
+                    message: format!(
+                        "{} [Expected: h{}, Actual: h{}]",
+                        meta.description,
+                        last_level + 1,
+                        current_level
+                    ),
+                    rule_id: meta.code.to_string(),
+                    official_meta: Some(meta.clone()),
+                    fix_info: None,
+                });
             }
-            if in_code_block {
-                continue;
-            }
-            if let Some(level) = RuleHelpers::get_heading_level(line) {
-                let current_level = level;
-                if last_level > 0 && current_level > last_level + 1 {
-                    diagnostics.push(MarkdownDiagnostic {
-                        file: file_path.to_path_buf(),
-                        severity: DiagnosticSeverity::Warning,
-                        range: DiagnosticRange {
-                            start_line: line_idx + 1,
-                            start_column: 1,
-                            end_line: line_idx + 1,
-                            end_column: line.len(),
-                        },
-                        message: format!(
-                            "{} [Expected: h{}, Actual: h{}]",
-                            meta.description,
-                            last_level + 1,
-                            current_level
-                        ),
-                        rule_id: meta.code.to_string(),
-                        official_meta: Some(meta.clone()),
-                        fix_info: None,
-                    });
-                }
-                last_level = current_level;
-            }
+            last_level = current_level;
         }
         diagnostics
     }

--- a/src/rules/markdown/rules/heading_style.rs
+++ b/src/rules/markdown/rules/heading_style.rs
@@ -19,8 +19,13 @@ impl MarkdownRule for HeadingStyleRule {
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD003");
         let mut diagnostics = Vec::new();
+        let lines: Vec<&str> = content.lines().collect();
+        let front_matter = detect_front_matter(&lines);
         let mut in_code_block = false;
-        for (i, line) in content.lines().enumerate() {
+        for (i, line) in lines.iter().enumerate() {
+            if front_matter.is_some_and(|(start, end)| (start..=end).contains(&i)) {
+                continue;
+            }
             let trimmed = line.trim_start();
             if RuleHelpers::is_fence(trimmed) {
                 in_code_block = !in_code_block;
@@ -29,8 +34,8 @@ impl MarkdownRule for HeadingStyleRule {
             if in_code_block {
                 continue;
             }
-            /* WHY: Detect setext-style headings (underline with === or ---) */
-            if is_setext_underline(trimmed) && i > 0 {
+            /* WHY: Setext heading markers only count when attached to paragraph text. */
+            if is_setext_heading_marker(&lines, i) {
                 RuleHelpers::push_diag(
                     &mut diagnostics,
                     file_path,
@@ -45,9 +50,62 @@ impl MarkdownRule for HeadingStyleRule {
     }
 }
 
+fn detect_front_matter(lines: &[&str]) -> Option<(usize, usize)> {
+    if lines.first().map(|line| line.trim()) != Some("---") {
+        return None;
+    }
+    lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| matches!(line.trim(), "---" | "..."))
+        .map(|(end, _)| (0, end))
+}
+
+fn is_setext_heading_marker(lines: &[&str], idx: usize) -> bool {
+    if idx == 0 || !is_setext_underline(lines[idx].trim()) {
+        return false;
+    }
+    let previous = lines[idx - 1].trim();
+    !previous.is_empty()
+        && !RuleHelpers::is_fence(previous)
+        && !RuleHelpers::is_atx_heading(previous)
+        && !is_setext_underline(previous)
+}
+
 fn is_setext_underline(trimmed: &str) -> bool {
     if trimmed.len() < 2 {
         return false;
     }
     trimmed.chars().all(|c| c == '=') || trimmed.chars().all(|c| c == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_setext_heading_marker() {
+        let diagnostics = HeadingStyleRule.evaluate(Path::new("test.md"), "Heading\n---\n");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule_id, "MD003");
+        assert_eq!(diagnostics[0].range.start_line, 2);
+    }
+
+    #[test]
+    fn ignores_standalone_horizontal_rule_after_blank_line() {
+        let diagnostics =
+            HeadingStyleRule.evaluate(Path::new("test.md"), "# Heading\n\n---\n\nText\n");
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_front_matter_delimiters() {
+        let diagnostics =
+            HeadingStyleRule.evaluate(Path::new("test.md"), "---\ntitle: Doc\n---\n\n# Doc\n");
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/src/rules/markdown/rules/md060.rs
+++ b/src/rules/markdown/rules/md060.rs
@@ -1,10 +1,11 @@
-use crate::rules::markdown::helpers::RuleHelpers;
 use crate::rules::markdown::{
-    DiagnosticSeverity, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta,
+    DiagnosticFix, DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule,
+    OfficialRuleMeta, TableBlock, TableRow,
 };
+use crate::types::RuleConfig;
 use std::path::Path;
 
-/// MD060 / table-column-style — Table column style.
+/// MD060 / table-column-style - Table column style.
 pub struct TableColumnStyleRule;
 
 impl MarkdownRule for TableColumnStyleRule {
@@ -17,21 +18,333 @@ impl MarkdownRule for TableColumnStyleRule {
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
+        let ctx = DocumentContext::new(file_path, content);
+        self.evaluate_context(&ctx, None)
+    }
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD060");
-        let mut diagnostics = Vec::new();
-        for (i, line) in content.lines().enumerate() {
-            let trimmed = line.trim();
-            if trimmed.contains('|') && trimmed.contains(" | ") {
-                RuleHelpers::push_diag(
-                    &mut diagnostics,
-                    file_path,
-                    i,
-                    line,
-                    &meta,
-                    DiagnosticSeverity::Warning,
-                );
-            }
+        let options = TableStyleOptions::from_config(config);
+        ctx.tables()
+            .iter()
+            .filter_map(|table| evaluate_table(ctx, &meta, &options, table))
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TableStyle {
+    Aligned,
+    Compact,
+    Tight,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConfiguredStyle {
+    Any,
+    Style(TableStyle),
+}
+
+struct TableStyleOptions {
+    style: ConfiguredStyle,
+    aligned_delimiter: bool,
+}
+
+impl TableStyleOptions {
+    fn from_config(config: Option<&RuleConfig>) -> Self {
+        let style = config
+            .and_then(|config| config.properties.get("style"))
+            .map(|style| match style.as_str() {
+                "aligned" => ConfiguredStyle::Style(TableStyle::Aligned),
+                "compact" => ConfiguredStyle::Style(TableStyle::Compact),
+                "tight" => ConfiguredStyle::Style(TableStyle::Tight),
+                _ => ConfiguredStyle::Any,
+            })
+            .unwrap_or(ConfiguredStyle::Any);
+        let aligned_delimiter = config
+            .and_then(|config| config.properties.get("aligned_delimiter"))
+            .is_some_and(|value| value == "true");
+        Self {
+            style,
+            aligned_delimiter,
         }
-        diagnostics
+    }
+}
+
+fn evaluate_table<'a>(
+    ctx: &DocumentContext<'a>,
+    meta: &OfficialRuleMeta,
+    options: &TableStyleOptions,
+    table: &TableBlock<'a>,
+) -> Option<MarkdownDiagnostic> {
+    if table_matches(ctx, options, table) {
+        return None;
+    }
+    let range = ctx.diagnostic_range(table.range);
+    Some(MarkdownDiagnostic {
+        file: ctx.file_path().to_path_buf(),
+        severity: DiagnosticSeverity::Warning,
+        range: range.clone(),
+        message: meta.description.to_string(),
+        rule_id: meta.code.to_string(),
+        official_meta: Some(meta.clone()),
+        fix_info: safe_fix(ctx, options, table).map(|replacement| DiagnosticFix {
+            start_line: range.start_line,
+            start_column: range.start_column,
+            end_line: range.end_line,
+            end_column: range.end_column,
+            replacement,
+        }),
+    })
+}
+
+fn table_matches<'a>(
+    ctx: &DocumentContext<'a>,
+    options: &TableStyleOptions,
+    table: &TableBlock<'a>,
+) -> bool {
+    let style_ok = match options.style {
+        ConfiguredStyle::Any => {
+            matches_style(ctx, table, TableStyle::Aligned)
+                || matches_style(ctx, table, TableStyle::Compact)
+                || matches_style(ctx, table, TableStyle::Tight)
+        }
+        ConfiguredStyle::Style(style) => matches_style(ctx, table, style),
+    };
+    style_ok && (!options.aligned_delimiter || delimiter_aligned_with_header(ctx, table))
+}
+
+fn matches_style<'a>(ctx: &DocumentContext<'a>, table: &TableBlock<'a>, style: TableStyle) -> bool {
+    match style {
+        TableStyle::Aligned => rows_have_same_pipe_positions(ctx, table),
+        TableStyle::Compact => table
+            .rows
+            .iter()
+            .all(|row| line_text(ctx, row).trim() == format_simple_row(row, " ")),
+        TableStyle::Tight => table
+            .rows
+            .iter()
+            .all(|row| line_text(ctx, row).trim() == format_simple_row(row, "")),
+    }
+}
+
+fn safe_fix<'a>(
+    ctx: &DocumentContext<'a>,
+    options: &TableStyleOptions,
+    table: &TableBlock<'a>,
+) -> Option<String> {
+    if !safe_to_fix(table) {
+        return None;
+    }
+    let style = match options.style {
+        ConfiguredStyle::Style(style) => style,
+        ConfiguredStyle::Any => closest_style(ctx, table),
+    };
+    let mut replacement = match style {
+        TableStyle::Aligned => table
+            .rows
+            .iter()
+            .map(|row| format_aligned_row(table, row))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        TableStyle::Compact => table
+            .rows
+            .iter()
+            .map(|row| format_simple_row(row, " "))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        TableStyle::Tight => table
+            .rows
+            .iter()
+            .map(|row| format_simple_row(row, ""))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    if ctx.content()[table.range.start..table.range.end].ends_with('\n') {
+        replacement.push('\n');
+    }
+    Some(replacement)
+}
+
+fn safe_to_fix(table: &TableBlock<'_>) -> bool {
+    let Some(first) = table.rows.first() else {
+        return false;
+    };
+    table.rows.iter().all(|row| {
+        row.safe_to_fix
+            && row.cells.len() == first.cells.len()
+            && row.leading_pipe == first.leading_pipe
+            && row.trailing_pipe == first.trailing_pipe
+    })
+}
+
+fn closest_style<'a>(ctx: &DocumentContext<'a>, table: &TableBlock<'a>) -> TableStyle {
+    let compact_distance = table
+        .rows
+        .iter()
+        .filter(|row| line_text(ctx, row).trim() != format_simple_row(row, " "))
+        .count();
+    let tight_distance = table
+        .rows
+        .iter()
+        .filter(|row| line_text(ctx, row).trim() != format_simple_row(row, ""))
+        .count();
+    if tight_distance < compact_distance {
+        TableStyle::Tight
+    } else {
+        TableStyle::Compact
+    }
+}
+
+fn format_simple_row(row: &TableRow<'_>, padding: &str) -> String {
+    let cells = row
+        .cells
+        .iter()
+        .map(|cell| {
+            if row.delimiter {
+                normalize_delimiter(cell.text, 3)
+            } else {
+                cell.text.to_string()
+            }
+        })
+        .collect::<Vec<_>>();
+    let separator = format!("{padding}|{padding}");
+    let mut output = cells.join(&separator);
+    if row.leading_pipe {
+        output = format!("|{padding}{output}");
+    }
+    if row.trailing_pipe {
+        output.push_str(padding);
+        output.push('|');
+    }
+    output
+}
+
+fn format_aligned_row(table: &TableBlock<'_>, row: &TableRow<'_>) -> String {
+    let widths = column_widths(table);
+    let mut cells = Vec::new();
+    for (idx, cell) in row.cells.iter().enumerate() {
+        let width = widths[idx];
+        let text = if row.delimiter {
+            normalize_delimiter(cell.text, width.max(3))
+        } else {
+            cell.text.to_string()
+        };
+        cells.push(format!("{text:<width$}"));
+    }
+    let mut output = cells.join(" | ");
+    if row.leading_pipe {
+        output = format!("| {output}");
+    }
+    if row.trailing_pipe {
+        output.push_str(" |");
+    }
+    output
+}
+
+fn column_widths(table: &TableBlock<'_>) -> Vec<usize> {
+    let column_count = table.rows.first().map(|row| row.cells.len()).unwrap_or(0);
+    let mut widths = vec![3; column_count];
+    for row in &table.rows {
+        for (idx, cell) in row.cells.iter().enumerate() {
+            widths[idx] = widths[idx].max(cell.text.chars().count());
+        }
+    }
+    widths
+}
+
+fn normalize_delimiter(cell: &str, width: usize) -> String {
+    let left = cell.starts_with(':');
+    let right = cell.ends_with(':');
+    let dash_count = width.saturating_sub(usize::from(left) + usize::from(right));
+    format!(
+        "{}{}{}",
+        if left { ":" } else { "" },
+        "-".repeat(dash_count.max(3)),
+        if right { ":" } else { "" }
+    )
+}
+
+fn rows_have_same_pipe_positions<'a>(ctx: &DocumentContext<'a>, table: &TableBlock<'a>) -> bool {
+    let Some(first) = table.rows.first() else {
+        return true;
+    };
+    let expected = pipe_positions(line_text(ctx, first));
+    table
+        .rows
+        .iter()
+        .all(|row| pipe_positions(line_text(ctx, row)) == expected)
+}
+
+fn delimiter_aligned_with_header<'a>(ctx: &DocumentContext<'a>, table: &TableBlock<'a>) -> bool {
+    if table.rows.len() < 2 {
+        return true;
+    }
+    pipe_positions(line_text(ctx, &table.rows[0])) == pipe_positions(line_text(ctx, &table.rows[1]))
+}
+
+fn pipe_positions(line: &str) -> Vec<usize> {
+    line.bytes()
+        .enumerate()
+        .filter_map(|(idx, byte)| (byte == b'|').then_some(idx))
+        .collect()
+}
+
+fn line_text<'a>(ctx: &DocumentContext<'a>, row: &TableRow<'a>) -> &'a str {
+    ctx.lines()[row.line].text
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{fix_with_results, lint, LintOptions, RuleConfig};
+    use std::collections::HashMap;
+
+    fn md060_options(style: &str) -> LintOptions {
+        let mut rules = HashMap::new();
+        rules.insert(
+            "MD060".to_string(),
+            RuleConfig {
+                enabled: true,
+                properties: HashMap::from([("style".to_string(), style.to_string())]),
+            },
+        );
+        LintOptions {
+            rules,
+            ..LintOptions::default()
+        }
+    }
+
+    #[test]
+    fn accepts_official_table_styles() {
+        for (style, content) in [
+            ("aligned", "| A | B |\n|---|---|\n| C | D |\n"),
+            ("compact", "| A | B |\n| --- | --- |\n| C | D |\n"),
+            ("tight", "|A|B|\n|---|---|\n|C|D|\n"),
+        ] {
+            let results = lint(content, &md060_options(style)).expect("lint runs");
+            assert!(
+                results.iter().all(|result| result.rule_id != "MD060"),
+                "{style} should pass"
+            );
+        }
+    }
+
+    #[test]
+    fn fixes_table_style_from_context_range() {
+        let content = "|A|B|\n|---|---|\n|C|D|\n";
+        let options = md060_options("compact");
+        let results = lint(content, &options).expect("lint runs");
+        let md060 = results
+            .iter()
+            .find(|result| result.rule_id == "MD060")
+            .expect("MD060 diagnostic exists");
+
+        assert!(md060.fix.is_some());
+        let fixed = fix_with_results(content, &results);
+        assert_eq!(fixed.content, "| A | B |\n| --- | --- |\n| C | D |\n");
     }
 }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -278,8 +278,20 @@ fn ast_linter_readme_rule_map_matches_public_catalog() {
         violations.push("README.md: missing `## Rule Map`".to_string());
     }
 
+    let fixture_matrix: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/rule-fixture-matrix.json"))
+            .expect("fixture matrix should parse");
+    let rules = fixture_matrix["rules"]
+        .as_array()
+        .expect("fixture matrix rules should be an array");
+
     for rule in katana_markdown_linter::available_rules() {
-        let safe_fix = if rule.fixable { "yes" } else { "no" };
+        let safe_fix = rules
+            .iter()
+            .find(|entry| entry["rule_id"].as_str() == Some(rule.id.as_str()))
+            .and_then(|entry| entry["fix"].as_array())
+            .is_some_and(|fixes| !fixes.is_empty());
+        let safe_fix = if safe_fix { "yes" } else { "no" };
         let row = format!("| `{}` | {} |", rule.id, safe_fix);
         if !readme.contains(&row) {
             violations.push(format!("README.md: missing rule map row `{row}`"));

--- a/tests/fixtures/rule-fixture-matrix.json
+++ b/tests/fixtures/rule-fixture-matrix.json
@@ -5,7 +5,7 @@
     "rules_with_examples": 53,
     "rules_with_fix_metadata": 33,
     "rules_with_parameters": 34,
-    "manual_required": 3,
+    "manual_required": 2,
     "missing_fixtures": 0,
     "stale_fixtures": 0
   },
@@ -3737,19 +3737,60 @@
       "fixable": null,
       "check_pass": [
         {
+          "name": "aligned_table",
+          "source": "| A | B |\n|---|---|\n| C | D |\n",
+          "expected": null
+        },
+        {
           "name": "compact_table",
-          "source": "|A|B|\n|-|-|\n|C|D|\n",
+          "source": "| A | B |\n| --- | --- |\n| C | D |\n",
+          "expected": null
+        },
+        {
+          "name": "tight_table",
+          "source": "|A|B|\n|---|---|\n|C|D|\n",
           "expected": null
         }
       ],
       "check_fail": [
         {
-          "name": "inconsistent_table_style",
-          "source": "| A | B |\n| --- | - |\n| C | D |\n",
+          "name": "mixed_table_style",
+          "source": "|A| B |\n|---|---|\n| C | D |\n",
           "expected": "MD060"
         }
       ],
-      "fix": [],
+      "fix": [
+        {
+          "name": "tight_to_compact",
+          "source": "|A|B|\n|---|---|\n|C|D|\n",
+          "expected": "| A | B |\n| --- | --- |\n| C | D |\n",
+          "config": {
+            "MD060": {
+              "style": "compact"
+            }
+          }
+        },
+        {
+          "name": "compact_to_tight",
+          "source": "| A | B |\n| --- | --- |\n| C | D |\n",
+          "expected": "|A|B|\n|---|---|\n|C|D|\n",
+          "config": {
+            "MD060": {
+              "style": "tight"
+            }
+          }
+        },
+        {
+          "name": "compact_to_aligned",
+          "source": "| A | B |\n| --- | --- |\n| C | D |\n",
+          "expected": "| A   | B   |\n| --- | --- |\n| C   | D   |\n",
+          "config": {
+            "MD060": {
+              "style": "aligned"
+            }
+          }
+        }
+      ],
       "config_valid": [
         {
           "name": "rule_enabled_valid",
@@ -3797,18 +3838,21 @@
       "edge": [
         {
           "name": "compact_table_is_accepted",
-          "source": "|A|B|\n|-|-|\n|C|D|\n",
+          "source": "| A | B |\n| --- | --- |\n| C | D |\n",
           "expected": null
         },
         {
-          "name": "spaced_table_is_diagnostic_only",
-          "source": "| A | B |\n| --- | - |\n| C | D |\n",
+          "name": "mixed_table_style_has_safe_fix",
+          "source": "|A| B |\n|---|---|\n| C | D |\n",
           "expected": "MD060"
+        },
+        {
+          "name": "escaped_pipe_is_not_a_table",
+          "source": "| A \\| B | C |\n|---|---|\n",
+          "expected": null
         }
       ],
-      "manual_required": [
-        "fix unsupported: table column style requires strategy-aware table formatting before safe fix can be locked"
-      ]
+      "manual_required": []
     }
   ]
 }

--- a/tests/fixtures/rule-fixture-matrix.json
+++ b/tests/fixtures/rule-fixture-matrix.json
@@ -138,7 +138,18 @@
           "expected": "invalid type"
         }
       ],
-      "edge": [],
+      "edge": [
+        {
+          "name": "horizontal_rule_after_blank_line",
+          "source": "# Heading\n\n---\n\nText\n",
+          "expected": null
+        },
+        {
+          "name": "front_matter_delimiters",
+          "source": "---\ntitle: Doc\n---\n\n# Doc\n",
+          "expected": null
+        }
+      ],
       "manual_required": []
     },
     {

--- a/tests/fixtures/rule-fixture-matrix.md
+++ b/tests/fixtures/rule-fixture-matrix.md
@@ -2,7 +2,7 @@
 
 - upstream source: DavidAnson/markdownlint default branch
 - total rules: 53
-- manual required: 3
+- manual required: 2
 - missing fixtures: 0
 - stale fixtures: 0
 
@@ -60,4 +60,4 @@
 | MD056 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD058 | 1 | 1 | 1 | 1 | 1 | 0 |  |
 | MD059 | 1 | 1 | 0 | 2 | 2 | 0 |  |
-| MD060 | 1 | 1 | 0 | 3 | 5 | 2 | fix unsupported: table column style requires strategy-aware table formatting before safe fix can be locked |
+| MD060 | 3 | 1 | 3 | 3 | 5 | 3 |  |

--- a/tests/fixtures/rule-fixture-matrix.md
+++ b/tests/fixtures/rule-fixture-matrix.md
@@ -9,7 +9,7 @@
 | Rule | Check Pass | Check Fail | Fix | Config Valid | Config Invalid | Edge | Manual Required |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 | MD001 | 1 | 1 | 0 | 2 | 2 | 1 |  |
-| MD003 | 1 | 1 | 0 | 2 | 2 | 0 |  |
+| MD003 | 1 | 1 | 0 | 2 | 2 | 2 |  |
 | MD004 | 1 | 1 | 1 | 2 | 2 | 0 |  |
 | MD005 | 1 | 1 | 1 | 1 | 1 | 1 |  |
 | MD007 | 1 | 1 | 1 | 4 | 4 | 0 |  |

--- a/tests/rule_fixture_harness.rs
+++ b/tests/rule_fixture_harness.rs
@@ -98,7 +98,7 @@ fn fixture_matrix_can_be_loaded_by_harness() {
         .filter_map(|rule| rule.official_meta().map(|meta| meta.code.to_string()))
         .collect::<HashSet<_>>();
 
-    assert_eq!(matrix["summary"]["manual_required"].as_u64(), Some(3));
+    assert_eq!(matrix["summary"]["manual_required"].as_u64(), Some(2));
     assert!(rules(&matrix)
         .iter()
         .all(|rule| active.contains(rule_id(rule))));
@@ -314,7 +314,7 @@ fn front_matter_and_gfm_extension_behavior_is_explicit() {
         "front matter is currently parsed as markdown content, not skipped for first-line heading"
     );
 
-    let gfm_table = "| a | b |\n| - | - |\n| c | d |\n";
+    let gfm_table = "|a| b |\n|---|---|\n| c | d |\n";
     let table_diagnostics = lint(gfm_table, &options).expect("lint should run");
     assert!(table_diagnostics
         .iter()


### PR DESCRIPTION
## Summary
- Introduce source-preserving DocumentContext and route rule execution through shared context where needed
- Improve MD060 context-backed table style detection/fix behavior
- Prepare v0.5.0 release metadata and changelog
- Carry forward MD003 horizontal-rule/front-matter false-positive regression coverage

## Verification
- cargo fmt --all -- --check
- cargo test --workspace --locked
- cargo test --test ast_linter --locked
- cargo test --test upstream_golden_comparison --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- make dogfood
- make perf-check
- make release-check VERSION=v0.5.0