### PR TITLE
Polish README rule map

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,24 +104,43 @@ below match the public catalog returned by `available_rules()` and
 status. Run `kml rule MD013` to inspect one rule with its upstream documentation
 URL.
 
-State values are `Supported`, `Partial`, `Not implemented`, `Not planned`, and
-`Not feasible`. Safe fixes are often `Partial` because kml only rewrites
-fixture-locked, low-risk violation forms. Unsafe fixes are unavailable until a
-future explicit opt-in mode exists.
+The short version:
+
+| Capability | Status |
+| --- | --- |
+| Check coverage | `Supported` for all 53 active rules |
+| Safe fix coverage | `Partial` for 35 rules; diagnostic-only for 18 rules |
+| Unsafe fix coverage | Not available yet; reserved for a future explicit opt-in mode |
+| Deleted upstream IDs | 7 historical IDs shown as `Deleted` with `-` fix states |
+
+Safe fixes are intentionally conservative. `Partial` means kml rewrites at least
+one fixture-locked, low-risk violation form for that rule. `Not implemented`
+means the rule is currently diagnostic-only. `Not planned` means unsafe rewriting
+is outside the default safe-fix contract. `Deleted` rows are historical
+markdownlint IDs that are not part of the active upstream rule catalog.
+
+<details>
+<summary>Full fixture-backed rule matrix</summary>
 
 | Rule | Check | Fix (safe) | Fix (unsafe) |
 | --- | --- | --- | --- |
 | `MD001` | Supported | Not implemented | Not planned |
+| `MD002` | Deleted | - | - |
 | `MD003` | Supported | Not implemented | Not planned |
 | `MD004` | Supported | Partial | Not planned |
 | `MD005` | Supported | Partial | Not planned |
+| `MD006` | Deleted | - | - |
 | `MD007` | Supported | Partial | Not planned |
+| `MD008` | Deleted | - | - |
 | `MD009` | Supported | Partial | Not planned |
 | `MD010` | Supported | Partial | Not planned |
 | `MD011` | Supported | Partial | Not planned |
 | `MD012` | Supported | Partial | Not planned |
 | `MD013` | Supported | Not implemented | Not planned |
 | `MD014` | Supported | Partial | Not planned |
+| `MD015` | Deleted | - | - |
+| `MD016` | Deleted | - | - |
+| `MD017` | Deleted | - | - |
 | `MD018` | Supported | Partial | Not planned |
 | `MD019` | Supported | Partial | Not planned |
 | `MD020` | Supported | Partial | Not planned |
@@ -161,9 +180,12 @@ future explicit opt-in mode exists.
 | `MD054` | Supported | Partial | Not planned |
 | `MD055` | Supported | Not implemented | Not planned |
 | `MD056` | Supported | Not implemented | Not planned |
+| `MD057` | Deleted | - | - |
 | `MD058` | Supported | Partial | Not planned |
 | `MD059` | Supported | Not implemented | Not planned |
 | `MD060` | Supported | Partial | Not implemented |
+
+</details>
 
 ## Configuration
 

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -291,7 +291,13 @@ fn ast_linter_readme_rule_map_matches_public_catalog() {
         .as_array()
         .expect("fixture matrix rules should be an array");
 
-    for rule in katana_markdown_linter::available_rules() {
+    let active_rules = katana_markdown_linter::available_rules();
+    let active_rule_ids = active_rules
+        .iter()
+        .map(|rule| rule.id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    for rule in &active_rules {
         let safe_fix = rule_map_safe_fix_status(rules, rule.id.as_str());
         let unsafe_fix = rule_map_unsafe_fix_status(rule.id.as_str());
         let row = format!(
@@ -300,6 +306,22 @@ fn ast_linter_readme_rule_map_matches_public_catalog() {
         );
         if !readme.contains(&row) {
             violations.push(format!("README.md: missing rule map row `{row}`"));
+        }
+    }
+
+    let max_rule_number = active_rule_ids
+        .iter()
+        .filter_map(|rule_id| rule_id.strip_prefix("MD")?.parse::<u16>().ok())
+        .max()
+        .expect("active rules should contain MD-prefixed rule IDs");
+    for number in 1..=max_rule_number {
+        let rule_id = format!("MD{number:03}");
+        if active_rule_ids.contains(rule_id.as_str()) {
+            continue;
+        }
+        let row = format!("| `{rule_id}` | Deleted | - | - |");
+        if !readme.contains(&row) {
+            violations.push(format!("README.md: missing deleted rule gap row `{row}`"));
         }
     }
 


### PR DESCRIPTION
## Summary
- collapse the full README rule matrix behind details
- add a compact Rule Map summary
- show deleted historical markdownlint IDs as `Deleted | - | -`
- extend AST lint so README gap rows stay enforced

## Verification
- `cargo fmt --all -- --check`
- `cargo test --test ast_linter --locked`
- `make dogfood`
- `git diff --check`