### PR TITLE
Add GitHub Action distribution channel

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -32,6 +32,9 @@ jobs:
       - name: MCP build
         run: make mcp-build
 
+      - name: Action smoke
+        run: make action-smoke
+
       - name: Dogfood
         run: make dogfood
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
       - name: MCP build
         run: make mcp-build
 
+      - name: Action smoke
+        run: make action-smoke
+
       - name: Dogfood
         run: make dogfood
 

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -8,6 +8,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Makefile'
+      - 'action.yml'
       - '.markdownlint-dogfood.json'
       - '.github/workflows/**'
       - 'README.md'
@@ -22,6 +23,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Makefile'
+      - 'action.yml'
       - '.markdownlint-dogfood.json'
       - '.github/workflows/**'
       - 'README.md'
@@ -89,6 +91,10 @@ jobs:
 
       - name: Run dogfood
         run: make dogfood
+
+      - name: Run action smoke
+        if: matrix.os == 'ubuntu-latest'
+        run: make action-smoke
 
       - name: Run coverage
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.11.0
+
+- Adds an official root GitHub Action for running `kml` in CI from release tags.
+- Adds shared action install/run scripts with crates.io and local-path install modes.
+- Adds `make action-smoke` plus CI and release workflow smoke coverage for the action channel.
+- Documents distribution channel status, official support policy, and deferred wrapper channels.
+
 ## v0.10.0
 
 - Adds a dedicated layout formatter API with `format_markdown()`, `FormatOptions`, and `FormatResult`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "markdownlint-compatible Markdown linter library"

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ CROSS_TOOL_SUMMARY ?= target/cross-tool-benchmark.md
 CROSS_TOOL_RUNS ?= 5
 CROSS_TOOL_WARMUP ?= 1
 CROSS_TOOL_ARGS ?=
+ACTION_SMOKE_DIR ?= target/action-smoke
 export RUSTFLAGS=-D warnings
 
 # AI context-aware CLI proxy (mandatory for agents)
@@ -155,6 +156,14 @@ bench-cross-tools-fix: ## Benchmark fix behavior across available CLIs
 examples: ## Compile public Rust embedding examples
 	cargo build --examples --locked
 
+.PHONY: action-smoke
+action-smoke: ## Smoke test the repository GitHub Action through shared action scripts
+	mkdir -p "$(ACTION_SMOKE_DIR)"
+	printf '# Action Smoke\n\nText\n' > "$(ACTION_SMOKE_DIR)/README.md"
+	printf '{\n  "default": true,\n  "MD013": false\n}\n' > "$(ACTION_SMOKE_DIR)/.markdownlint.json"
+	KML_ACTION_INSTALL_SOURCE=path KML_ACTION_PATH=. KML_ACTION_INSTALL_ROOT="$(ACTION_SMOKE_DIR)/install" bash scripts/action/install-kml.sh
+	PATH="$(CURDIR)/$(ACTION_SMOKE_DIR)/install/bin:$$PATH" KML_ACTION_COMMAND=check KML_ACTION_PATHS="$(ACTION_SMOKE_DIR)/README.md" KML_ACTION_CONFIG="$(ACTION_SMOKE_DIR)/.markdownlint.json" KML_ACTION_LOCALE=en KML_ACTION_OUTPUT=text bash scripts/action/run-kml.sh
+
 .PHONY: mcp-build
 mcp-build: ## Build optional experimental MCP server
 	cargo build --bin kml-mcp --features mcp --locked
@@ -168,7 +177,7 @@ release-test: ## Run release-equivalent tests with all optional features
 	cargo test --all-features --locked
 
 .PHONY: release-check
-release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
+release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build action-smoke ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
 	scripts/release/verify-version.sh "$(VERSION)"
 	cargo publish --dry-run --locked --allow-dirty
 	cargo install --path . --locked --force --root "$${TMPDIR:-/tmp}/kml-release-install-check" --bin kml

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ cargo install katana-markdown-linter
 
 The binary target is `kml`.
 
