### PR TITLE
Release v0.6.0 i18n expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.0
+
+- Promotes i18n to a library, CLI, and MCP product surface while keeping English and Japanese as the supported locale set.
+- Adds localized rule catalog APIs with canonical English metadata preserved.
+- Makes `Locale` non-exhaustive so future locale additions can be handled without repeating exhaustive-match breakage.
+- Localizes `kml rule` text/JSON output and config validation errors with stable message IDs and parameters.
+- Adds optional MCP `locale` request support for diagnostics, config validation errors, and rule metadata.
+- Adds translation coverage gates for supported message IDs and active rule descriptions.
+
 ## v0.5.0
 
 - Adds source-preserving `DocumentContext` for shared line, heading, code block, reference, table, and lazy AST structure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/README.md
+++ b/README.md
@@ -9,20 +9,27 @@ Use the crate directly when embedding linting into another Rust application.
 - `lint(content, options)`
 - `fix(content, options)`
 - `available_rules()`
+- `localized_available_rules(language_code)`
 - `implemented_rules()`
 - `missing_rules()`
+- `rule_catalog()`
+- `localized_rule_catalog(language_code)`
 - `resolve_locale_code(language_code)`
 - `resolve_locale_code_or(language_code, fallback)`
 - `localized_rule_description(rule_id, fallback_description, language_code)`
+- `supported_locales()`
 - `MarkdownLintConfig`
 - `MarkdownLintConfig::to_lint_options()`
 
 `available_rules()` returns canonical English metadata. For user-facing rule
-catalogs, call `RuleMeta::localized_description(language_code)` or
-`localized_rule_description(...)` so applications can pass UI language codes
-without reimplementing kml's fallback policy. `Locale` remains source-compatible
-in v0.4.x; consumers should prefer resolver helpers instead of exhaustive
-fallback matches.
+catalogs, call `localized_available_rules(language_code)`,
+`localized_rule_catalog(language_code)`, `RuleMeta::localized_description(...)`,
+or `localized_rule_description(...)` so applications can pass UI language codes
+without reimplementing kml's fallback policy.
+
+`Locale` is `#[non_exhaustive]` from v0.6.0. Consumers that match on `Locale`
+should include a wildcard arm and prefer `resolve_locale_code(...)` or
+`resolve_locale_code_or(...)` for UI language strings.
 
 Minimal embedding examples are available under [`examples/`](examples/):
 
@@ -58,7 +65,9 @@ kml check --no-ignore --force-exclude --exclude "vendor/**" vendor/README.md
 kml check --statistics --quiet
 kml fix --diff README.md
 kml rule
+kml rule --locale ja
 kml rule MD013
+kml rule MD013 --locale ja --output json
 kml config file
 kml config get --output json
 kml version
@@ -82,6 +91,10 @@ Supported values currently resolve to English (`en`, `en-US`) or Japanese
 falls back to English if the locale is unavailable or unsupported. Explicit
 unsupported locales fail with a CLI error. `--local` is accepted as a
 backward-compatible alias for v0.4.0 users.
+
+`kml rule` and `kml rule <id>` also honor `--locale`. Text output uses localized
+rule descriptions, and JSON output includes both `description` (localized) and
+`english_description` (canonical English).
 
 ## Rule Map
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -28,6 +28,24 @@ The server uses MCP stdio transport.
 | `rule_list` | none | Lists known rule metadata. |
 | `rule_get` | none | Returns metadata for one rule ID. |
 
+All tools default to English. Pass an optional `locale` string to request
+localized messages or rule descriptions. Supported values currently resolve to
+English (`en`, `en-US`) or Japanese (`ja`, `ja-JP`); unsupported MCP locale
+values fall back to English instead of failing the tool call.
+
+Examples:
+
+```json
+{ "content": "# title\n\n### skipped\n", "locale": "ja-JP" }
+```
+
+```json
+{ "rule_id": "MD003", "locale": "ja" }
+```
+
+Localized responses keep stable fields such as `message_id`, `message_params`,
+`kind`, `expected`, `actual`, `allowed`, rule IDs, and documentation URLs.
+
 ## Safety Boundary
 
 The prototype does not expose file read or file write tools.

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,6 +1,6 @@
 use katana_markdown_linter::{
-    available_rules, fix, lint, localized_rule_description, resolve_locale_code_or, LintOptions,
-    Locale, MarkdownLintConfig,
+    available_rules, fix, lint, localized_rule_catalog, localized_rule_description,
+    resolve_locale_code_or, LintOptions, Locale, MarkdownLintConfig,
 };
 use std::fs;
 use std::path::Path;
