### PR TITLE
Add layout formatter for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.10.0
+
+- Adds a dedicated layout formatter API with `format_markdown()`, `FormatOptions`, and `FormatResult`.
+- Changes `kml fmt` from a `fix` alias into an indentation/newline formatter with editor-friendly exit code `0` on successful formatting.
+- Normalizes CRLF/CR line endings, final newlines, repeated blank lines, structural blank lines, and safe list indentation/list-marker spacing.
+- Keeps semantic/style rewrites out of formatter scope, including paragraph reflow, heading/emphasis/link/table style conversion, trailing-space removal, and unsafe fixes.
+- Adds formatter idempotence, stdin contract, and CLI exit-code coverage.
+
 ## v0.9.0
 
 - Adds fix safety metadata to public diagnostics so consumers can distinguish `safe` and `unsafe` candidates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/README.md
+++ b/README.md
@@ -78,14 +78,25 @@ kml init-config
 
 When no files are provided, `kml check`, `kml fix`, and `kml fmt` recursively process Markdown files under the current directory. Use `--file` to make single-file intent explicit.
 
-`check` exits with `1` when lint violations are found. `check --fix`, `fix`, and `fmt` apply safe fixes and exit with `1` if violations remain after rewriting. Filesystem or configuration errors exit with `2`.
+`check` reports diagnostics and exits with `1` when lint violations are found.
+`fix` and `check --fix` apply safe lint-driven fixes and exit with `1` if
+violations remain after rewriting. `fmt` is a layout formatter for indentation
+and newline normalization; it exits with `0` after successful formatting even
+when unrelated lint diagnostics would still be reported by `check`. Filesystem
+or configuration errors exit with `2`.
+
+`fmt` currently normalizes CRLF/CR line endings to LF, final newlines, repeated
+blank lines, blank lines around headings/fences/lists/tables, and safe list
+indentation/list-marker spacing. It does not reflow paragraphs, change heading
+or emphasis style, change URL/table style, remove trailing spaces, or apply
+unsafe fixes by default.
 
 Unsafe fixes require explicit opt-in. Interactive use prompts with `[Y/n]`;
 non-interactive use must pass `--unsafe --yes`.
 
 `--output json` is the preferred JSON output flag. `--format json` remains a compatibility alias.
 
-`--stdin` reads Markdown from standard input. `check --stdin` reports diagnostics against `<stdin>`; `fix --stdin` and `fmt --stdin` write fixed Markdown to stdout.
+`--stdin` reads Markdown from standard input. `check --stdin` reports diagnostics against `<stdin>`; `fix --stdin` writes fixed Markdown to stdout; `fmt --stdin` writes formatted Markdown only to stdout.
 
 Directory scans respect gitignore files by default. Use `--no-ignore` to include ignored paths. `--exclude` filters discovered files; explicit files are kept unless `--force-exclude` is also set.
 

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,6 +1,7 @@
 use katana_markdown_linter::{
-    available_rules, fix, lint, localized_rule_catalog, localized_rule_description,
-    resolve_locale_code_or, LintOptions, Locale, MarkdownLintConfig,
+    available_rules, fix, format_markdown, lint, localized_rule_catalog,
+    localized_rule_description, resolve_locale_code_or, FormatOptions, LintOptions, Locale,
+    MarkdownLintConfig,
 };
 use std::fs;
 use std::path::Path;