+## GitHub Actions
+
+Use the repository action to run `kml` in CI without writing install steps:
+
+~~~yaml
+- uses: actions/checkout@v5
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.11.0
+  with: { version: "0.11.0", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+~~~
+
+Pin the action tag and `version` together for reproducible runs. The action
+installs `kml` from crates.io by default. Repository-local smoke tests can set
+`install-source: path` and `path: .`.
+
+`extra-args` accepts one argument per line, so flags that take values must use
+separate lines.
+
 ## CLI Usage
 
 ~~~bash
@@ -220,6 +237,9 @@ Use `make dogfood` to run `kml` against this repository's Markdown documentation
 Use `make examples` to compile the public Rust embedding examples.
 
 Quality gate details, CI required checks, coverage modes, and release readiness are documented in [`docs/quality-gates.md`](docs/quality-gates.md).
+
+Distribution channel status and deferral notes are documented in
+[`docs/distribution.md`](docs/distribution.md).
 
 MCP integration has been evaluated separately in
 [`docs/mcp-integration-evaluation.md`](docs/mcp-integration-evaluation.md).

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,65 @@
+name: kml
+description: Run katana-markdown-linter in GitHub Actions.
+
+inputs:
+  install-source:
+    description: Install source. Use crates-io for released usage or path for repository smoke tests.
+    required: false
+    default: crates-io
+  version:
+    description: katana-markdown-linter crate version to install when install-source is crates-io.
+    required: false
+    default: ""
+  path:
+    description: Local crate path used when install-source is path.
+    required: false
+    default: "."
+  command:
+    description: kml command to run.
+    required: false
+    default: check
+  paths:
+    description: Newline-separated paths passed to check, fix, or fmt.
+    required: false
+    default: "."
+  config:
+    description: Optional markdownlint config path.
+    required: false
+    default: ""
+  locale:
+    description: CLI message locale.
+    required: false
+    default: en
+  output:
+    description: Output format. Use text or json.
+    required: false
+    default: text
+  extra-args:
+    description: Additional kml arguments, one argument per line.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install kml
+      shell: bash
+      env:
+        KML_ACTION_INSTALL_SOURCE: ${{ inputs.install-source }}
+        KML_ACTION_VERSION: ${{ inputs.version }}
+        KML_ACTION_PATH: ${{ inputs.path }}
+      run: bash "${GITHUB_ACTION_PATH}/scripts/action/install-kml.sh"
+
+    - name: Run kml
+      shell: bash
+      env:
+        KML_ACTION_COMMAND: ${{ inputs.command }}
+        KML_ACTION_PATHS: ${{ inputs.paths }}
+        KML_ACTION_CONFIG: ${{ inputs.config }}
+        KML_ACTION_LOCALE: ${{ inputs.locale }}
+        KML_ACTION_OUTPUT: ${{ inputs.output }}
+        KML_ACTION_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: bash "${GITHUB_ACTION_PATH}/scripts/action/run-kml.sh"

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,48 @@
+# Distribution Channels
+
+## Official Channels
+
+| Channel | Status | Verification | Policy |
+| --- | --- | --- | --- |
+| Cargo crate | Official | `make release-check`, install smoke test, crates.io publish verification | Primary library and CLI package |
+| GitHub Action | Official from `v0.11.0` | `make action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
+
+The GitHub Action lives at the repository root as `action.yml`, so consumers can
+use the release tag directly:
+
+~~~yaml
+- uses: actions/checkout@v5
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.11.0
+  with: { version: "0.11.0", command: check, paths: "README.md\ndocs" }
+~~~
+
+Pin both the action tag and the crate `version` input. The action installs the
+published crate by default. Repository-local validation uses
+`install-source: path` so pull requests verify the same action scripts without
+waiting for crates.io publication.
+
+## Deferred Channels
+
+| Channel | Decision | Reason |
+| --- | --- | --- |
+| pre-commit hook repository | Deferred | A dedicated hook repository adds release ownership. Local hooks can call `kml` or the GitHub Action can protect CI first. |
+| Homebrew | Deferred | A tap needs stable binary archive naming or a crate-install formula policy. Current release artifacts are crate package and checksum only. |
+| standalone binary artifacts | Deferred | Binary archives need platform matrix ownership and checksum verification before becoming official. |
+| npm wrapper | Deferred | A Node wrapper would add another release surface before binary artifact naming is stable. |
+| pip/uv wrapper | Deferred | A Python wrapper has the same binary artifact dependency as npm. |
+| config schema publication | Deferred | Schema output needs versioned config metadata and editor validation tests before it can be treated as stable. |
+| editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
+
+## Action Inputs
+
+| Input | Default | Meaning |
+| --- | --- | --- |
+| `install-source` | `crates-io` | `crates-io` installs the published package; `path` installs a local checkout. |
+| `version` | empty | Crate version passed to `cargo install` for published package installs. |
+| `path` | `.` | Local crate path used with `install-source: path`. |
+| `command` | `check` | Supported commands are `check`, `fix`, `fmt`, `rule`, `config`, `version`, and `init-config`. |
+| `paths` | `.` | Newline-separated paths passed to `check`, `fix`, or `fmt`. |
+| `config` | empty | Optional markdownlint config path. |
+| `locale` | `en` | CLI message locale. |
+| `output` | `text` | Use `text` or `json`. |
+| `extra-args` | empty | Additional `kml` arguments, one argument per line. |

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -17,6 +17,7 @@
 | `make upstream-golden-live` | Run the live upstream markdownlint oracle against the golden corpus | No, manual update check |
 | `make rule-dashboard` | Regenerate `docs/rule-coverage-dashboard.md` | No, generation helper |
 | `make bench-cross-tools` | Compare `kml` CLI timing with optional `mado` and `rumdl` binaries | No, manual performance probe |
+| `make action-smoke` | Install through the shared GitHub Action scripts and run a CLI smoke check | Yes for release gates |
 | `make release-check` | Run local release preflight gates except live upstream clone | Yes |
 | `make release-verify` | Verify published tag, GitHub Release, and crates.io state | Yes after publication |
 
@@ -32,6 +33,7 @@
 - release workflow must require an existing annotated signed tag that GitHub reports as Verified
 - release retry helpers must refuse remote tag overwrites and already-published crates.io versions
 - upstream drift checking must be wired through `make upstream-drift` and release workflows
+- the GitHub Action channel must stay wired through `action.yml`, shared scripts, and release smoke checks
 - public Markdown docs must stay English-only
 - public library API and rule catalog entrypoints must remain explicit
 - localization catalog tests must keep supported locales on the same message id set and preserve English fallback behavior
@@ -52,12 +54,22 @@ Use these targets when comparing CLI behavior or speed against peer tools:
 - `make bench-cross-tools-common`
 - `make bench-cross-tools-fix`
 
+## Distribution Smoke
+
+`make action-smoke` verifies the official GitHub Action channel without needing a
+published crate. It installs the current checkout through the shared action
+install script, then runs `kml check` through the shared action runner script.
+
+The release workflows run the same smoke target so `action.yml`,
+`scripts/action/install-kml.sh`, and `scripts/action/run-kml.sh` are tested
+before publication.
+
 ## CI Required Checks
 
 Branch protection for `main` currently requires:
 
 - `Test and Build (macos-latest)` -> `.github/workflows/test-and-build.yml`, `make fmt-check`, `make lint`, `make ast-lint`, `cargo test --workspace`, `make dogfood`
-- `Test and Build (ubuntu-latest)` -> `.github/workflows/test-and-build.yml`, same checks plus non-blocking `make coverage`
+- `Test and Build (ubuntu-latest)` -> `.github/workflows/test-and-build.yml`, same checks plus `make action-smoke` and non-blocking `make coverage`
 
 If required check names or workflow job names change, update branch protection in the same change. Otherwise the repository can either block valid merges or allow merges without the intended gate.
 
@@ -81,9 +93,9 @@ make release-check VERSION=vX.Y.Z
 
 The local release check runs formatting, Clippy, AST lint, tests, dogfood,
 coverage regression, example builds, optional MCP build, version verification,
-dry-run publish, and install smoke checks. The GitHub release workflows
-additionally clone upstream markdownlint and run `make upstream-drift` against
-the default branch docs.
+dry-run publish, action smoke, and install smoke checks. The GitHub release
+workflows additionally clone upstream markdownlint and run `make upstream-drift`
+against the default branch docs.
 
 Use `make release-tag VERSION=vX.Y.Z` before dispatching a release. It creates
 or verifies a signed annotated tag and then requires GitHub to report the tag as

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -58,6 +58,7 @@ The workflow validates:
 - `cargo test --all-features --locked`
 - `make examples`
 - `make mcp-build`
+- `make action-smoke`
 - upstream markdownlint drift gate
 - `make lint`
 - `cargo publish --dry-run --locked --allow-dirty`
@@ -68,6 +69,9 @@ The workflow creates or updates:
 - GitHub Release
 - `.crate` package artifact
 - `.sha256` checksum
+
+The root `action.yml` is the official GitHub Action channel from `v0.11.0`.
+Release preflight must keep `make action-smoke` passing before publishing a tag.
 
 Tag push flow is also supported. Pushing `vX.Y.Z` runs the same gates and creates or updates the GitHub Release, but it does not publish to crates.io. Use manual dispatch with `publish_crate: true` when crates.io publication is intended.
 
@@ -142,6 +146,12 @@ If workflow job names are changed, update branch protection in the same change. 
 
 - Verify `[[bin]] name = "kml"` remains unchanged.
 - Re-run the install check with `cargo install --path . --bin kml`.
+
+### GitHub Action smoke fails
+
+- Re-run `make action-smoke`.
+- Inspect `action.yml`, `scripts/action/install-kml.sh`, and `scripts/action/run-kml.sh`.
+- Keep the action scripts generic; do not add repository-specific lint policy outside action inputs.
 
 ### Incorrect files were packaged
 

--- a/openspec/changes/tool-distribution-and-editor-expansion/design.md
+++ b/openspec/changes/tool-distribution-and-editor-expansion/design.md
@@ -20,6 +20,18 @@ for its own sake.
 3. npm/pip wrappers only after binary artifact naming is stable.
 4. Editor/LSP work after formatter semantics are stable.
 
+### v0.11.0 Decision
+
+The first official non-Cargo channel is a root GitHub Action. It installs the
+published crate by default and supports a local path mode for repository smoke
+tests. The action is intentionally a thin wrapper over `kml`; it does not embed
+Node, Python, or consumer-specific adapter logic.
+
+Release gates SHALL include an action smoke target that installs from the local
+checkout and runs `kml check` through the same scripts used by the GitHub
+Action. Other channels are documented as deferred until binary artifact naming,
+schema metadata, or dedicated ownership is stable.
+
 ### Non-Goals
 
 - Node/Python implementation of the linter.

--- a/openspec/changes/tool-distribution-and-editor-expansion/proposal.md
+++ b/openspec/changes/tool-distribution-and-editor-expansion/proposal.md
@@ -11,6 +11,10 @@ outside Cargo once the lint/fix/format contracts are stable.
 
 - Define which channels are official and which are documented as examples.
 
+- Promote a root GitHub Action as the first non-Cargo official channel.
+
+- Add smoke verification for the GitHub Action path in local release checks and CI.
+
 - Add schema/config/editor integration plan when it benefits users.
 
 - Keep core crate independent from distribution wrappers.

--- a/openspec/changes/tool-distribution-and-editor-expansion/tasks.md
+++ b/openspec/changes/tool-distribution-and-editor-expansion/tasks.md
@@ -2,32 +2,32 @@
 
 ## Definition Of Ready
 
-- [ ] Release workflow is stable for the current crate.
-- [ ] CLI contracts for check/fix/fmt are stable enough to document externally.
-- [ ] Maintenance cost for each channel is understood.
+- [x] Release workflow is stable for the current crate.
+- [x] CLI contracts for check/fix/fmt are stable enough to document externally.
+- [x] Maintenance cost for each channel is understood.
 
 ## 1. Channel Evaluation
 
-- [ ] 1.1 Evaluate GitHub Action wrapper.
-- [ ] 1.2 Evaluate pre-commit integration.
-- [ ] 1.3 Evaluate Homebrew distribution.
-- [ ] 1.4 Evaluate npm and pip/uv wrappers.
-- [ ] 1.5 Evaluate config schema publication.
+- [x] 1.1 Evaluate GitHub Action wrapper.
+- [x] 1.2 Evaluate pre-commit integration.
+- [x] 1.3 Evaluate Homebrew distribution.
+- [x] 1.4 Evaluate npm and pip/uv wrappers.
+- [x] 1.5 Evaluate config schema publication.
 
 ## 2. Implementation
 
-- [ ] 2.1 Implement the first selected official channel.
-- [ ] 2.2 Add release verification for that channel.
-- [ ] 2.3 Document installation and update policy.
+- [x] 2.1 Implement the first selected official channel.
+- [x] 2.2 Add release verification for that channel.
+- [x] 2.3 Document installation and update policy.
 
 ## Verification
 
-- [ ] Release preflight passes.
-- [ ] New channel smoke test passes.
-- [ ] `git diff --check` passes.
+- [x] Release preflight passes.
+- [x] New channel smoke test passes.
+- [x] `git diff --check` passes.
 
 ## Definition Of Done
 
-- [ ] At least one non-Cargo integration channel is official and verified.
-- [ ] Unsupported channels are explicitly deferred with reasons.
-- [ ] Core crate remains independent from wrappers.
+- [x] At least one non-Cargo integration channel is official and verified.
+- [x] Unsupported channels are explicitly deferred with reasons.
+- [x] Core crate remains independent from wrappers.

--- a/scripts/action/install-kml.sh
+++ b/scripts/action/install-kml.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_source="${KML_ACTION_INSTALL_SOURCE:-crates-io}"
+version="${KML_ACTION_VERSION:-}"
+install_path="${KML_ACTION_PATH:-.}"
+install_root="${KML_ACTION_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/kml-action}"
+bin_dir="${install_root}/bin"
+
+mkdir -p "${install_root}"
+
+case "${install_source}" in
+  crates-io)
+    command=(cargo install katana-markdown-linter --locked --force --root "${install_root}" --bin kml)
+    if [[ -n "${version}" ]]; then
+      command+=(--version "${version}")
+    fi
+    ;;
+  path)
+    command=(cargo install --path "${install_path}" --locked --force --root "${install_root}" --bin kml)
+    ;;
+  *)
+    echo "unsupported install-source: ${install_source}" >&2
+    exit 2
+    ;;
+esac
+
+"${command[@]}"
+
+if [[ ! -x "${bin_dir}/kml" ]]; then
+  echo "kml binary was not installed under ${bin_dir}" >&2
+  exit 2
+fi
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "${bin_dir}" >>"${GITHUB_PATH}"
+else
+  printf 'KML_ACTION_BIN_DIR=%s\n' "${bin_dir}"
+fi

--- a/scripts/action/run-kml.sh
+++ b/scripts/action/run-kml.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${KML_ACTION_COMMAND:-check}"
+paths="${KML_ACTION_PATHS:-.}"
+config="${KML_ACTION_CONFIG:-}"
+locale="${KML_ACTION_LOCALE:-en}"
+output="${KML_ACTION_OUTPUT:-text}"
+extra_args="${KML_ACTION_EXTRA_ARGS:-}"
+
+case "${command_name}" in
+  check | fix | fmt | rule | config | version | init-config) ;;
+  *)
+    echo "unsupported kml command: ${command_name}" >&2
+    exit 2
+    ;;
+esac
+
+args=("${command_name}")
+
+if [[ -n "${config}" ]]; then
+  args+=(--config "${config}")
+fi
+
+if [[ -n "${locale}" ]]; then
+  args+=(--locale "${locale}")
+fi
+
+if [[ -n "${output}" && "${output}" != "text" ]]; then
+  args+=(--output "${output}")
+fi
+
+append_multiline_args() {
+  local value="$1"
+  local line
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    if [[ -n "${line}" ]]; then
+      args+=("${line}")
+    fi
+  done <<<"${value}"
+}
+
+append_multiline_args "${extra_args}"
+
+case "${command_name}" in
+  check | fix | fmt)
+    append_multiline_args "${paths}"
+    ;;
+esac
+
+kml "${args[@]}"

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -238,7 +238,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let crate_guard = read_workspace_file("scripts/release/assert-crate-not-published.sh");
     let published_verifier = read_workspace_file("scripts/release/verify-release-published.sh");
     let required = [
-        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build"),
+        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build action-smoke"),
         ("Makefile", &makefile, "release-test:"),
         ("Makefile", &makefile, "cargo test --all-features --locked"),
         ("Makefile", &makefile, "scripts/release/assert-crate-not-published.sh"),
@@ -270,6 +270,63 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         .collect();
 
     assert_no_violations("release-local-ci-parity-and-retry-safety", violations);
+}
+
+#[test]
+fn ast_linter_github_action_channel_is_wired() {
+    let action = read_workspace_file("action.yml");
+    let makefile = read_workspace_file("Makefile");
+    let workflow = read_workspace_file(".github/workflows/test-and-build.yml");
+    let preflight = read_workspace_file(".github/workflows/release-preflight.yml");
+    let release = read_workspace_file(".github/workflows/release.yml");
+    let install = read_workspace_file("scripts/action/install-kml.sh");
+    let runner = read_workspace_file("scripts/action/run-kml.sh");
+    let required = [
+        ("action.yml", &action, "using: composite"),
+        ("action.yml", &action, "KML_ACTION_INSTALL_SOURCE"),
+        ("action.yml", &action, "scripts/action/install-kml.sh"),
+        ("action.yml", &action, "scripts/action/run-kml.sh"),
+        (
+            "scripts/action/install-kml.sh",
+            &install,
+            "cargo install katana-markdown-linter",
+        ),
+        (
+            "scripts/action/install-kml.sh",
+            &install,
+            "cargo install --path",
+        ),
+        (
+            "scripts/action/run-kml.sh",
+            &runner,
+            "append_multiline_args",
+        ),
+        ("Makefile", &makefile, "action-smoke:"),
+        ("Makefile", &makefile, "KML_ACTION_INSTALL_SOURCE=path"),
+        (
+            ".github/workflows/test-and-build.yml",
+            &workflow,
+            "Run action smoke",
+        ),
+        (
+            ".github/workflows/test-and-build.yml",
+            &workflow,
+            "'action.yml'",
+        ),
+        (
+            ".github/workflows/release-preflight.yml",
+            &preflight,
+            "Action smoke",
+        ),
+        (".github/workflows/release.yml", &release, "Action smoke"),
+    ];
+    let violations = required
+        .iter()
+        .filter(|(_, content, required)| !content.contains(*required))
+        .map(|(path, _, required)| format!("{path}: missing `{required}`"))
+        .collect();
+
+    assert_no_violations("github-action-channel", violations);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the root GitHub Action for kml CI usage
- add shared action install/run scripts and action smoke verification
- document distribution status and deferred wrapper channels
- bump package metadata and changelog to v0.11.0

## Verification

- make action-smoke
- make dogfood
- make check
- make release-check VERSION=v0.11.0
- git diff --check