@@ -29,6 +29,11 @@ fn main() -> Result<(), DynError> {
     println!("available rules: {}", rules.len());
     let locale = resolve_locale_code_or("ja-JP", Locale::En);
     println!("resolved locale: {locale:?}");
+    let localized_catalog = localized_rule_catalog(locale.code());
+    println!(
+        "localized active rules: {}",
+        localized_catalog.active_rules().count()
+    );
     if let Some(rule) = rules.iter().find(|rule| rule.id == "MD003") {
         println!(
             "localized MD003 description: {}",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -6,6 +6,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 
 - `v0.4.0`: check/fix 拡充を優先する。default fix は safe subset のみを対象にする。
 - `v0.5.0`: `DocumentContext` 主体の AST 部分導入を優先する。unsafe fix mode は別 change として扱い、default safe fix には混ぜない。
+- `v0.6.0`: i18n を library / CLI / MCP の product surface として拡充し、将来 locale 追加のための coverage gate と API 安定化を優先する。
 
 | Priority | Work Area | Change | Why Now |
 | --- | --- | --- | --- |
@@ -13,6 +14,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | Safe check/fix expansion for `v0.4.0` | `safe-fix-strategy-expansion` | Completed for `v0.4.0`; `MD005` and `MD030` safe subsets are locked, while `MD060` remains diagnostic/manual-required because official metadata marks it non-fixable. |
 | Done | Table strategy for `v0.5.0` | `v0-5-0-table-strategy-md060` | Completed for `v0.5.0`; `MD060` now has table-block parsing, official style checks, and safe fix subsets. |
 | Done | Source-preserving document context for `v0.5.0` | `source-preserving-document-context` | Completed for `v0.5.0`; `DocumentContext` now shares source-preserving structure across migrated rule families. |
+| P1 | i18n product surface for `v0.6.0` | `v0-6-0-i18n-expansion-draft` | Active; hardens en/ja localization across Rust API, CLI rule/config output, MCP metadata, and translation coverage gates. |
 | P2 | Unsafe fix mode for `v0.5.0` | `unsafe-fix-mode-and-confirmation` | Unsafe fix requires explicit user opt-in, CLI confirmation, and automation guardrails. |
 | P2 | MCP productization | `mcp-workspace-tools-productization` | Current MCP server is experimental and text-first only. |
 | Done | Performance hot path work | `performance-hotpath-competition` | Completed; docs now include baseline, profile summary, before/after, and local regression guidance. |
@@ -26,9 +28,10 @@ Archived `v0.4.0` changes:
 
 ## Suggested Order
 
-1. Apply `mcp-workspace-tools-productization` when MCP usage is prioritized.
-2. Apply `unsafe-fix-mode-and-confirmation` after default safe context-based behavior is stable.
-3. Use `source-preserving-document-context` as the baseline for later structural fix work.
+1. Complete `v0-6-0-i18n-expansion-draft` before adding new locales.
+2. Apply `mcp-workspace-tools-productization` when workspace MCP usage is prioritized.
+3. Apply `unsafe-fix-mode-and-confirmation` after default safe context-based behavior is stable.
+4. Use `source-preserving-document-context` as the baseline for later structural fix work.
 
 ## Repository Guardrails
 

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/design.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/design.md
@@ -1,0 +1,56 @@
+# Design
+
+## Goals
+
+- Treat i18n as a library/CLI/MCP contract, not only diagnostic text rendering.
+- Keep the crate generic and independent from any consuming application.
+- Avoid adding new locales before translation coverage can be enforced.
+- Preserve strict CLI locale validation while keeping embedding/MCP locale input lenient.
+
+## Decisions
+
+### Locale Support
+
+The v0.6.0 i18n expansion supports English and Japanese only. Additional
+language catalogs are deferred until coverage gates can prevent partial
+catalog additions.
+
+### Locale API Stability
+
+`Locale` becomes `#[non_exhaustive]` in v0.6.0. This is a semver-minor boundary in the `0.x` series and is intentional because future locale additions should not repeatedly break exhaustive matches. Documentation must tell consumers to add wildcard match arms.
+
+### Fallback Policy
+
+- CLI explicit `--locale` / `-l`: strict. Unsupported values return an error.
+- CLI omitted locale: OS locale detection, then English fallback.
+- Library language-code helpers: lenient. Unsupported values resolve to English or caller-provided fallback.
+- MCP locale parameter: lenient. Unsupported values resolve to English.
+
+### Catalog Representation
+
+Canonical rule metadata remains English. Localized APIs return owned metadata with localized descriptions while preserving stable IDs, docs URLs, lifecycle, and fixability.
+
+The Rust-native catalog remains the storage mechanism for v0.6.0. Data-file catalogs are deferred until additional locales make operational overhead worthwhile.
+
+### Config Validation Localization
+
+`ConfigError` gains stable message IDs and structured params derived from `ConfigErrorKind`. Text rendering remains separate from error classification. CLI and MCP responses can localize messages without losing machine-readable kind, expected, actual, allowed values, rule ID, or property.
+
+### MCP Boundary
+
+`kml-mcp` remains an adapter over public crate APIs. It accepts optional `locale` request fields and returns localized diagnostics/rule metadata/config errors. The core crate remains MCP-free.
+
+## Validation Strategy
+
+- Unit tests cover non-exhaustive-compatible API behavior, localized catalog APIs, and config error message metadata.
+- CLI tests cover `kml rule --locale ja` and localized JSON config errors.
+- MCP tests cover localized `rule_list`, `rule_get`, `check_text`, and `config_validate`.
+- AST lint covers translation coverage for supported message IDs and active rule descriptions.
+- Release check remains the final gate.
+
+## Out of Scope
+
+- Adding new locales.
+- Unsafe fix mode.
+- Workspace-writing MCP tools.
+- Moving catalogs to external data files.

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/proposal.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/proposal.md
@@ -9,70 +9,77 @@ v0.4.3 should close the immediate API gap with additive locale resolver and
 localized rule metadata helpers. v0.6.0 should then treat i18n as a product
 surface and define the next durable contract.
 
-## Draft Scope
+## Scope
 
-v0.6.0 should investigate and plan:
+v0.6.0 promotes i18n from diagnostic rendering to a repository-wide product
+surface while keeping the crate generic and application-independent.
 
-- locale support policy beyond English and Japanese
+- Keep English and Japanese as the only supported locales in this release.
 
-- whether `Locale` should become non-exhaustive in a semver-minor release
+- Make `Locale` non-exhaustive in the v0.6.0 semver-minor line so future
+  locale additions do not repeatedly break consumers.
 
-- localized rule catalog output for CLI and MCP
+- Provide localized rule catalog output for Rust API, CLI `kml rule`, and MCP
+  `rule_list` / `rule_get`.
 
-- localized config validation errors with stable error ids and parameters
+- Localize config validation errors with stable message IDs and structured
+  parameters.
 
-- translation coverage tooling for rule descriptions, config errors, CLI text,
-  MCP metadata, and docs snippets
+- Add translation coverage gates for supported message IDs and active rule
+  descriptions.
 
-- fallback policy for explicit user locale vs OS locale vs API-provided locale
+- Preserve the existing fallback split: CLI explicit unsupported locale remains
+  a hard error, OS locale fallback is English, and library/MCP language-code
+  helpers are lenient.
 
-- whether message catalogs should stay Rust-native or move to data files
+- Keep catalogs Rust-native for v0.6.0; moving to data files remains a later
+  implementation detail once additional locales create enough pressure.
 
-- public API stability rules for adding future locales
+- Document the public API stability rule for future locale additions.
 
-## Candidate Deliverables
+## Deliverables
 
-- A detailed design for kml-wide i18n boundaries across library, CLI, and MCP
+- A detailed design for kml-wide i18n boundaries across library, CLI, and MCP.
 
-- A locale support matrix and fallback policy
+- A locale support matrix and fallback policy.
 
-- A translation catalog coverage gate
+- A translation catalog coverage gate.
 
-- Localized `kml rule` / MCP `rule_list` output if product value is confirmed
+- Localized Rust API, `kml rule`, and MCP `rule_list` / `rule_get` output.
 
-- A migration note for consumers currently matching `Locale` exhaustively
+- Localized config validation errors in CLI JSON/text and MCP responses.
 
-## Out of Scope For The Draft
+- A migration note for consumers currently matching `Locale` exhaustively.
 
-- Implementing new locales immediately
+## Out of Scope
+
+- Implementing new locales immediately.
 
 - Rewriting the current message catalog before v0.4.3 is released
 
-- Coupling i18n behavior to any specific consuming application
+- Coupling i18n behavior to any specific consuming application.
 
-- Blocking v0.5.0 DocumentContext / AST work
+- Unsafe fix mode and workspace-writing MCP productization.
 
-## Open Questions For Kickoff
+## Resolved Kickoff Decisions
 
-- Which additional locales are worth supporting first?
+- Additional locales are deferred; v0.6.0 hardens en/ja first.
 
-- Should CLI explicit unsupported locale remain a hard error for all commands?
+- CLI explicit unsupported locale remains a hard error for all commands.
 
-- Should library resolver behavior stay lenient while CLI behavior stays strict?
+- Library resolver behavior stays lenient while CLI behavior stays strict.
 
-- Does MCP need localized metadata by default, or should clients request locale
-  explicitly?
+- MCP responses default to English and accept an explicit `locale` parameter.
 
-- Do rule descriptions need per-rule translation files, or is a single catalog
-  sufficient for the next minor release?
+- A single Rust-native catalog is sufficient for v0.6.0.
 
 ## Readiness Notes
 
-When the draft is promoted to implementation planning, create or expand:
+This change is ready for implementation when:
 
-- `design.md` with final API and catalog architecture
+- `design.md` defines final API and catalog architecture.
 
-- `tasks.md` with DoR, DoD, and rule-by-rule / surface-by-surface progress
+- `tasks.md` includes DoR, DoD, and surface-by-surface progress.
 
-- delta specs for library i18n API, CLI localized catalog output, and MCP
-  metadata localization if those surfaces are included
+- Delta specs cover library i18n API, CLI localized catalog output, MCP
+  metadata localization, and coverage gates.

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/specs/cli/spec.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/specs/cli/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: CLI rule introspection SHALL honor selected locale
+
+CLI は、`kml rule` と `kml rule <id>` の rule description を selected locale で表示しなければならない（SHALL）。
+
+#### Scenario: rule list を localized 表示する
+
+- **WHEN** user が `kml rule --locale ja` を実行する
+- **THEN** CLI は rule ID と rule name に加えて Japanese description を表示する
+- **THEN** unsupported explicit locale は existing CLI locale policy に従って hard error になる
+
+#### Scenario: rule JSON を localized 表示する
+
+- **WHEN** user が `kml rule MD003 --locale ja --format json` を実行する
+- **THEN** CLI JSON は selected locale を示す
+- **THEN** CLI JSON は localized description を含む
+- **THEN** CLI JSON は English canonical description を失わない
+
+### Requirement: CLI config validation errors SHALL expose localized message metadata
+
+CLI は config validation error を text と JSON の両方で localized metadata 付きで返さなければならない（SHALL）。
+
+#### Scenario: config validation error を JSON で出力する
+
+- **WHEN** user が invalid config を使って `kml check --format json --locale ja` を実行する
+- **THEN** CLI JSON error は localized message を含む
+- **THEN** CLI JSON error は stable message ID と message parameters を含む
+- **THEN** exit code は existing config error behavior と同じく `2` になる

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/specs/i18n-api/spec.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/specs/i18n-api/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: library SHALL expose localized rule catalog APIs
+
+Library API は、consumer application が rule catalog を指定 locale で取得できる API を提供しなければならない（SHALL）。
+
+#### Scenario: localized catalog を取得する
+
+- **WHEN** consumer が supported または unsupported language code を渡して localized catalog API を呼び出す
+- **THEN** system は existing resolver fallback policy に従って locale を解決する
+- **THEN** system は rule description を解決済み locale に合わせて返す
+- **THEN** system は rule ID、rule name、docs URL、fixability、lifecycle を保持する
+
+### Requirement: Locale enum SHALL be non-exhaustive for future locale additions
+
+`Locale` enum は、将来の locale 追加に備えて non-exhaustive でなければならない（SHALL）。
+
+#### Scenario: future locale を追加する
+
+- **WHEN** system が v0.6.0 以降で supported locale を増やす
+- **THEN** external consumer は wildcard match を要求される
+- **THEN** system は locale 追加ごとに exhaustive match consumer を破壊しない
+- **THEN** documentation は v0.5.x 以前の exhaustive match consumer 向け migration note を含む
+
+### Requirement: config validation errors SHALL have localized stable message metadata
+
+Config validation errors は、localized rendering に使える stable message ID と structured parameters を持たなければならない（SHALL）。
+
+#### Scenario: invalid config を localized 表示する
+
+- **WHEN** system が unknown rule、unknown property、invalid type、invalid enum、invalid root を検出する
+- **THEN** system は stable message ID を返す
+- **THEN** system は rule ID、property、expected、actual、allowed values を applicable な structured parameters として返す
+- **THEN** system は English fallback と Japanese message rendering を提供する
+
+### Requirement: translation coverage SHALL be gateable
+
+Translation coverage は、supported locale ごとの漏れを CI / AST lint で検出できなければならない（SHALL）。
+
+#### Scenario: translation coverage を検証する
+
+- **WHEN** developer が repository quality gates を実行する
+- **THEN** system は supported locale が同じ message ID set を持つことを確認する
+- **THEN** system は active rule descriptions が Japanese catalog に存在することを確認する
+- **THEN** system は missing translation を failure として報告する
+
+## MODIFIED Requirements
+
+### Requirement: library SHALL expose localized rule metadata descriptions
+
+Library API は、rule metadata の description を caller が指定した locale code に基づいて描画できなければならない（SHALL）。
+
+#### Scenario: known rule description を localized 表示する
+
+- **WHEN** consumer が known rule id、English fallback description、Japanese locale code を渡す
+- **THEN** system はその rule の Japanese description を返す
+- **THEN** consumer は diagnostic-specific helper を直接使う必要がない
+
+#### Scenario: unsupported locale の rule description を表示する
+
+- **WHEN** consumer が unsupported locale code を渡す
+- **THEN** system は English fallback description を返す
+- **THEN** system は canonical English description を保持する API を残す

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/specs/mcp-integration/spec.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/specs/mcp-integration/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: MCP metadata tools SHALL accept explicit locale
+
+MCP metadata tools は、client が明示した locale に基づいて metadata を localized できなければならない（SHALL）。
+
+#### Scenario: localized rule list を取得する
+
+- **WHEN** MCP client が `rule_list` に `locale` を渡す
+- **THEN** system は lenient library resolver で locale を解決する
+- **THEN** response は resolved locale と localized rule descriptions を含む
+- **THEN** locale が省略された場合は English を返す
+
+#### Scenario: localized rule detail を取得する
+
+- **WHEN** MCP client が `rule_get` に rule ID と `locale` を渡す
+- **THEN** system は該当 rule の localized description を返す
+- **THEN** unknown rule handling は existing behavior と同じ error contract を保つ
+
+### Requirement: MCP diagnostic and config responses SHALL localize when requested
+
+MCP check/config tools は、client が明示した locale に基づいて diagnostic と config validation error を localized できなければならない（SHALL）。
+
+#### Scenario: check_text diagnostic を localized 表示する
+
+- **WHEN** MCP client が `check_text` に Markdown content と Japanese locale を渡す
+- **THEN** response diagnostics は Japanese message を含む
+- **THEN** response diagnostics は stable message ID と parameters を保持する
+
+#### Scenario: config_validate error を localized 表示する
+
+- **WHEN** MCP client が `config_validate` に invalid config と Japanese locale を渡す
+- **THEN** response errors は Japanese message を含む
+- **THEN** response errors は stable kind、message ID、parameters、expected/actual/allowed metadata を含む

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/tasks.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/tasks.md
@@ -1,0 +1,68 @@
+# Tasks
+
+## Definition Of Ready
+
+- [x] v0.5.0 is released and `source-preserving-document-context` is archived.
+- [x] Issue #4 follow-up is closed or no longer blocks v0.6.0.
+- [x] Implementation branch is based on latest `origin/main`.
+- [x] OpenSpec proposal, design, delta specs, and tasks exist for this change.
+- [x] Scope excludes new locales, unsafe fix mode, and workspace-writing MCP tools.
+
+## 0. Planning
+
+- [x] 0.1 Finalize proposal from draft to implementation-ready scope.
+- [x] 0.2 Add delta spec for library i18n API.
+- [x] 0.3 Add delta spec for CLI localized rule/config output.
+- [x] 0.4 Add delta spec for MCP localized metadata/config output.
+- [x] 0.5 Add design with fallback policy and API stability decisions.
+
+## 1. Library i18n API
+
+- [x] 1.1 Mark `Locale` as non-exhaustive.
+- [x] 1.2 Add localized rule catalog API while preserving canonical English metadata.
+- [x] 1.3 Add stable config validation message IDs and structured params.
+- [x] 1.4 Add localized config error rendering helper.
+- [x] 1.5 Add unit tests for fallback policy, localized catalog, and config error metadata.
+
+## 2. CLI i18n Surface
+
+- [x] 2.1 Route selected locale into `kml rule` and `kml rule <id>`.
+- [x] 2.2 Include localized descriptions and canonical English descriptions in JSON rule output.
+- [x] 2.3 Use structured localized config errors for validation failures.
+- [x] 2.4 Add CLI tests for Japanese rule output and JSON config error metadata.
+
+## 3. MCP i18n Surface
+
+- [x] 3.1 Add optional locale request fields to text and metadata tools.
+- [x] 3.2 Localize `check_text` and `fix_text` diagnostics when requested.
+- [x] 3.3 Localize `config_validate` errors when requested.
+- [x] 3.4 Localize `rule_list` and `rule_get` descriptions when requested.
+- [x] 3.5 Add MCP tests for localized rule metadata, diagnostics, and config errors.
+
+## 4. Coverage And Documentation
+
+- [x] 4.1 Add translation coverage gate for supported message IDs.
+- [x] 4.2 Add translation coverage gate for active rule descriptions.
+- [x] 4.3 Update README with v0.6.0 i18n behavior and `Locale` migration note.
+- [x] 4.4 Update MCP documentation with locale request behavior.
+- [x] 4.5 Update examples to demonstrate localized catalog usage.
+
+## 5. Release Preparation
+
+- [x] 5.1 Bump crate version to 0.6.0.
+- [x] 5.2 Add CHANGELOG entry for v0.6.0.
+- [x] 5.3 Run `cargo fmt --all -- --check`.
+- [x] 5.4 Run `cargo test --workspace --locked`.
+- [x] 5.5 Run `cargo test --test ast_linter --locked`.
+- [x] 5.6 Run `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`.
+- [x] 5.7 Run `make dogfood`.
+- [x] 5.8 Run `make release-check VERSION=v0.6.0`.
+- [x] 5.9 Run `git diff --check`.
+
+## Definition Of Done
+
+- [x] Rust API exposes localized catalog/config error helpers without app-specific coupling.
+- [x] CLI rule/config output respects selected locale and keeps machine-readable metadata stable.
+- [x] MCP read-only tools accept explicit locale and preserve structured fields.
+- [x] Translation coverage gates fail on missing supported-locale message IDs or rule descriptions.
+- [ ] v0.6.0 release readiness gates pass locally and in CI.

--- a/openspec/changes/v0-6-0-i18n-expansion-draft/tasks.md
+++ b/openspec/changes/v0-6-0-i18n-expansion-draft/tasks.md
@@ -65,4 +65,4 @@
 - [x] CLI rule/config output respects selected locale and keeps machine-readable metadata stable.
 - [x] MCP read-only tools accept explicit locale and preserve structured fields.
 - [x] Translation coverage gates fail on missing supported-locale message IDs or rule descriptions.
-- [ ] v0.6.0 release readiness gates pass locally and in CI.
+- [x] v0.6.0 release readiness gates pass locally and in CI.

--- a/src/bin/kml-mcp.rs
+++ b/src/bin/kml-mcp.rs
@@ -1,6 +1,6 @@
 use katana_markdown_linter::{
-    fix, lint, rule_catalog, ConfigError, ConfigErrorKind, LintOptions, LintResult,
-    MarkdownLintConfig,
+    catalog::RuleCatalogEntry, fix, lint, rule_catalog, ConfigError, LintOptions, LintResult,
+    Locale, MarkdownLintConfig,
 };
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -41,7 +41,10 @@ impl KmlMcpServer {
     ) -> Result<Json<CheckTextResponse>, String> {
         let options = LintOptions::default();
         let diagnostics = lint(&request.content, &options).map_err(|err| err.to_string())?;
-        Ok(Json(CheckTextResponse::from_results(diagnostics)))
+        Ok(Json(CheckTextResponse::from_results(
+            diagnostics,
+            request_locale(request.locale.as_deref()),
+        )))
     }
 
     #[tool(
@@ -53,13 +56,17 @@ impl KmlMcpServer {
         Parameters(request): Parameters<FixTextRequest>,
     ) -> Result<Json<FixTextResponse>, String> {
         let options = LintOptions::default();
+        let locale = request_locale(request.locale.as_deref());
         let fix_result = fix(&request.content, &options).map_err(|err| err.to_string())?;
         let remaining = lint(&fix_result.content, &options).map_err(|err| err.to_string())?;
         Ok(Json(FixTextResponse {
             content: fix_result.content,
             applied_fixes: fix_result.applied_fixes,
             remaining_issue_count: remaining.len(),
-            remaining_diagnostics: remaining.into_iter().map(Diagnostic::from).collect(),
+            remaining_diagnostics: remaining
+                .into_iter()
+                .map(|diagnostic| Diagnostic::from_result(diagnostic, locale))
+                .collect(),
         }))
     }
 
@@ -71,7 +78,8 @@ impl KmlMcpServer {
         &self,
         Parameters(request): Parameters<ConfigValidateRequest>,
     ) -> Json<ConfigValidateResponse> {
-        let errors = validate_config(request.config);
+        let locale = request_locale(request.locale.as_deref());
+        let errors = validate_config(request.config, locale);
         Json(ConfigValidateResponse {
             valid: errors.is_empty(),
             error_count: errors.len(),
@@ -83,9 +91,14 @@ impl KmlMcpServer {
         name = "rule_list",
         description = "List markdownlint-compatible rule metadata known to kml."
     )]
-    async fn rule_list(&self) -> Json<RuleListResponse> {
-        let rules = catalog_rules();
+    async fn rule_list(
+        &self,
+        Parameters(request): Parameters<RuleListRequest>,
+    ) -> Json<RuleListResponse> {
+        let locale = request_locale(request.locale.as_deref());
+        let rules = catalog_rules(locale);
         Json(RuleListResponse {
+            locale: locale.code().to_string(),
             count: rules.len(),
             rules,
         })
@@ -100,7 +113,8 @@ impl KmlMcpServer {
         Parameters(request): Parameters<RuleGetRequest>,
     ) -> Result<Json<RuleMetadata>, String> {
         let rule_id = request.rule_id.to_ascii_uppercase();
-        catalog_rules()
+        let locale = request_locale(request.locale.as_deref());
+        catalog_rules(locale)
             .into_iter()
             .find(|rule| rule.id == rule_id)
             .map(Json)
@@ -124,21 +138,30 @@ impl ServerHandler for KmlMcpServer {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct CheckTextRequest {
     content: String,
+    locale: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct FixTextRequest {
     content: String,
+    locale: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ConfigValidateRequest {
     config: Value,
+    locale: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct RuleListRequest {
+    locale: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct RuleGetRequest {
     rule_id: String,
+    locale: Option<String>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -148,10 +171,13 @@ struct CheckTextResponse {
 }
 
 impl CheckTextResponse {
-    fn from_results(results: Vec<LintResult>) -> Self {
+    fn from_results(results: Vec<LintResult>, locale: Locale) -> Self {
         Self {
             issue_count: results.len(),
-            diagnostics: results.into_iter().map(Diagnostic::from).collect(),
+            diagnostics: results
+                .into_iter()
+                .map(|result| Diagnostic::from_result(result, locale))
+                .collect(),
         }
     }
 }
@@ -169,6 +195,8 @@ struct Diagnostic {
     rule_id: String,
     rule_name: String,
     message: String,
+    message_id: String,
+    message_params: std::collections::BTreeMap<String, String>,
     severity: String,
     line: usize,
     column: usize,
@@ -178,13 +206,21 @@ struct Diagnostic {
     fix: Option<TextFix>,
 }
 
-impl From<LintResult> for Diagnostic {
-    fn from(result: LintResult) -> Self {
+impl Diagnostic {
+    fn from_result(result: LintResult, locale: Locale) -> Self {
         let fixable = result.fix.is_some();
+        let message = katana_markdown_linter::i18n::render_message(
+            locale,
+            result.message_id.as_str(),
+            &result.message_params,
+            result.message.as_str(),
+        );
         Self {
             rule_id: result.rule_id,
             rule_name: result.rule_name,
-            message: result.message,
+            message,
+            message_id: result.message_id,
+            message_params: result.message_params,
             severity: match result.severity {
                 katana_markdown_linter::Severity::Error => "error",
                 katana_markdown_linter::Severity::Warning => "warning",
@@ -229,45 +265,32 @@ struct ConfigValidationError {
     property: Option<String>,
     kind: String,
     message: String,
+    message_id: String,
+    message_params: std::collections::BTreeMap<String, String>,
     expected: Option<String>,
     actual: Option<String>,
     allowed: Vec<String>,
 }
 
-impl From<ConfigError> for ConfigValidationError {
-    fn from(error: ConfigError) -> Self {
-        let (kind, expected, actual, allowed) = match error.kind {
-            ConfigErrorKind::InvalidRoot => ("invalid_root", None, None, Vec::new()),
-            ConfigErrorKind::UnknownRule => ("unknown_rule", None, None, Vec::new()),
-            ConfigErrorKind::UnknownProperty => ("unknown_property", None, None, Vec::new()),
-            ConfigErrorKind::InvalidType { expected, actual } => (
-                "invalid_type",
-                Some(expected.to_string()),
-                Some(actual.to_string()),
-                Vec::new(),
-            ),
-            ConfigErrorKind::InvalidEnumValue { allowed, actual } => (
-                "invalid_enum_value",
-                None,
-                Some(actual),
-                allowed.into_iter().map(str::to_string).collect(),
-            ),
-        };
-
+impl ConfigValidationError {
+    fn from_error(error: ConfigError, locale: Locale) -> Self {
         Self {
-            rule_id: error.rule_id,
-            property: error.property,
-            kind: kind.to_string(),
-            message: error.message,
-            expected,
-            actual,
-            allowed,
+            rule_id: error.rule_id.clone(),
+            property: error.property.clone(),
+            kind: error.kind_code().to_string(),
+            message: error.localized_message(locale),
+            message_id: error.message_id().to_string(),
+            message_params: error.message_params(),
+            expected: error.expected().map(str::to_string),
+            actual: error.actual().map(str::to_string),
+            allowed: error.allowed().into_iter().map(str::to_string).collect(),
         }
     }
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
 struct RuleListResponse {
+    locale: String,
     count: usize,
     rules: Vec<RuleMetadata>,
 }
@@ -277,53 +300,65 @@ struct RuleMetadata {
     id: String,
     name: String,
     description: String,
+    english_description: String,
     docs_url: String,
     fixable: bool,
     implemented_check: bool,
     lifecycle: String,
+    locale: String,
 }
 
-fn catalog_rules() -> Vec<RuleMetadata> {
+impl RuleMetadata {
+    fn from_entry(rule: RuleCatalogEntry, lifecycle: &str, locale: Locale) -> Self {
+        let locale_code = locale.code();
+        let description = rule.localized_description(locale_code);
+        Self {
+            id: rule.id,
+            name: rule.name,
+            description,
+            english_description: rule.description,
+            docs_url: rule.docs_url,
+            fixable: rule.fixable,
+            implemented_check: rule.implemented_check,
+            lifecycle: lifecycle.to_string(),
+            locale: locale_code.to_string(),
+        }
+    }
+}
+
+fn catalog_rules(locale: Locale) -> Vec<RuleMetadata> {
     let catalog = rule_catalog();
     catalog
         .active
         .into_iter()
-        .map(|rule| RuleMetadata {
-            id: rule.id,
-            name: rule.name,
-            description: rule.description,
-            docs_url: rule.docs_url,
-            fixable: rule.fixable,
-            implemented_check: rule.implemented_check,
-            lifecycle: "active".to_string(),
-        })
-        .chain(catalog.deprecated.into_iter().map(|rule| RuleMetadata {
-            id: rule.id,
-            name: rule.name,
-            description: rule.description,
-            docs_url: rule.docs_url,
-            fixable: rule.fixable,
-            implemented_check: rule.implemented_check,
-            lifecycle: "deprecated".to_string(),
-        }))
-        .chain(catalog.removed.into_iter().map(|rule| RuleMetadata {
-            id: rule.id,
-            name: rule.name,
-            description: rule.description,
-            docs_url: rule.docs_url,
-            fixable: rule.fixable,
-            implemented_check: rule.implemented_check,
-            lifecycle: "removed".to_string(),
-        }))
+        .map(|rule| RuleMetadata::from_entry(rule, "active", locale))
+        .chain(
+            catalog
+                .deprecated
+                .into_iter()
+                .map(|rule| RuleMetadata::from_entry(rule, "deprecated", locale)),
+        )
+        .chain(
+            catalog
+                .removed
+                .into_iter()
+                .map(|rule| RuleMetadata::from_entry(rule, "removed", locale)),
+        )
         .collect()
 }
 
-fn validate_config(raw: Value) -> Vec<ConfigValidationError> {
+fn validate_config(raw: Value, locale: Locale) -> Vec<ConfigValidationError> {
     MarkdownLintConfig { raw }
         .validate_cached_rules()
         .into_iter()
-        .map(Into::into)
+        .map(|error| ConfigValidationError::from_error(error, locale))
         .collect()
+}
+
+fn request_locale(locale: Option<&str>) -> Locale {
+    locale
+        .map(katana_markdown_linter::resolve_locale_code)
+        .unwrap_or(Locale::En)
 }
 
 #[tokio::main]
@@ -345,15 +380,19 @@ mod tests {
         let Json(response) = server
             .check_text(Parameters(CheckTextRequest {
                 content: "# title\n\n### skipped\n".to_string(),
+                locale: Some("ja-JP".to_string()),
             }))
             .await
             .expect("check_text should succeed");
 
         assert!(response.issue_count > 0);
-        assert!(response
+        let diagnostic = response
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.rule_id == "MD001"));
+            .find(|diagnostic| diagnostic.rule_id == "MD001")
+            .expect("MD001 should be reported");
+        assert_eq!(diagnostic.message_id, "rule.MD001.heading_increment");
+        assert!(diagnostic.message.contains("見出しレベル"));
     }
 
     #[tokio::test]
@@ -362,6 +401,7 @@ mod tests {
         let Json(response) = server
             .fix_text(Parameters(FixTextRequest {
                 content: "#Title\n".to_string(),
+                locale: Some("ja".to_string()),
             }))
             .await
             .expect("fix_text should succeed");
@@ -376,6 +416,7 @@ mod tests {
         let Json(response) = server
             .config_validate(Parameters(ConfigValidateRequest {
                 config: json!({ "MD999": true }),
+                locale: Some("ja".to_string()),
             }))
             .await;
 
@@ -383,21 +424,37 @@ mod tests {
         assert_eq!(response.error_count, 1);
         assert_eq!(response.errors[0].kind, "unknown_rule");
         assert_eq!(response.errors[0].rule_id.as_deref(), Some("MD999"));
+        assert_eq!(response.errors[0].message_id, "config.unknown_rule");
+        assert_eq!(
+            response.errors[0].message,
+            "未知の markdownlint rule です: MD999"
+        );
     }
 
     #[tokio::test]
     async fn rule_tools_expose_catalog_metadata() {
         let server = KmlMcpServer::new();
-        let Json(list) = server.rule_list().await;
+        let Json(list) = server
+            .rule_list(Parameters(RuleListRequest {
+                locale: Some("ja".to_string()),
+            }))
+            .await;
+        assert_eq!(list.locale, "ja");
         assert!(list.rules.iter().any(|rule| rule.id == "MD001"));
+        assert!(list.rules.iter().any(|rule| {
+            rule.id == "MD003" && rule.description == "見出しのスタイルを統一してください"
+        }));
 
         let Json(rule) = server
             .rule_get(Parameters(RuleGetRequest {
                 rule_id: "md001".to_string(),
+                locale: Some("ja-JP".to_string()),
             }))
             .await
             .expect("MD001 should exist");
         assert_eq!(rule.id, "MD001");
+        assert_eq!(rule.locale, "ja");
+        assert_ne!(rule.description, rule.english_description);
     }
 
     #[test]

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -20,6 +20,18 @@ pub struct RuleCatalogEntry {
     pub lifecycle: RuleLifecycleState,
 }
 
+impl RuleCatalogEntry {
+    pub fn localized_description(&self, language_code: &str) -> String {
+        crate::i18n::localized_rule_description(&self.id, &self.description, language_code)
+    }
+
+    pub fn localized(&self, language_code: &str) -> Self {
+        let mut entry = self.clone();
+        entry.description = self.localized_description(language_code);
+        entry
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct RuleCatalog {
     pub active: Vec<RuleCatalogEntry>,
@@ -85,5 +97,25 @@ impl RuleCatalog {
                 fixable: entry.fixable,
             })
             .collect()
+    }
+
+    pub fn localized(&self, language_code: &str) -> Self {
+        Self {
+            active: self
+                .active
+                .iter()
+                .map(|entry| entry.localized(language_code))
+                .collect(),
+            deprecated: self
+                .deprecated
+                .iter()
+                .map(|entry| entry.localized(language_code))
+                .collect(),
+            removed: self
+                .removed
+                .iter()
+                .map(|entry| entry.localized(language_code))
+                .collect(),
+        }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,7 +101,7 @@ pub fn run(cli: Cli) -> Result<i32, String> {
             let exit = run_check_like(true, &cli, locale)?;
             Ok(exit)
         }
-        Command::Rule(rule_id) => run_rule(rule_id.as_deref(), cli.format),
+        Command::Rule(rule_id) => run_rule(rule_id.as_deref(), cli.format, locale),
         Command::Config(ref command) => run_config(command.clone(), &cli),
         Command::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
@@ -153,7 +153,7 @@ fn run_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32, Stri
             for error in config_errors {
                 report
                     .errors
-                    .push(CliError::config(&path, error.to_string()));
+                    .push(CliError::config_validation(&path, error));
             }
             continue;
         }
@@ -321,25 +321,30 @@ fn apply_fixes_until_stable(
     })
 }
 
-fn run_rule(rule_id: Option<&str>, format: OutputFormat) -> Result<i32, String> {
-    print!("{}", render_rule(rule_id, format)?);
+fn run_rule(rule_id: Option<&str>, format: OutputFormat, locale: Locale) -> Result<i32, String> {
+    print!("{}", render_rule(rule_id, format, locale)?);
     Ok(0)
 }
 
-fn render_rule(rule_id: Option<&str>, format: OutputFormat) -> Result<String, String> {
+fn render_rule(
+    rule_id: Option<&str>,
+    format: OutputFormat,
+    locale: Locale,
+) -> Result<String, String> {
     let rules = crate::available_rules();
     if let Some(rule_id) = rule_id {
         let Some(rule) = rules.iter().find(|rule| rule.id == rule_id) else {
             return Err(format!("unknown rule: {rule_id}"));
         };
+        let output = LocalizedRuleMeta::from_rule(rule, locale);
         return match format {
             OutputFormat::Text => Ok(format!(
                 "{} {}\n{}\n{}\n",
-                rule.id, rule.name, rule.description, rule.docs_url
+                output.id, output.name, output.description, output.docs_url
             )),
             OutputFormat::Json => Ok(format!(
                 "{}\n",
-                serde_json::to_string_pretty(rule).map_err(|err| err.to_string())?
+                serde_json::to_string_pretty(&output).map_err(|err| err.to_string())?
             )),
         };
     }
@@ -348,14 +353,49 @@ fn render_rule(rule_id: Option<&str>, format: OutputFormat) -> Result<String, St
         OutputFormat::Text => {
             let mut output = String::new();
             for rule in rules {
-                output.push_str(&format!("{} {}\n", rule.id, rule.name));
+                let rule = LocalizedRuleMeta::from_rule(&rule, locale);
+                output.push_str(&format!(
+                    "{} {} - {}\n",
+                    rule.id, rule.name, rule.description
+                ));
             }
             Ok(output)
         }
-        OutputFormat::Json => Ok(format!(
-            "{}\n",
-            serde_json::to_string_pretty(&rules).map_err(|err| err.to_string())?
-        )),
+        OutputFormat::Json => {
+            let rules = rules
+                .iter()
+                .map(|rule| LocalizedRuleMeta::from_rule(rule, locale))
+                .collect::<Vec<_>>();
+            Ok(format!(
+                "{}\n",
+                serde_json::to_string_pretty(&rules).map_err(|err| err.to_string())?
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LocalizedRuleMeta {
+    id: String,
+    name: String,
+    description: String,
+    english_description: String,
+    docs_url: String,
+    fixable: bool,
+    locale: &'static str,
+}
+
+impl LocalizedRuleMeta {
+    fn from_rule(rule: &crate::RuleMeta, locale: Locale) -> Self {
+        Self {
+            id: rule.id.clone(),
+            name: rule.name.clone(),
+            description: rule.localized_description(locale.code()),
+            english_description: rule.description.clone(),
+            docs_url: rule.docs_url.clone(),
+            fixable: rule.fixable,
+            locale: locale.code(),
+        }
     }
 }
 
@@ -675,6 +715,16 @@ impl CliError {
             message_params: message_params(&message),
             message,
             message_id: "config.error".to_string(),
+        }
+    }
+
+    fn config_validation(path: &Path, error: crate::ConfigError) -> Self {
+        Self {
+            kind: "config",
+            path: Some(path.display().to_string()),
+            message_params: error.message_params(),
+            message: error.to_string(),
+            message_id: error.message_id().to_string(),
         }
     }
 
@@ -1163,20 +1213,39 @@ mod tests {
 
     #[test]
     fn renders_rule_list_and_detail_contract() {
-        let list = render_rule(None, OutputFormat::Text).expect("rule list should render");
+        let list =
+            render_rule(None, OutputFormat::Text, Locale::En).expect("rule list should render");
         assert!(list.contains("MD013 line-length"));
+        assert!(list.contains("Line length"));
 
-        let detail =
-            render_rule(Some("MD013"), OutputFormat::Text).expect("rule detail should render");
+        let detail = render_rule(Some("MD013"), OutputFormat::Text, Locale::En)
+            .expect("rule detail should render");
         assert!(detail.contains("MD013 line-length"));
         assert!(detail.contains("Line length"));
         assert!(detail.contains("markdownlint"));
 
-        let json =
-            render_rule(Some("MD013"), OutputFormat::Json).expect("rule detail json should render");
+        let json = render_rule(Some("MD013"), OutputFormat::Json, Locale::En)
+            .expect("rule detail json should render");
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("rule detail should be json");
         assert_eq!(value["id"], "MD013");
+        assert_eq!(value["locale"], "en");
+        assert_eq!(value["description"], value["english_description"]);
+    }
+
+    #[test]
+    fn rule_output_uses_selected_japanese_locale() {
+        let list =
+            render_rule(None, OutputFormat::Text, Locale::Ja).expect("rule list should render");
+        assert!(list.contains("MD003 heading-style - 見出しのスタイルを統一してください"));
+
+        let json = render_rule(Some("MD003"), OutputFormat::Json, Locale::Ja)
+            .expect("rule detail json should render");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("rule detail should be json");
+        assert_eq!(value["locale"], "ja");
+        assert_eq!(value["description"], "見出しのスタイルを統一してください");
+        assert_eq!(value["english_description"], "Heading style");
     }
 
     #[test]
@@ -1402,6 +1471,34 @@ mod tests {
             .as_str()
             .expect("message should be string")
             .contains("設定エラー"));
+    }
+
+    #[test]
+    fn json_report_localizes_structured_config_validation_errors() {
+        let config = MarkdownLintConfig {
+            raw: serde_json::json!({ "MD999": true }),
+        };
+        let error = config
+            .validate_cached_rules()
+            .into_iter()
+            .next()
+            .expect("config should be invalid");
+        let report = CliReport {
+            command: "check",
+            summary: CliSummary::default(),
+            files: Vec::new(),
+            errors: vec![CliError::config_validation(Path::new("README.md"), error)],
+        };
+
+        let json = serde_json::to_value(LocalizedCliReport::from_report(&report, Locale::Ja))
+            .expect("localized report should serialize");
+
+        assert_eq!(json["errors"][0]["message_id"], "config.unknown_rule");
+        assert_eq!(json["errors"][0]["message_params"]["rule_id"], "MD999");
+        assert_eq!(
+            json["errors"][0]["message"],
+            "未知の markdownlint rule です: MD999"
+        );
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -4,12 +4,20 @@ use std::collections::BTreeMap;
 pub type MessageParams = BTreeMap<String, String>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Locale {
     En,
     Ja,
 }
 
 impl Locale {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::En => "en",
+            Self::Ja => "ja",
+        }
+    }
+
     pub fn resolve(explicit: Option<&str>) -> Result<Self, LocaleError> {
         Self::resolve_with(explicit, |key| std::env::var(key).ok())
     }
@@ -57,6 +65,10 @@ impl Locale {
     pub fn resolve_code_or(value: &str, fallback: Self) -> Self {
         Self::parse(value).unwrap_or(fallback)
     }
+}
+
+pub fn supported_locales() -> &'static [Locale] {
+    &[Locale::En, Locale::Ja]
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -135,6 +147,13 @@ pub fn localized_rule_description(
     )
 }
 
+pub fn has_rule_description_translation(rule_id: &str, locale: Locale) -> bool {
+    match locale {
+        Locale::En => true,
+        Locale::Ja => japanese_rule_description(rule_id).is_some(),
+    }
+}
+
 pub fn diagnostic_message_id(rule_id: &str, message: &str) -> String {
     if rule_id == "MD001" && message.contains("[Expected: h") {
         "rule.MD001.heading_increment".to_string()
@@ -183,6 +202,30 @@ pub fn render_message(
             }
             "glob.error" => format!("glob エラー: {}", param(params, "message", fallback)),
             "rule.error" => format!("ルール実行エラー: {}", param(params, "message", fallback)),
+            "config.invalid_root" => "設定ルートは JSON object である必要があります".to_string(),
+            "config.unknown_rule" => format!(
+                "未知の markdownlint rule です: {}",
+                param(params, "rule_id", "")
+            ),
+            "config.unknown_property" => format!(
+                "{}.{} は未知の rule property です",
+                param(params, "rule_id", ""),
+                param(params, "property", "")
+            ),
+            "config.invalid_type" => format!(
+                "{}{} の型が不正です。期待値: {}、実際: {}",
+                param(params, "rule_id", ""),
+                config_property_suffix(params),
+                param(params, "expected", ""),
+                param(params, "actual", "")
+            ),
+            "config.invalid_enum_value" => format!(
+                "{}{} の値が不正です。許可値: {}、実際: {}",
+                param(params, "rule_id", ""),
+                config_property_suffix(params),
+                param(params, "allowed", ""),
+                param(params, "actual", "")
+            ),
             "summary.no_files" => "Markdown ファイルが見つかりません".to_string(),
             "summary.statistics" => format!(
                 "files: {}, files_with_issues: {}, issues: {}, fixable: {}, fixed: {}",
@@ -212,6 +255,14 @@ fn param<'a>(params: &'a MessageParams, key: &str, fallback: &'a str) -> &'a str
     params.get(key).map(String::as_str).unwrap_or(fallback)
 }
 
+fn config_property_suffix(params: &MessageParams) -> String {
+    params
+        .get("property")
+        .filter(|property| !property.is_empty())
+        .map(|property| format!(".{property}"))
+        .unwrap_or_default()
+}
+
 fn parse_heading_levels(message: &str) -> Option<(String, String)> {
     let expected = message.split("[Expected: ").nth(1)?.split(',').next()?;
     let actual = message.split("Actual: ").nth(1)?.trim_end_matches(']');
@@ -219,69 +270,81 @@ fn parse_heading_levels(message: &str) -> Option<(String, String)> {
 }
 
 fn japanese_rule_message(rule_id: &str, fallback: &str) -> String {
-    match rule_id {
-        "MD001" => "見出しレベルは一度に1段階だけ増やしてください".to_string(),
-        "MD003" => "見出しのスタイルを統一してください".to_string(),
-        "MD004" => "箇条書きリストの記号スタイルを統一してください".to_string(),
-        "MD005" => "同じレベルのリスト項目のインデントを揃えてください".to_string(),
-        "MD007" => "箇条書きリストのインデントを設定に合わせてください".to_string(),
-        "MD009" => "行末の余分なスペースを削除してください".to_string(),
-        "MD010" => "ハードタブを使用しないでください".to_string(),
-        "MD011" => "逆向きのリンク構文を修正してください".to_string(),
-        "MD012" => "複数の連続した空行を削減してください".to_string(),
-        "MD013" => "行の長さが上限を超えています".to_string(),
-        "MD014" => "コマンド例の前に不要なドル記号があります".to_string(),
-        "MD018" => "ATX 見出しの # の後にスペースが必要です".to_string(),
-        "MD019" => "ATX 見出しの # の後のスペースは1つにしてください".to_string(),
-        "MD020" => "閉じた ATX 見出しの内側にスペースが必要です".to_string(),
-        "MD021" => "閉じた ATX 見出しの内側のスペースは1つにしてください".to_string(),
-        "MD022" => "見出しは空行で囲んでください".to_string(),
-        "MD023" => "見出しは行頭から始めてください".to_string(),
-        "MD024" => "同じ内容の見出しが複数あります".to_string(),
-        "MD025" => "同一文書内のトップレベル見出しは1つにしてください".to_string(),
-        "MD026" => "見出し末尾の句読点を削除してください".to_string(),
-        "MD027" => "引用記号の後の余分なスペースを削除してください".to_string(),
-        "MD028" => "引用ブロック内に不要な空行があります".to_string(),
-        "MD029" => "番号付きリストの番号を正しく並べてください".to_string(),
-        "MD030" => "リスト記号後のスペース数を揃えてください".to_string(),
-        "MD031" => "コードブロックは空行で囲んでください".to_string(),
-        "MD032" => "リストは空行で囲んでください".to_string(),
-        "MD033" => "インライン HTML を使用しないでください".to_string(),
-        "MD034" => "裸の URL は山括弧またはリンクとして記述してください".to_string(),
-        "MD035" => "水平線のスタイルを統一してください".to_string(),
-        "MD036" => "強調だけの行を見出しとして使用しないでください".to_string(),
-        "MD037" => "強調記号の内側にスペースを入れないでください".to_string(),
-        "MD038" => "コード記号の内側にスペースを入れないでください".to_string(),
-        "MD039" => "リンクテキストの内側に余分なスペースを入れないでください".to_string(),
-        "MD040" => "フェンス付きコードブロックには言語を指定してください".to_string(),
-        "MD041" => "ファイルの最初の行はトップレベル見出しにしてください".to_string(),
-        "MD042" => "空のリンクを使用しないでください".to_string(),
-        "MD043" => "必要な見出し構造に合わせてください".to_string(),
-        "MD044" => "固有名詞の表記を設定に合わせてください".to_string(),
-        "MD045" => "画像には代替テキストを設定してください".to_string(),
-        "MD046" => "コードブロックのスタイルを統一してください".to_string(),
-        "MD047" => "ファイル末尾には改行を入れてください".to_string(),
-        "MD048" => "フェンス付きコードブロックの記号スタイルを統一してください".to_string(),
-        "MD049" => "強調のスタイルを統一してください".to_string(),
-        "MD050" => "強い強調のスタイルを統一してください".to_string(),
-        "MD051" => "リンク先の見出しフラグメントが存在しません".to_string(),
-        "MD052" => "参照リンクまたは画像の定義がありません".to_string(),
-        "MD053" => "未使用のリンク定義があります".to_string(),
-        "MD054" => "リンクと画像のスタイルを設定に合わせてください".to_string(),
-        "MD055" => "表の区切り行のスタイルを統一してください".to_string(),
-        "MD056" => "表の列数を揃えてください".to_string(),
-        "MD058" => "表は空行で囲んでください".to_string(),
-        "MD059" => "リンクテキストは説明的にしてください".to_string(),
-        "MD060" => "表セルのスペースを揃えてください".to_string(),
-        "md-broken-link" => format!("ローカルリンクが壊れています: {fallback}"),
-        _ => format!("ルール {rule_id}: {fallback}"),
+    match japanese_rule_description(rule_id) {
+        Some(message) => message.to_string(),
+        None if rule_id == "md-broken-link" => format!("ローカルリンクが壊れています: {fallback}"),
+        None => format!("ルール {rule_id}: {fallback}"),
     }
 }
 
-const CATALOG_KEYS: [&str; 9] = [
+fn japanese_rule_description(rule_id: &str) -> Option<&'static str> {
+    match rule_id {
+        "MD001" => Some("見出しレベルは一度に1段階だけ増やしてください"),
+        "MD003" => Some("見出しのスタイルを統一してください"),
+        "MD004" => Some("箇条書きリストの記号スタイルを統一してください"),
+        "MD005" => Some("同じレベルのリスト項目のインデントを揃えてください"),
+        "MD007" => Some("箇条書きリストのインデントを設定に合わせてください"),
+        "MD009" => Some("行末の余分なスペースを削除してください"),
+        "MD010" => Some("ハードタブを使用しないでください"),
+        "MD011" => Some("逆向きのリンク構文を修正してください"),
+        "MD012" => Some("複数の連続した空行を削減してください"),
+        "MD013" => Some("行の長さが上限を超えています"),
+        "MD014" => Some("コマンド例の前に不要なドル記号があります"),
+        "MD018" => Some("ATX 見出しの # の後にスペースが必要です"),
+        "MD019" => Some("ATX 見出しの # の後のスペースは1つにしてください"),
+        "MD020" => Some("閉じた ATX 見出しの内側にスペースが必要です"),
+        "MD021" => Some("閉じた ATX 見出しの内側のスペースは1つにしてください"),
+        "MD022" => Some("見出しは空行で囲んでください"),
+        "MD023" => Some("見出しは行頭から始めてください"),
+        "MD024" => Some("同じ内容の見出しが複数あります"),
+        "MD025" => Some("同一文書内のトップレベル見出しは1つにしてください"),
+        "MD026" => Some("見出し末尾の句読点を削除してください"),
+        "MD027" => Some("引用記号の後の余分なスペースを削除してください"),
+        "MD028" => Some("引用ブロック内に不要な空行があります"),
+        "MD029" => Some("番号付きリストの番号を正しく並べてください"),
+        "MD030" => Some("リスト記号後のスペース数を揃えてください"),
+        "MD031" => Some("コードブロックは空行で囲んでください"),
+        "MD032" => Some("リストは空行で囲んでください"),
+        "MD033" => Some("インライン HTML を使用しないでください"),
+        "MD034" => Some("裸の URL は山括弧またはリンクとして記述してください"),
+        "MD035" => Some("水平線のスタイルを統一してください"),
+        "MD036" => Some("強調だけの行を見出しとして使用しないでください"),
+        "MD037" => Some("強調記号の内側にスペースを入れないでください"),
+        "MD038" => Some("コード記号の内側にスペースを入れないでください"),
+        "MD039" => Some("リンクテキストの内側に余分なスペースを入れないでください"),
+        "MD040" => Some("フェンス付きコードブロックには言語を指定してください"),
+        "MD041" => Some("ファイルの最初の行はトップレベル見出しにしてください"),
+        "MD042" => Some("空のリンクを使用しないでください"),
+        "MD043" => Some("必要な見出し構造に合わせてください"),
+        "MD044" => Some("固有名詞の表記を設定に合わせてください"),
+        "MD045" => Some("画像には代替テキストを設定してください"),
+        "MD046" => Some("コードブロックのスタイルを統一してください"),
+        "MD047" => Some("ファイル末尾には改行を入れてください"),
+        "MD048" => Some("フェンス付きコードブロックの記号スタイルを統一してください"),
+        "MD049" => Some("強調のスタイルを統一してください"),
+        "MD050" => Some("強い強調のスタイルを統一してください"),
+        "MD051" => Some("リンク先の見出しフラグメントが存在しません"),
+        "MD052" => Some("参照リンクまたは画像の定義がありません"),
+        "MD053" => Some("未使用のリンク定義があります"),
+        "MD054" => Some("リンクと画像のスタイルを設定に合わせてください"),
+        "MD055" => Some("表の区切り行のスタイルを統一してください"),
+        "MD056" => Some("表の列数を揃えてください"),
+        "MD058" => Some("表は空行で囲んでください"),
+        "MD059" => Some("リンクテキストは説明的にしてください"),
+        "MD060" => Some("表セルのスペースを揃えてください"),
+        _ => None,
+    }
+}
+
+const CATALOG_KEYS: [&str; 14] = [
     "rule.generic",
     "rule.MD001.heading_increment",
     "config.error",
+    "config.invalid_root",
+    "config.unknown_rule",
+    "config.unknown_property",
+    "config.invalid_type",
+    "config.invalid_enum_value",
     "filesystem.error",
     "glob.error",
     "rule.error",
@@ -328,7 +391,9 @@ mod tests {
 
     #[test]
     fn catalog_keys_match_between_supported_locales() {
-        assert_eq!(catalog_keys(Locale::En), catalog_keys(Locale::Ja));
+        for locale in supported_locales() {
+            assert_eq!(catalog_keys(Locale::En), catalog_keys(*locale));
+        }
     }
 
     #[test]
@@ -367,5 +432,30 @@ mod tests {
         );
         assert!(localized_rule_description("MD999", "Custom fallback", "ja")
             .contains("Custom fallback"));
+    }
+
+    #[test]
+    fn config_error_messages_render_with_structured_params() {
+        let mut params = MessageParams::new();
+        params.insert("rule_id".to_string(), "MD013".to_string());
+        params.insert("property".to_string(), "line_length".to_string());
+        params.insert("expected".to_string(), "number".to_string());
+        params.insert("actual".to_string(), "string".to_string());
+
+        assert_eq!(
+            render_message(
+                Locale::Ja,
+                "config.invalid_type",
+                &params,
+                "invalid rule property value"
+            ),
+            "MD013.line_length の型が不正です。期待値: number、実際: string"
+        );
+    }
+
+    #[test]
+    fn active_rule_description_translation_status_is_explicit() {
+        assert!(has_rule_description_translation("MD003", Locale::Ja));
+        assert!(!has_rule_description_translation("MD999", Locale::Ja));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ pub mod upstream;
 
 pub use config::{ConfigError, ConfigErrorKind, MarkdownLintConfig};
 pub use i18n::{
-    localized_rule_description, resolve_locale_code, resolve_locale_code_or, Locale, LocaleError,
-    LocalizedDiagnostic,
+    has_rule_description_translation, localized_rule_description, resolve_locale_code,
+    resolve_locale_code_or, supported_locales, Locale, LocaleError, LocalizedDiagnostic,
 };
 pub use types::{Fix, FixResult, LintOptions, LintResult, Range, RuleConfig, RuleMeta, Severity};
 
@@ -82,6 +82,14 @@ pub fn available_rules() -> Vec<RuleMeta> {
     catalog::RuleCatalog::build().to_rule_meta()
 }
 
+/// Returns the set of available rules with descriptions localized by language code.
+pub fn localized_available_rules(language_code: &str) -> Vec<RuleMeta> {
+    available_rules()
+        .into_iter()
+        .map(|rule| rule.localized(language_code))
+        .collect()
+}
+
 /// Returns the set of rules that are currently executed by the linter.
 pub fn implemented_rules() -> Vec<RuleMeta> {
     rules::markdown::MarkdownLinterOps::official_rules()
@@ -109,6 +117,11 @@ pub fn missing_rules() -> Vec<RuleMeta> {
 /// Returns a structured catalog of active, deprecated, and removed rules.
 pub fn rule_catalog() -> catalog::RuleCatalog {
     catalog::RuleCatalog::build()
+}
+
+/// Returns a structured catalog with descriptions localized by language code.
+pub fn localized_rule_catalog(language_code: &str) -> catalog::RuleCatalog {
+    catalog::RuleCatalog::build().localized(language_code)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -304,6 +317,32 @@ mod tests {
             "見出しのスタイルを統一してください"
         );
         assert_eq!(resolve_locale_code_or("fr", Locale::Ja), Locale::Ja);
+    }
+
+    #[test]
+    fn localized_catalog_api_preserves_metadata_and_localizes_descriptions() {
+        let english = rule_catalog();
+        let japanese = localized_rule_catalog("ja-JP");
+        let en_md003 = english
+            .active
+            .iter()
+            .find(|rule| rule.id == "MD003")
+            .expect("MD003 should exist");
+        let ja_md003 = japanese
+            .active
+            .iter()
+            .find(|rule| rule.id == "MD003")
+            .expect("MD003 should exist");
+
+        assert_eq!(en_md003.id, ja_md003.id);
+        assert_eq!(en_md003.docs_url, ja_md003.docs_url);
+        assert_eq!(ja_md003.description, "見出しのスタイルを統一してください");
+
+        let rules = localized_available_rules("ja");
+        assert!(rules
+            .iter()
+            .any(|rule| rule.id == "MD003"
+                && rule.description == "見出しのスタイルを統一してください"));
     }
 
     #[test]

--- a/src/rules/markdown/config.rs
+++ b/src/rules/markdown/config.rs
@@ -361,6 +361,92 @@ impl ConfigError {
             message: message.into(),
         }
     }
+
+    pub fn kind_code(&self) -> &'static str {
+        self.kind.code()
+    }
+
+    pub fn message_id(&self) -> &'static str {
+        self.kind.message_id()
+    }
+
+    pub fn message_params(&self) -> crate::i18n::MessageParams {
+        let mut params = crate::i18n::MessageParams::new();
+        if let Some(rule_id) = &self.rule_id {
+            params.insert("rule_id".to_string(), rule_id.clone());
+        }
+        if let Some(property) = &self.property {
+            params.insert("property".to_string(), property.clone());
+        }
+        match &self.kind {
+            ConfigErrorKind::InvalidType { expected, actual } => {
+                params.insert("expected".to_string(), (*expected).to_string());
+                params.insert("actual".to_string(), (*actual).to_string());
+            }
+            ConfigErrorKind::InvalidEnumValue { allowed, actual } => {
+                params.insert("allowed".to_string(), allowed.join(", "));
+                params.insert("actual".to_string(), actual.clone());
+            }
+            ConfigErrorKind::InvalidRoot
+            | ConfigErrorKind::UnknownRule
+            | ConfigErrorKind::UnknownProperty => {}
+        }
+        params.insert("message".to_string(), self.message.clone());
+        params
+    }
+
+    pub fn localized_message(&self, locale: crate::i18n::Locale) -> String {
+        crate::i18n::render_message(
+            locale,
+            self.message_id(),
+            &self.message_params(),
+            &self.to_string(),
+        )
+    }
+
+    pub fn expected(&self) -> Option<&'static str> {
+        match &self.kind {
+            ConfigErrorKind::InvalidType { expected, .. } => Some(expected),
+            _ => None,
+        }
+    }
+
+    pub fn actual(&self) -> Option<&str> {
+        match &self.kind {
+            ConfigErrorKind::InvalidType { actual, .. } => Some(actual),
+            ConfigErrorKind::InvalidEnumValue { actual, .. } => Some(actual),
+            _ => None,
+        }
+    }
+
+    pub fn allowed(&self) -> Vec<&'static str> {
+        match &self.kind {
+            ConfigErrorKind::InvalidEnumValue { allowed, .. } => allowed.clone(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+impl ConfigErrorKind {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidRoot => "invalid_root",
+            Self::UnknownRule => "unknown_rule",
+            Self::UnknownProperty => "unknown_property",
+            Self::InvalidType { .. } => "invalid_type",
+            Self::InvalidEnumValue { .. } => "invalid_enum_value",
+        }
+    }
+
+    pub fn message_id(&self) -> &'static str {
+        match self {
+            Self::InvalidRoot => "config.invalid_root",
+            Self::UnknownRule => "config.unknown_rule",
+            Self::UnknownProperty => "config.unknown_property",
+            Self::InvalidType { .. } => "config.invalid_type",
+            Self::InvalidEnumValue { .. } => "config.invalid_enum_value",
+        }
+    }
 }
 
 impl fmt::Display for ConfigError {
@@ -550,6 +636,16 @@ mod tests {
             error.rule_id.as_deref() == Some("MD999")
                 && matches!(error.kind, ConfigErrorKind::UnknownRule)
         }));
+        let unknown = errors
+            .iter()
+            .find(|error| matches!(error.kind, ConfigErrorKind::UnknownRule))
+            .expect("unknown rule error should exist");
+        assert_eq!(unknown.kind_code(), "unknown_rule");
+        assert_eq!(unknown.message_id(), "config.unknown_rule");
+        assert_eq!(
+            unknown.localized_message(crate::i18n::Locale::Ja),
+            "未知の markdownlint rule です: MD999"
+        );
         assert!(errors.iter().any(|error| {
             error.rule_id.as_deref() == Some("MD001")
                 && error.property.as_deref() == Some("front_matter_title")

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,4 +69,10 @@ impl RuleMeta {
     pub fn localized_description(&self, language_code: &str) -> String {
         crate::i18n::localized_rule_description(&self.id, &self.description, language_code)
     }
+
+    pub fn localized(&self, language_code: &str) -> Self {
+        let mut rule = self.clone();
+        rule.description = self.localized_description(language_code);
+        rule
+    }
 }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -326,14 +326,18 @@ fn ast_linter_public_api_surface_is_explicit() {
         "pub fn lint(content: &str, options: &LintOptions) -> Result<Vec<LintResult>, Error>",
         "pub fn fix(content: &str, options: &LintOptions) -> Result<FixResult, Error>",
         "pub fn available_rules() -> Vec<RuleMeta>",
+        "pub fn localized_available_rules(language_code: &str) -> Vec<RuleMeta>",
         "pub fn implemented_rules() -> Vec<RuleMeta>",
         "pub fn missing_rules() -> Vec<RuleMeta>",
         "pub fn rule_catalog() -> catalog::RuleCatalog",
+        "pub fn localized_rule_catalog(language_code: &str) -> catalog::RuleCatalog",
         "pub use config::{ConfigError, ConfigErrorKind, MarkdownLintConfig};",
         "pub use i18n::{",
+        "has_rule_description_translation",
         "localized_rule_description",
         "resolve_locale_code",
         "resolve_locale_code_or",
+        "supported_locales",
         "Locale, LocaleError",
         "LocalizedDiagnostic",
         "pub use types::{Fix, FixResult, LintOptions, LintResult, Range, RuleConfig, RuleMeta, Severity};",
@@ -357,6 +361,35 @@ fn ast_linter_public_api_surface_is_explicit() {
     }
 
     assert_no_violations("public-api-surface", violations);
+}
+
+#[test]
+fn ast_linter_i18n_translation_coverage_is_complete_for_supported_locales() {
+    let mut violations = Vec::new();
+    for locale in katana_markdown_linter::supported_locales() {
+        if katana_markdown_linter::i18n::catalog_keys(katana_markdown_linter::Locale::En)
+            != katana_markdown_linter::i18n::catalog_keys(*locale)
+        {
+            violations.push(format!(
+                "i18n: catalog key set differs for {}",
+                locale.code()
+            ));
+        }
+    }
+
+    for rule in katana_markdown_linter::available_rules() {
+        if !katana_markdown_linter::has_rule_description_translation(
+            &rule.id,
+            katana_markdown_linter::Locale::Ja,
+        ) {
+            violations.push(format!(
+                "i18n: missing Japanese rule description for {}",
+                rule.id
+            ));
+        }
+    }
+
+    assert_no_violations("i18n-translation-coverage", violations);
 }
 
 fn workspace_root() -> PathBuf {


### PR DESCRIPTION
## Summary
- Promote i18n to Rust API, CLI, and MCP surfaces
- Add localized rule catalog APIs while preserving canonical English metadata
- Make Locale non-exhaustive for future locale additions
- Localize kml rule output and structured config validation errors
- Add optional MCP locale request fields for diagnostics, config validation, and rule metadata
- Add translation coverage AST gate for supported message IDs and active rule descriptions

## Verification
- cargo fmt --all -- --check
- cargo test --workspace --locked
- cargo test --test ast_linter --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- make dogfood
- make release-check VERSION=v0.6.0
- git diff --check