@@ -23,6 +24,8 @@ fn main() -> Result<(), DynError> {
 
     let fixed = fix("text with trailing spaces  \n", &options)?;
     println!("applied fixes: {}", fixed.applied_fixes);
+    let formatted = format_markdown("# Title\r\nText\n\n\n", &FormatOptions::default())?;
+    println!("format operations: {}", formatted.applied_operations);
 
     let config = MarkdownLintConfig::load(Path::new(".markdownlint.json"))?;
     let configured_options = config.to_lint_options();

--- a/openspec/changes/formatter-productization/design.md
+++ b/openspec/changes/formatter-productization/design.md
@@ -4,10 +4,30 @@
 
 - `check`: report diagnostics
 - `fix`: apply safe lint-driven fixes
-- `fmt`: apply deterministic formatting policy
+- `fmt`: apply deterministic layout formatting policy
 
-`fmt` may use lint fixes internally, but it must be documented as a formatter
-contract and tested for idempotence.
+`fmt` may use lint fixes internally, but it must use a fixed formatter rule
+subset and must be documented as a formatter contract. It must be tested for
+idempotence.
+
+### Formatter Scope
+
+The `v0.10.0` formatter is a layout formatter. It SHALL normalize:
+
+- CRLF and CR line endings to LF
+- missing final newline
+- repeated blank lines outside code fences
+- missing blank lines around ATX headings, fenced code blocks, lists, and tables
+- safe list indentation and list-marker spacing when the existing lint fix logic can prove the rewrite
+
+The formatter SHALL NOT perform:
+
+- paragraph reflow or hard wrapping
+- heading style conversion
+- emphasis or strong marker conversion
+- URL/reference style conversion
+- table pipe/alignment style conversion
+- trailing-space removal
 
 ### Exit Code Policy
 
@@ -15,10 +35,23 @@ Formatter exit codes should be editor-friendly:
 
 - success after formatting should exit `0`
 - filesystem/config errors should exit `2`
-- unresolved diagnostics should be reported according to the final policy, not
-  inherited accidentally from `check --fix`
+- unresolved non-formatting lint diagnostics must not make `fmt` exit `1`
+- `fmt --stdin` writes formatted Markdown to stdout and returns `0` on success
+
+### API Policy
+
+The library SHALL expose a formatter entrypoint separate from `fix` so embedders
+can format content without running a CLI command.
+
+The first formatter API SHOULD expose:
+
+- input content
+- formatter options with a default policy
+- formatted content
+- applied operation count
 
 ### Non-Goals
 
-- Implementing formatter behavior before linter precision work is complete.
 - Treating unsafe rewrites as formatter defaults.
+- Making the formatter a full Prettier-compatible Markdown formatter.
+- Making formatter behavior depend on every enabled lint rule.

--- a/openspec/changes/formatter-productization/proposal.md
+++ b/openspec/changes/formatter-productization/proposal.md
@@ -5,10 +5,14 @@ kml should first improve linter precision and safe fix coverage. Once that
 baseline is stronger, formatter behavior can be designed as a deterministic,
 idempotent policy rather than a collection of lint rule side effects.
 
+For `v0.10.0`, formatter scope is intentionally narrow: indentation and newline
+normalization only. It must not become a general Markdown rewriter.
+
 ## What Changes
 
-- Define `kml fmt` as formatter policy distinct from `kml fix`.
-- Decide which rewrites belong to formatter-only behavior.
+- Define `kml fmt` as a layout formatter distinct from `kml fix`.
+- Add a Rust library entrypoint for deterministic Markdown layout formatting.
+- Normalize only layout-safe areas: line endings, final newline, repeated blank lines, structural blank lines, and safe list indentation/marker spacing.
 - Define formatter exit codes for editor integration.
 - Add idempotence tests and stdin/stdout contract tests.
 
@@ -16,7 +20,9 @@ idempotent policy rather than a collection of lint rule side effects.
 
 In scope:
 
-- Formatter semantics and API shape.
+- Formatter semantics and API shape for indentation and newline normalization.
+- Layout-only formatter rule subset: `MD005`, `MD007`, `MD012`, `MD022`, `MD030`, `MD031`, `MD032`, `MD047`, and `MD058`.
+- CRLF/CR to LF normalization.
 - Idempotence and stdout behavior.
 - Documentation that explains `check`, `fix`, and `fmt`.
 
@@ -24,9 +30,14 @@ Out of scope:
 
 - Unsafe formatter rewrites without opt-in.
 - LSP/editor distribution.
-- New rule implementation.
+- New markdownlint rule implementation.
+- Hard wrapping or paragraph reflow.
+- Heading style, emphasis style, URL/reference style, table style, or marker style conversion.
+- Removing trailing spaces because they can encode Markdown hard line breaks.
 
 ## Impact
 
 - Users can distinguish lint-driven fixes from whole-document formatting.
 - Editor integrations can use stable formatter behavior later.
+- Formatting becomes predictable enough to be used on stdin/stdout without
+  accidentally inheriting `check --fix` exit-code behavior.

--- a/openspec/changes/formatter-productization/tasks.md
+++ b/openspec/changes/formatter-productization/tasks.md
@@ -1,31 +1,51 @@
 # Tasks
 
-## Definition Of Ready
+## Definition of Ready
 
-- [ ] `safe-fix-coverage-continuous-expansion` has completed at least one batch.
-- [ ] `check`, `fix`, and `fmt` responsibility split is accepted.
-- [ ] Unsafe fix policy is not required for default formatter behavior.
+- [x] `safe-fix-coverage-continuous-expansion` and `unsafe-fix-mode-and-confirmation` are archived.
+- [x] `check`, `fix`, and `fmt` responsibility split is accepted.
+- [x] Default formatter behavior does not require unsafe fix policy.
+- [x] `v0.10.0` formatter scope is limited to indentation and newline/layout normalization.
+- [x] Out-of-scope rewrites are explicit: paragraph reflow, heading style conversion, emphasis/URL style conversion, table style conversion, and trailing-space removal.
 
 ## 1. Contract
 
-- [ ] 1.1 Define formatter API and CLI semantics.
-- [ ] 1.2 Define formatter exit code behavior.
-- [ ] 1.3 Define stdin/stdout behavior for editor integration.
+- [x] 1.1 Define formatter API separate from `fix`.
+- [x] 1.2 Define CLI `fmt` semantics as layout formatting, not `fix` alias.
+- [x] 1.3 Define formatter exit code behavior: success is `0`, filesystem/config errors are `2`, unresolved non-formatting lint diagnostics do not produce `1`.
+- [x] 1.4 Define stdin/stdout behavior for editor integration.
+- [x] 1.5 Document formatter rule subset: `MD005`, `MD007`, `MD012`, `MD022`, `MD030`, `MD031`, `MD032`, `MD047`, `MD058`, plus CRLF/CR to LF normalization.
 
 ## 2. Implementation
 
-- [ ] 2.1 Implement formatter policy entrypoint if current `fmt` alias is insufficient.
-- [ ] 2.2 Add idempotence tests.
-- [ ] 2.3 Add docs that compare `check`, `fix`, and `fmt`.
+- [x] 2.1 Add library formatter entrypoint and result/options types.
+- [x] 2.2 Make `kml fmt` call formatter entrypoint instead of `check --fix` behavior.
+- [x] 2.3 Keep `kml fix` and `kml check --fix` behavior unchanged.
+- [x] 2.4 Ensure `fmt --stdin` writes only formatted Markdown to stdout on success.
+- [x] 2.5 Ensure `fmt` never applies unsafe fix candidates by default.
+
+## 3. Tests And Docs
+
+- [x] 3.1 Add formatter idempotence tests.
+- [x] 3.2 Add formatter CRLF/final-newline/blank-line tests.
+- [x] 3.3 Add CLI `fmt` exit-code test for unresolved non-formatting diagnostics.
+- [x] 3.4 Add CLI `fmt --stdin` stdout contract test.
+- [x] 3.5 Update README to compare `check`, `fix`, and `fmt`.
+- [x] 3.6 Update examples or public API surface tests to include formatter API.
 
 ## Verification
 
-- [ ] `cargo test --workspace --locked` passes.
-- [ ] `make dogfood` passes.
-- [ ] `git diff --check` passes.
+- [x] `cargo fmt --all -- --check` passes.
+- [x] `cargo test --workspace --locked` passes.
+- [x] `make check` passes.
+- [x] `make dogfood` passes.
+- [x] `make release-check VERSION=v0.10.0` passes.
+- [x] `git diff --check` passes.
 
-## Definition Of Done
+## Definition of Done
 
-- [ ] Formatter behavior is deterministic and idempotent.
-- [ ] Formatter contract is separate from lint fix contract.
-- [ ] Editor-friendly stdout and exit code behavior is documented.
+- [x] Formatter behavior is deterministic and idempotent.
+- [x] Formatter contract is separate from lint fix contract.
+- [x] Formatter scope is limited to indentation and newline/layout normalization.
+- [x] Editor-friendly stdout and exit code behavior is documented.
+- [x] Unsafe fixes are not part of default formatter behavior.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::i18n::{Locale, LocalizedDiagnostic, MessageParams};
 use crate::{
-    fix_with_results, fix_with_results_including_unsafe, lint, FixSafety, LintOptions,
-    MarkdownLintConfig,
+    fix_with_results, fix_with_results_including_unsafe, format_markdown, lint, FixSafety,
+    FormatOptions, LintOptions, MarkdownLintConfig,
 };
 use glob::{glob, Pattern};
 use ignore::{WalkBuilder, WalkState};
@@ -104,10 +104,11 @@ pub fn run(cli: Cli) -> Result<i32, String> {
             let exit = run_check_like(cli.check_fix, &cli, locale)?;
             Ok(exit)
         }
-        Command::Fix | Command::Fmt => {
+        Command::Fix => {
             let exit = run_check_like(true, &cli, locale)?;
             Ok(exit)
         }
+        Command::Fmt => run_fmt(&cli, locale),
         Command::Rule(rule_id) => run_rule(rule_id.as_deref(), cli.format, locale),
         Command::Config(ref command) => run_config(command.clone(), &cli),
         Command::Version => {
@@ -115,6 +116,79 @@ pub fn run(cli: Cli) -> Result<i32, String> {
             Ok(0)
         }
     }
+}
+
+fn run_fmt(cli: &Cli, locale: Locale) -> Result<i32, String> {
+    let mut report = CliReport {
+        command: "fmt",
+        files: Vec::new(),
+        errors: Vec::new(),
+        summary: CliSummary::default(),
+    };
+    if cli.stdin {
+        return run_stdin_fmt(cli, locale);
+    }
+
+    let files = match expand_inputs(cli) {
+        Ok(files) => files,
+        Err(err) => {
+            report.errors.push(CliError::from_input_expand_error(err));
+            report.recompute_summary();
+            output_report(&report, true, cli, locale)?;
+            return Ok(2);
+        }
+    };
+
+    for path in files {
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) => {
+                report.errors.push(CliError::filesystem(&path, err));
+                continue;
+            }
+        };
+
+        match validate_effective_config(&path, cli.config.as_deref()) {
+            Ok(errors) if errors.is_empty() => {}
+            Ok(errors) => {
+                for error in errors {
+                    report
+                        .errors
+                        .push(CliError::config_validation(&path, error));
+                }
+                continue;
+            }
+            Err(err) => {
+                report.errors.push(CliError::config(&path, err));
+                continue;
+            }
+        }
+
+        let formatted =
+            format_markdown(&content, &FormatOptions::default()).map_err(|err| err.to_string())?;
+        let changed = formatted.content != content;
+        if changed {
+            if cli.diff {
+                print_diff(&path, &content, &formatted.content);
+            }
+            if let Err(err) = fs::write(&path, &formatted.content) {
+                report.errors.push(CliError::filesystem(&path, err));
+                continue;
+            }
+        }
+
+        report.files.push(FileReport {
+            path: path.display().to_string(),
+            diagnostics: Vec::new(),
+            applied_fixes: formatted.applied_operations,
+            changed,
+        });
+    }
+
+    report.recompute_summary();
+    let exit_code = if report.errors.is_empty() { 0 } else { 2 };
+    output_report(&report, true, cli, locale)?;
+    Ok(exit_code)
 }
 
 fn run_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32, String> {
@@ -235,6 +309,55 @@ fn run_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32, Stri
     output_report(&report, fix_mode, cli, locale)?;
 
     Ok(exit_code)
+}
+
+fn run_stdin_fmt(cli: &Cli, locale: Locale) -> Result<i32, String> {
+    let mut content = String::new();
+    io::stdin()
+        .read_to_string(&mut content)
+        .map_err(|err| err.to_string())?;
+    match validate_effective_config(Path::new("<stdin>"), cli.config.as_deref()) {
+        Ok(errors) if errors.is_empty() => {}
+        Ok(errors) => {
+            let mut report = CliReport {
+                command: "fmt",
+                summary: CliSummary::default(),
+                files: Vec::new(),
+                errors: errors
+                    .into_iter()
+                    .map(|error| CliError::config_validation(Path::new("<stdin>"), error))
+                    .collect(),
+            };
+            report.recompute_summary();
+            output_report(&report, true, cli, locale)?;
+            return Ok(2);
+        }
+        Err(err) => {
+            let mut report = CliReport {
+                command: "fmt",
+                summary: CliSummary::default(),
+                files: Vec::new(),
+                errors: vec![CliError::config(Path::new("<stdin>"), err)],
+            };
+            report.recompute_summary();
+            output_report(&report, true, cli, locale)?;
+            return Ok(2);
+        }
+    }
+
+    let formatted = format_stdin_content(&content)?;
+    if cli.diff {
+        print_diff(Path::new("<stdin>"), &content, &formatted);
+    } else {
+        print!("{formatted}");
+    }
+    Ok(0)
+}
+
+fn format_stdin_content(content: &str) -> Result<String, String> {
+    Ok(format_markdown(content, &FormatOptions::default())
+        .map_err(|err| err.to_string())?
+        .content)
 }
 
 fn run_stdin_check_like(fix_mode: bool, cli: &Cli, locale: Locale) -> Result<i32, String> {
@@ -664,17 +787,29 @@ fn render_text_report(report: &CliReport, fix_mode: bool, cli: &Cli, locale: Loc
             let mut params = MessageParams::new();
             params.insert("path".to_string(), file.path.clone());
             params.insert("count".to_string(), file.applied_fixes.to_string());
-            let fallback = format!(
-                "{}: fixed {} issue{}",
-                file.path,
-                file.applied_fixes,
-                plural(file.applied_fixes)
-            );
+            let (message_id, fallback) = if report.command == "fmt" {
+                (
+                    "format.formatted_count",
+                    format!(
+                        "{}: formatted {} operation{}",
+                        file.path,
+                        file.applied_fixes,
+                        plural(file.applied_fixes)
+                    ),
+                )
+            } else {
+                (
+                    "fix.fixed_count",
+                    format!(
+                        "{}: fixed {} issue{}",
+                        file.path,
+                        file.applied_fixes,
+                        plural(file.applied_fixes)
+                    ),
+                )
+            };
             output.push_str(&crate::i18n::render_message(
-                locale,
-                "fix.fixed_count",
-                &params,
-                &fallback,
+                locale, message_id, &params, &fallback,
             ));
             output.push('\n');
         }
@@ -1037,6 +1172,13 @@ fn load_effective_config(
     }
 
     Ok(MarkdownLintConfig::default())
+}
+
+fn validate_effective_config(
+    path: &Path,
+    explicit: Option<&Path>,
+) -> Result<Vec<crate::ConfigError>, String> {
+    Ok(load_effective_config(path, explicit)?.validate_cached_rules())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1998,18 +2140,14 @@ mod tests {
     }
 
     #[test]
-    fn fmt_applies_fixes_like_fix() {
-        let dir = test_dir("fmt");
+    fn fmt_applies_layout_formatting_and_is_idempotent() {
+        let dir = test_dir("fmt-layout");
         fs::create_dir_all(&dir).expect("test dir should be created");
         let file = dir.join("bad.md");
-        let config = dir.join(".markdownlint.json");
-        fs::write(&file, "#Title\n").expect("test file should be written");
-        fs::write(&config, "{ \"default\": false, \"MD018\": true }\n")
-            .expect("config should be written");
+        fs::write(&file, "# Title\r\nText\n\n\n-  item").expect("test file should be written");
 
         let exit = run(Cli {
             command: Command::Fmt,
-            config: Some(config),
             inputs: vec![file.display().to_string()],
             ..Cli::default()
         })
@@ -2018,9 +2156,52 @@ mod tests {
         assert_eq!(exit, 0);
         assert_eq!(
             fs::read_to_string(&file).expect("fixed file should be readable"),
-            "# Title\n"
+            "# Title\n\nText\n\n- item\n"
+        );
+
+        let second_exit = run(Cli {
+            command: Command::Fmt,
+            inputs: vec![file.display().to_string()],
+            ..Cli::default()
+        })
+        .expect("fmt should run again");
+
+        assert_eq!(second_exit, 0);
+        assert_eq!(
+            fs::read_to_string(&file).expect("fixed file should be readable"),
+            "# Title\n\nText\n\n- item\n"
         );
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn fmt_does_not_apply_non_layout_safe_fixes_or_return_one_for_lint_issues() {
+        let dir = test_dir("fmt-non-layout");
+        fs::create_dir_all(&dir).expect("test dir should be created");
+        let file = dir.join("bad.md");
+        fs::write(&file, "#Title\n").expect("test file should be written");
+
+        let exit = run(Cli {
+            command: Command::Fmt,
+            inputs: vec![file.display().to_string()],
+            ..Cli::default()
+        })
+        .expect("fmt should run");
+
+        assert_eq!(exit, 0);
+        assert_eq!(
+            fs::read_to_string(&file).expect("fixed file should be readable"),
+            "#Title\n"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn fmt_stdin_contract_formats_markdown_only() {
+        let formatted =
+            format_stdin_content("# Title\r\nText\n\n\n").expect("stdin format should run");
+
+        assert_eq!(formatted, "# Title\n\nText\n");
     }
 
     #[test]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,0 +1,179 @@
+use crate::{fix_with_results, lint, Error, FixResult, LintOptions, RuleConfig};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+const MAX_FORMAT_PASSES: usize = 8;
+const LAYOUT_RULES: [&str; 9] = [
+    "MD005", "MD007", "MD012", "MD022", "MD030", "MD031", "MD032", "MD047", "MD058",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FormatOptions {
+    pub max_passes: usize,
+}
+
+impl Default for FormatOptions {
+    fn default() -> Self {
+        Self {
+            max_passes: MAX_FORMAT_PASSES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct FormatResult {
+    pub content: String,
+    pub applied_operations: usize,
+}
+
+/// Applies deterministic Markdown layout formatting.
+///
+/// The formatter intentionally uses a narrow layout-only policy. It normalizes line endings and
+/// then applies safe fixes for the formatter rule subset; it does not apply semantic/style rewrites.
+pub fn format_markdown(content: &str, options: &FormatOptions) -> Result<FormatResult, Error> {
+    let mut content = content.to_string();
+    let mut applied_operations = 0;
+    let normalized = normalize_line_endings(&content);
+    if normalized != content {
+        applied_operations += 1;
+        content = normalized;
+    }
+    let terminal_normalized = normalize_terminal_newline(&content);
+    if terminal_normalized != content {
+        applied_operations += 1;
+        content = terminal_normalized;
+    }
+
+    let lint_options = layout_lint_options();
+    let max_passes = options.max_passes.max(1);
+    for _ in 0..max_passes {
+        let diagnostics = lint(&content, &lint_options)?;
+        if !diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.fix.is_some())
+        {
+            break;
+        }
+
+        let fixed: FixResult = fix_with_results(&content, &diagnostics);
+        if fixed.applied_fixes == 0 || fixed.content == content {
+            break;
+        }
+
+        applied_operations += fixed.applied_fixes;
+        content = fixed.content;
+    }
+
+    let terminal_normalized = normalize_terminal_newline(&content);
+    if terminal_normalized != content {
+        applied_operations += 1;
+        content = terminal_normalized;
+    }
+
+    Ok(FormatResult {
+        content,
+        applied_operations,
+    })
+}
+
+pub fn layout_lint_options() -> LintOptions {
+    let layout_rules = LAYOUT_RULES.into_iter().collect::<HashSet<_>>();
+    LintOptions {
+        default_severity: crate::Severity::Warning,
+        rules: crate::rules::markdown::MarkdownLinterOps::official_rules()
+            .iter()
+            .map(|rule_id| {
+                (
+                    rule_id.id().to_string(),
+                    RuleConfig {
+                        enabled: layout_rules.contains(rule_id.id()),
+                        properties: HashMap::new(),
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+fn normalize_line_endings(content: &str) -> String {
+    if !content.as_bytes().contains(&b'\r') {
+        return content.to_string();
+    }
+
+    let mut normalized = String::with_capacity(content.len());
+    let mut chars = content.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\r' {
+            if chars.peek() == Some(&'\n') {
+                chars.next();
+            }
+            normalized.push('\n');
+        } else {
+            normalized.push(ch);
+        }
+    }
+    normalized
+}
+
+fn normalize_terminal_newline(content: &str) -> String {
+    if content.is_empty() {
+        return String::new();
+    }
+    let trimmed = content.trim_end_matches('\n');
+    format!("{trimmed}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formatter_normalizes_line_endings_and_final_newline() {
+        let formatted = format_markdown("# Title\r\nText\r", &FormatOptions::default())
+            .expect("format should succeed");
+
+        assert_eq!(formatted.content, "# Title\n\nText\n");
+        assert!(formatted.applied_operations >= 2);
+    }
+
+    #[test]
+    fn formatter_applies_layout_subset_without_semantic_style_rewrites() {
+        let source =
+            "# Title\nText\n\n\n## Next\n```rust\ncode\n```\n| A | B |\n|---|---|\n| 1 | 2 |";
+        let formatted =
+            format_markdown(source, &FormatOptions::default()).expect("format should succeed");
+
+        assert_eq!(
+            formatted.content,
+            "# Title\n\nText\n\n## Next\n\n```rust\ncode\n```\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+        );
+    }
+
+    #[test]
+    fn formatter_is_idempotent() {
+        let source = "# Title\nText\n\n\n-  item\n";
+        let first = format_markdown(source, &FormatOptions::default())
+            .expect("first format should succeed");
+        let second = format_markdown(&first.content, &FormatOptions::default())
+            .expect("second format should succeed");
+
+        assert_eq!(first.content, second.content);
+        assert_eq!(second.applied_operations, 0);
+    }
+
+    #[test]
+    fn formatter_does_not_remove_trailing_spaces() {
+        let formatted = format_markdown("hard break  \nnext\n", &FormatOptions::default())
+            .expect("format should succeed");
+
+        assert_eq!(formatted.content, "hard break  \nnext\n");
+    }
+
+    #[test]
+    fn formatter_reduces_trailing_blank_lines_to_single_final_newline() {
+        let formatted = format_markdown("Text\n\n\n", &FormatOptions::default())
+            .expect("format should succeed");
+
+        assert_eq!(formatted.content, "Text\n");
+    }
+}

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -240,6 +240,11 @@ pub fn render_message(
                 param(params, "path", ""),
                 param(params, "count", "0")
             ),
+            "format.formatted_count" => format!(
+                "{}: {} 件の整形操作を適用しました",
+                param(params, "path", ""),
+                param(params, "count", "0")
+            ),
             _ => fallback.to_string(),
         },
     }
@@ -336,7 +341,7 @@ fn japanese_rule_description(rule_id: &str) -> Option<&'static str> {
     }
 }
 
-const CATALOG_KEYS: [&str; 14] = [
+const CATALOG_KEYS: [&str; 15] = [
     "rule.generic",
     "rule.MD001.heading_increment",
     "config.error",
@@ -351,6 +356,7 @@ const CATALOG_KEYS: [&str; 14] = [
     "summary.no_files",
     "summary.statistics",
     "fix.fixed_count",
+    "format.formatted_count",
 ];
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod catalog;
 pub mod cli;
 pub mod config;
 pub mod fix;
+pub mod formatter;
 pub mod i18n;
 pub mod parser;
 pub mod rules;
@@ -11,6 +12,7 @@ pub mod types;
 pub mod upstream;
 
 pub use config::{ConfigError, ConfigErrorKind, MarkdownLintConfig};
+pub use formatter::{format_markdown, layout_lint_options, FormatOptions, FormatResult};
 pub use i18n::{
     has_rule_description_translation, localized_rule_description, resolve_locale_code,
     resolve_locale_code_or, supported_locales, Locale, LocaleError, LocalizedDiagnostic,

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -383,6 +383,7 @@ fn ast_linter_public_api_surface_is_explicit() {
     let required = [
         "pub fn lint(content: &str, options: &LintOptions) -> Result<Vec<LintResult>, Error>",
         "pub fn fix(content: &str, options: &LintOptions) -> Result<FixResult, Error>",
+        "pub use formatter::{format_markdown, layout_lint_options, FormatOptions, FormatResult};",
         "pub fn available_rules() -> Vec<RuleMeta>",
         "pub fn localized_available_rules(language_code: &str) -> Vec<RuleMeta>",
         "pub fn implemented_rules() -> Vec<RuleMeta>",


### PR DESCRIPTION
## Summary
- add a dedicated `format_markdown` formatter API with options/result types
- make `kml fmt` use layout formatting instead of `fix` alias behavior
- limit formatter scope to indentation and newline/layout normalization
- document `check` / `fix` / `fmt` responsibility split

## Verification
- `cargo test --workspace --locked`
- `make dogfood`
- `make check`
- `make release-check VERSION=v0.10.0`
- `git diff --check`