### PR TITLE
Prepare v0.12.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.12.21
+
+- Excludes reserved and normally ignored directories from recursive CLI input by
+  default, including `node_modules`, VCS metadata, build outputs, and cache
+  directories. `--include-reserved` restores reserved paths, while
+  `--include-ignored` allows explicitly requested ignored directories such as
+  `.agents`.
+- Adds JSON fix details for `fix --output json` and `check --fix --output json`
+  so automated reviews can map each applied rewrite back to its rule and source
+  range.
+- Completes a KatanA 524-file check/fix sweep with every check result, every fix
+  result, and all 82 fix hunks reviewed. The sweep found and fixed an `MD007`
+  bad-fix case for unordered child lists under ordered parents, then re-ran the
+  review with release-blocking check/fix findings at zero.
+- Closes the remaining diagnostic-only rule map by marking author-intent cases
+  as manual-required in README, fixture metadata, generated dashboard, and fix
+  feasibility docs.
+- Records external KatanA dogfood evidence with release-blocking issues at zero.
+
 ## v0.12.20
 
 - Adds an internal cache for exported rule metadata so `available_rules()` keeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.12.20"
+version = "0.12.21"
 dependencies = [
  "glob",
  "ignore",
@@ -346,6 +346,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "unicode-width",
 ]
 
 [[package]]
@@ -709,6 +710,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,10 +327,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -729,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -742,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -752,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -765,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.12.20"
+version = "0.12.21"
 
 edition = "2021"
 license = "MIT"
@@ -49,3 +49,4 @@ rmcp = { version = "1.5.0", optional = true, default-features = false, features 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", optional = true, features = ["macros", "rt-multi-thread"] }
+unicode-width = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,10 @@ release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking ex
 	cargo install --path . --locked --force --root "$${TMPDIR:-/tmp}/kml-release-install-check" --bin kml
 	"$${TMPDIR:-/tmp}/kml-release-install-check/bin/kml" init-config --config "$${TMPDIR:-/tmp}/kml-release-install-check/.markdownlint.json"
 
+.PHONY: release-task-ledger-check
+release-task-ledger-check: ## Verify OpenSpec tasks.md has no open work and the quality score is 100/100
+	python3 scripts/release/verify-task-ledger.py --version "$(VERSION)" --allow-open-containing "release-task-ledger-check"
+
 .PHONY: release-package
 release-package: ## Build .crate package and sha256 checksum for VERSION
 	scripts/release/verify-version.sh "$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ kml check --format json "docs/**/*.md"
 kml check --stdin
 kml fix --stdin
 kml check --include "**/*.md" --exclude "target/**"
+kml check --include-reserved node_modules
 kml check --no-ignore --force-exclude --exclude "vendor/**" vendor/README.md
 kml check --statistics --quiet
 kml fix --diff README.md
@@ -112,10 +113,12 @@ Unsafe fixes require explicit opt-in. Interactive use prompts with `[Y/n]`;
 non-interactive use must pass `--unsafe --yes`.
 
 `--output json` is the preferred JSON output flag. `--format json` remains a compatibility alias.
+Fix-mode JSON includes per-file `fix_details` so applied rules can be compared
+with pre-fix diagnostics and rewritten file diffs.
 
 `--stdin` reads Markdown from standard input. `check --stdin` reports diagnostics against `<stdin>`; `fix --stdin` writes fixed Markdown to stdout; `fmt --stdin` writes formatted Markdown only to stdout.
 
-Directory scans respect gitignore files by default. Use `--no-ignore` to include ignored paths. `--exclude` filters discovered files; explicit files are kept unless `--force-exclude` is also set.
+Directory scans respect gitignore files by default. Use `--no-ignore` to include ignored paths everywhere, or `--include-ignored` to include ignored paths only under explicit directory inputs such as `.agents`. Reserved directories such as `.git`, `node_modules`, `target`, `dist`, `build`, and `coverage` are skipped by default even without gitignore entries; use `--include-reserved` only when you intentionally want to scan them. Project-specific generated or agent directories should be covered by gitignore or `--exclude`. `--exclude` filters discovered files; explicit files are kept unless `--force-exclude` is also set.
 
 `--locale <locale>` and `-l <locale>` select user-facing CLI message locale.
 Supported values currently resolve to English (`en`, `en-US`) or Japanese
@@ -141,14 +144,13 @@ The short version:
 | Capability | Status |
 | --- | --- |
 | Check coverage | `Implemented` for all 53 active rules |
-| Safe fix coverage | Safe fix available for 39 rules; diagnostic-only for 14 rules |
-| Unsafe fix coverage | Explicit opt-in unsafe subset for 1 rule; remaining rules are not applicable, need manual intent, or need triage |
+| Safe fix coverage | Safe fix available for 38 rules; diagnostic-only for 15 rules |
+| Unsafe fix coverage | Explicit opt-in unsafe subset for 1 rule; remaining rules are not applicable or need manual intent |
 | Deleted upstream IDs | 7 historical IDs shown as `Deleted` with `-` fix states |
 
 Safe fixes are intentionally conservative. `Implemented subset` means kml
 rewrites fixture-locked, low-risk violation forms for that rule. `Diagnostic
 only` means checks are implemented, but safe fixes are not provided.
-`Needs triage` means an unsafe fix candidate has not been evaluated yet.
 `Manual intent required` means an automatic rewrite would choose author intent.
 `Not applicable` means no separate unsafe candidate is currently identified
 beyond the safe-fix policy. `Deleted` rows are historical markdownlint IDs that
@@ -159,7 +161,7 @@ are not part of the active upstream rule catalog.
 
 | Rule | Check | Fix (safe) | Fix (unsafe) |
 | --- | --- | --- | --- |
-| `MD001` | Implemented | Diagnostic only | Needs triage |
+| `MD001` | Implemented | Diagnostic only | Manual intent required |
 | `MD002` | Deleted | - | - |
 | `MD003` | Implemented | Implemented subset | Not applicable |
 | `MD004` | Implemented | Implemented subset | Not applicable |
@@ -171,7 +173,7 @@ are not part of the active upstream rule catalog.
 | `MD010` | Implemented | Implemented subset | Not applicable |
 | `MD011` | Implemented | Implemented subset | Not applicable |
 | `MD012` | Implemented | Implemented subset | Not applicable |
-| `MD013` | Implemented | Diagnostic only | Needs triage |
+| `MD013` | Implemented | Diagnostic only | Manual intent required |
 | `MD014` | Implemented | Implemented subset | Not applicable |
 | `MD015` | Deleted | - | - |
 | `MD016` | Deleted | - | - |
@@ -182,7 +184,7 @@ are not part of the active upstream rule catalog.
 | `MD021` | Implemented | Implemented subset | Not applicable |
 | `MD022` | Implemented | Implemented subset | Not applicable |
 | `MD023` | Implemented | Implemented subset | Not applicable |
-| `MD024` | Implemented | Diagnostic only | Needs triage |
+| `MD024` | Implemented | Diagnostic only | Manual intent required |
 | `MD025` | Implemented | Implemented subset | Not applicable |
 | `MD026` | Implemented | Implemented subset | Not applicable |
 | `MD027` | Implemented | Implemented subset | Not applicable |
@@ -191,7 +193,7 @@ are not part of the active upstream rule catalog.
 | `MD030` | Implemented | Implemented subset | Not applicable |
 | `MD031` | Implemented | Implemented subset | Not applicable |
 | `MD032` | Implemented | Implemented subset | Not applicable |
-| `MD033` | Implemented | Diagnostic only | Needs triage |
+| `MD033` | Implemented | Diagnostic only | Manual intent required |
 | `MD034` | Implemented | Implemented subset | Not applicable |
 | `MD035` | Implemented | Implemented subset | Not applicable |
 | `MD036` | Implemented | Diagnostic only | Implemented subset |
@@ -199,25 +201,25 @@ are not part of the active upstream rule catalog.
 | `MD038` | Implemented | Implemented subset | Not applicable |
 | `MD039` | Implemented | Implemented subset | Not applicable |
 | `MD040` | Implemented | Implemented subset | Not applicable |
-| `MD041` | Implemented | Diagnostic only | Needs triage |
-| `MD042` | Implemented | Diagnostic only | Needs triage |
-| `MD043` | Implemented | Diagnostic only | Needs triage |
+| `MD041` | Implemented | Diagnostic only | Manual intent required |
+| `MD042` | Implemented | Diagnostic only | Manual intent required |
+| `MD043` | Implemented | Diagnostic only | Manual intent required |
 | `MD044` | Implemented | Implemented subset | Not applicable |
-| `MD045` | Implemented | Diagnostic only | Needs triage |
+| `MD045` | Implemented | Diagnostic only | Manual intent required |
 | `MD046` | Implemented | Implemented subset | Not applicable |
 | `MD047` | Implemented | Implemented subset | Not applicable |
 | `MD048` | Implemented | Implemented subset | Not applicable |
 | `MD049` | Implemented | Implemented subset | Not applicable |
 | `MD050` | Implemented | Implemented subset | Not applicable |
 | `MD051` | Implemented | Implemented subset | Not applicable |
-| `MD052` | Implemented | Implemented subset | Not applicable |
+| `MD052` | Implemented | Diagnostic only | Manual intent required |
 | `MD053` | Implemented | Implemented subset | Not applicable |
 | `MD054` | Implemented | Implemented subset | Not applicable |
 | `MD055` | Implemented | Implemented subset | Not applicable |
 | `MD056` | Implemented | Implemented (pads short rows; overflow rows remain diagnostic-only) | Not applicable |
 | `MD057` | Deleted | - | - |
 | `MD058` | Implemented | Implemented subset | Not applicable |
-| `MD059` | Implemented | Diagnostic only | Needs triage |
+| `MD059` | Implemented | Diagnostic only | Manual intent required |
 | `MD060` | Implemented | Implemented subset | Not applicable |
 
 </details>

--- a/docs/rule-coverage-dashboard.md
+++ b/docs/rule-coverage-dashboard.md
@@ -4,7 +4,7 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 
 | Rule | Check | Safe Fix | Unsafe Fix | Config | Edge | Golden | Known Delta | Manual Required |
 | --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
-| MD001 | 2 | 0 | 0 | 4 | 1 | baseline | no | - |
+| MD001 | 2 | 0 | 0 | 4 | 1 | baseline | no | fix requires author intent: changing heading levels can change document structure and anchors |
 | MD003 | 2 | 2 | 0 | 4 | 2 | pending: not locked | no | - |
 | MD004 | 2 | 1 | 0 | 4 | 1 | pending: not locked | no | - |
 | MD005 | 2 | 1 | 0 | 2 | 1 | baseline | no | - |
@@ -13,7 +13,7 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | MD010 | 2 | 1 | 0 | 8 | 0 | pending: not locked | no | - |
 | MD011 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD012 | 2 | 1 | 0 | 4 | 0 | pending: not locked | no | - |
-| MD013 | 2 | 0 | 0 | 18 | 1 | pending: not locked | no | - |
+| MD013 | 2 | 0 | 0 | 18 | 1 | pending: not locked | no | fix requires author intent: line wrapping can change prose, code, tables, or inline references |
 | MD014 | 3 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD018 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD019 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
@@ -21,7 +21,7 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | MD021 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD022 | 2 | 1 | 0 | 6 | 0 | baseline | no | - |
 | MD023 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
-| MD024 | 2 | 0 | 0 | 4 | 0 | pending: not locked | no | - |
+| MD024 | 2 | 0 | 0 | 4 | 0 | pending: not locked | no | fix requires author intent: duplicate heading fixes require choosing new heading text |
 | MD025 | 2 | 1 | 0 | 6 | 0 | pending: not locked | no | - |
 | MD026 | 2 | 1 | 0 | 4 | 0 | pending: not locked | no | - |
 | MD027 | 2 | 1 | 0 | 5 | 0 | pending: not locked | no | - |
@@ -30,7 +30,7 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | MD030 | 2 | 2 | 0 | 10 | 1 | baseline | no | - |
 | MD031 | 2 | 1 | 0 | 4 | 0 | pending: not locked | no | - |
 | MD032 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
-| MD033 | 2 | 0 | 0 | 6 | 0 | pending: not locked | no | - |
+| MD033 | 2 | 0 | 0 | 6 | 0 | pending: not locked | no | fix requires author intent: removing or replacing inline HTML changes rendered output |
 | MD034 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD035 | 2 | 1 | 0 | 4 | 1 | baseline | no | - |
 | MD036 | 2 | 0 | 1 | 4 | 0 | pending: not locked | no | - |
@@ -38,22 +38,22 @@ Generated from `tests/fixtures/rule-fixture-matrix.json`.
 | MD038 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD039 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD040 | 2 | 1 | 0 | 6 | 0 | pending: not locked | no | - |
-| MD041 | 2 | 0 | 0 | 8 | 0 | pending: not locked | no | - |
-| MD042 | 2 | 0 | 0 | 2 | 0 | pending: not locked | no | - |
-| MD043 | 2 | 0 | 0 | 6 | 0 | pending: not locked | no | - |
+| MD041 | 2 | 0 | 0 | 8 | 0 | pending: not locked | no | fix requires author intent: first heading text cannot be inferred safely |
+| MD042 | 2 | 0 | 0 | 2 | 0 | pending: not locked | no | fix requires author intent: empty link or image targets require author-provided destinations |
+| MD043 | 3 | 0 | 0 | 6 | 0 | pending: not locked | no | check requires configured MD043.headings; default markdownlint headings is empty<br>fix requires author intent: required headings require author-provided sections and order |
 | MD044 | 3 | 1 | 0 | 8 | 0 | pending: not locked | no | check requires configured MD044.names; default markdownlint names is empty<br>fix requires: configured MD044.names to avoid guessing product capitalization |
-| MD045 | 2 | 0 | 0 | 2 | 0 | pending: not locked | no | - |
+| MD045 | 2 | 0 | 0 | 2 | 0 | pending: not locked | no | fix requires author intent: alt text requires image-specific author knowledge |
 | MD046 | 2 | 1 | 0 | 4 | 0 | pending: not locked | no | - |
 | MD047 | 2 | 1 | 0 | 2 | 0 | baseline | no | - |
 | MD048 | 2 | 1 | 0 | 4 | 1 | baseline | no | - |
 | MD049 | 2 | 2 | 0 | 4 | 0 | pending: not locked | no | - |
 | MD050 | 2 | 2 | 0 | 4 | 0 | pending: not locked | no | - |
 | MD051 | 6 | 1 | 0 | 6 | 0 | pending: not locked | no | - |
-| MD052 | 2 | 2 | 0 | 6 | 0 | pending: not locked | no | - |
+| MD052 | 2 | 0 | 0 | 6 | 0 | pending: not locked | no | safe fix is not provided because the missing reference destination cannot be inferred |
 | MD053 | 2 | 1 | 0 | 4 | 0 | pending: not locked | no | - |
-| MD054 | 3 | 1 | 0 | 14 | 0 | pending: not locked | no | check requires a disabled MD054 style such as MD054.collapsed=false<br>fix requires: disabled style and an inline-safe reference definition |
+| MD054 | 3 | 1 | 0 | 14 | 0 | pending: not locked | no | check requires a disabled link style such as MD054.collapsed=false<br>fix requires: disabled style and an inline-safe reference definition |
 | MD055 | 2 | 1 | 0 | 4 | 1 | baseline | no | - |
 | MD056 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
 | MD058 | 2 | 1 | 0 | 2 | 0 | pending: not locked | no | - |
-| MD059 | 2 | 0 | 0 | 4 | 0 | pending: not locked | no | - |
+| MD059 | 2 | 0 | 0 | 4 | 0 | pending: not locked | no | fix requires author intent: descriptive link text requires replacement wording |
 | MD060 | 4 | 3 | 0 | 8 | 3 | pending: not locked | no | - |

--- a/docs/rule-fix-feasibility.md
+++ b/docs/rule-fix-feasibility.md
@@ -16,7 +16,7 @@ diagnostic-only at the start of the change.
 
 | Rule | State | Reason |
 | --- | --- | --- |
-| `MD001` | `unsafe-candidate` | Changing heading levels can change document structure and anchors. |
+| `MD001` | `manual-required` | Changing heading levels can change document structure and anchors. |
 | `MD003` | `safe-after-context` | Setext/ATX conversion needs source ranges and style-specific guards. |
 | `MD013` | `manual-required` | Line wrapping can change prose, code, tables, or inline references. |
 | `MD024` | `manual-required` | Duplicate heading fixes require choosing new heading text. |

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -25,8 +25,8 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.12.14`: precision-first を維持したまま `DocumentContext` の inline 抽出統合 (`InlineIndex`)、`MD051` の `ignored_pattern` regex キャッシュ、`MD046` の `code_line_flags` 索引活用で hot path コストを削減する。
 - `v0.12.19`: `MD003` の safe-fix を追加し、`MD028` は作者判断が必要なため `v0.12.21` の by-design 宣言へ送る。
 - `v0.12.20`: released patch として `v0.12.19` 後の performance 計測、`api_rule_catalog` の hot path 改善、baseline refresh を完了した。新規 rule/fix は入れていない。
-- `v0.12.21`: `v0.12.20` 完了後に KatanA 側ドキュメント feedback sweep を行い、issue があれば bugfix として扱う。release-blocking issue がなければ残り rule の by-design 宣言で 0.12.x を閉じる。
-- `v0.13.0`: `v0.12.8` の stable 条件と `v0.12.9` の public confidence gate を満たしてから、MCP Registry / Hub 公開前の配布方式、`server.json`、security gate を決める。公開自体はまだ行わない。
+- `v0.12.21`: KatanA 側ドキュメント feedback sweep、`MD007` bad-fix 修正、reserved / ignored directory の default exclude、残り rule の by-design 宣言を完了し、0.12.x closeout 条件を満たした。
+- `v0.13.0`: `v0.12.21` release 後、MCP Registry / Hub 公開前の配布方式、`server.json`、security gate を決める。公開自体はまだ行わない。
 - `v0.14.0`: `v0.13.0` で選んだ package artifact と Registry metadata を実装し、公開まで進める。
 - `v0.15.0`: API-hosted LLM から直接使う必要が出た場合だけ、遠隔 MCP 接続（remote MCP transport）を設計・実装する。
 - `v0.16.0`: Introduce JSON schema and LSP entrypoint to enable editor auto-completion and real-time diagnostics.
@@ -62,7 +62,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | Precision fix+ continuous expansion for `v0.12.18` | `v0-12-18-md056-table-column-padding-safe-fix` | Added `MD029` regression fix for nested unordered-list interruption and `MD056` table-column safe-fix. |
 | Done | MD003 safe-fix and MD028 fix policy for `v0.12.19` | `v0-12-19-md003-md028-fix-policy` | Added fixture-backed `MD003` setext-to-ATX safe-fix and kept `MD028` diagnostic-only as a manual-intent by-design candidate for `v0.12.21`. |
 | Done | Performance measurement and hot path hardening for `v0.12.20` | `v0-12-20-performance-measurement-and-hotpath-hardening` | Completed post-`v0.12.19` measurement, fixed the `api_rule_catalog` metadata clone hot path, refreshed the baseline, and kept rule expansion frozen. |
-| P1 | KatanA feedback and 0.12.x closeout for `v0.12.21` | `v0-12-21-katana-feedback-and-012x-closeout` | Runs KatanA-side document feedback after `v0.12.20`; release-blocking issues are fixed here, otherwise remaining diagnostic-only rules get by-design reasons and 0.12.x closes. |
+| Done | KatanA feedback and 0.12.x closeout for `v0.12.21` | `v0-12-21-katana-feedback-and-012x-closeout` | Completed 524-file KatanA check/fix review, fixed the `MD007` bad-fix pattern, recorded release-blocking issues at 0, and closed remaining diagnostic-only rules with by-design reasons. |
 | P1 | MCP Registry and distribution planning for `v0.13.0` | `v0-13-0-mcp-registry-and-distribution-planning` | Proceed after release and user approval; defines package type, `server.json`, security review, and publish deferral before public Registry listing. |
 | Frozen | MCP package and Registry publication for `v0.14.0` | `v0-14-0-mcp-package-and-registry-publication` | Implements the selected MCP package artifact and publishes Registry / Hub metadata after readiness gates pass. |
 | Frozen | Remote MCP transport for `v0.15.0` | `v0-15-0-remote-mcp-transport` | Adds provider API reachable MCP transport only if local stdio support is not sufficient. |
@@ -100,8 +100,8 @@ Archived completed changes:
 
 ## Suggested Order
 
-1. Apply `v0-12-21-katana-feedback-and-012x-closeout`; it handles KatanA feedback issues discovered after `v0.12.20` and records the final by-design rule map.
-2. Apply `v0-13-0-mcp-registry-and-distribution-planning` only after `v0.12.21` has no release-blocking KatanA feedback issue and 0.12.x is marked DONE.
+1. Archive `v0-12-21-katana-feedback-and-012x-closeout` after release verification completes.
+2. Apply `v0-13-0-mcp-registry-and-distribution-planning` only after the `v0.12.21` release is published and 0.12.x remains release-blocking issue 0.
 3. Apply `v0-14-0-mcp-package-and-registry-publication` only after the `v0.13.0` package and security gates are complete.
 4. Apply `v0-15-0-remote-mcp-transport` only when API-hosted LLM usage is a concrete requirement; local stdio support is already covered by `v0.12.0`.
 5. Apply `v0-16-0-config-schema-and-editor-integration` after remote transport is stable.

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/design.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/design.md
@@ -9,7 +9,10 @@ KatanA 側の複数ドキュメントを読ませることで、synthetic fixtur
 
 ### Goals
 
+- CLI の directory traversal で、通常 git 管理しない予約領域を既定除外にする。
+- 予約領域を確認したい場合は、明示 opt-in で対象にできる。
 - KatanA feedback で出た issue を `v0.12.21` の対象として分類する。
+- `/tmp` の検証 worktree で `kml fix` を実行し、fix 後差分を全件確認する。
 - release-blocking な bug は `v0.12.21` で修正する。
 - 残り diagnostic-only rule の by-design 理由を公開表示に反映する。
 - 0.12.x を閉じ、`v0.13.0` の配布計画へ進める条件を明確にする。
@@ -17,6 +20,8 @@ KatanA 側の複数ドキュメントを読ませることで、synthetic fixtur
 ### Non-Goals
 
 - KatanA repository を required CI dependency にしない。
+- 元の KatanA checkout を直接書き換えない。
+- KatanA の `verify` branch を remote に push しない。
 - 全ての feedback を 0.12.x に詰め込まない。
 - 人間の意図が必要な unsafe fix を default safe-fix に混ぜない。
 
@@ -29,6 +34,7 @@ feedback は次の分類で扱う。
 - `false-positive`: 診断すべきでないものを診断した。
 - `false-negative`: 診断すべきものを見逃した。
 - `unsafe-fix-risk`: 自動修正すると意味が変わる可能性がある。
+- `bad-fix`: 診断は正しいが、自動修正後の Markdown が壊れる、または意味を変える。
 - `fmt-policy-gap`: formatter 方針の未定義。
 - `perf-regression`: 実文書で説明不能に遅い。
 - `docs-only`: 表示や説明だけ直せばよい。
@@ -56,11 +62,55 @@ release-blocking かどうかを先に決め、blocking だけを `v0.12.21` の
 `v0.12.21` の完了条件は、by-design 宣言だけではない。
 KatanA feedback 由来の release-blocking issue が 0 件であることも必要にする。
 
+### D-4. 予約領域は既定で再帰走査しない
+
+`node_modules` や `.git` のように、通常は git 管理せず、依存物・cache・生成物を置く directory は既定で lint / fix / fmt 対象外にする。
+これは `.gitignore` の有無に依存しない安全側の既定値とする。
+
+予約領域をあえて確認したい場合は、明示 option で対象に戻せるようにする。
+この option は `check`、`fix`、`fmt` の directory traversal で同じ意味を持つ。
+
+### D-5. KatanA fix 検証は隔離 worktree で行う
+
+KatanA の元 checkout は作業中差分やユーザー作業を含む可能性があるため、直接 fix しない。
+`/tmp` 配下に git worktree を作成し、local branch `verify` を使う。
+
+元 checkout に git 管理外 Markdown がある場合は、検証対象として必要なものを worktree 側に取り込み、baseline commit に含める。
+その後にまず `kml check --output json` を実行し、fix 前の diagnostics を保存する。
+この時点の check 結果は、diagnostics が出た file だけでなく、diagnostics 0 件の file も含めて全対象 file を評価対象にする。
+diagnostics 0 件という結果も「対象 file に対して何も検出しなかった」という check 結果として台帳に残す。
+check 評価台帳には、全対象 file ごとに diagnostics 数、rule 一覧、check 精査結果、根拠メモ、kml 側対応要否を記録する。
+check 評価台帳は全対象 file 数と同じ行数を持ち、`未評価` が 0 件になるまで完了扱いにしない。
+`markdownlint` など他実装との比較は、見逃し候補や誤検知候補を探すための補助線として使う。
+ただし他実装の結果を正解として扱わず、最終判断は markdownlint rule の仕様、KatanA 文書の文脈、kml の安全性契約を合わせて行う。
+仕様文書と他実装の挙動に差がある場合、または他実装側の false-positive / false-negative が疑われる場合は、markdownlint upstream issue / PR も確認する。
+他実装に合わせない判断をする場合も、台帳に理由を残す。
+check 側に release-blocking な false-positive / false-negative がある場合は、先に kml 側を修正し、再度 `kml check --output json` を実行して基準 check 結果を更新する。
+fix はその最適化後の基準 check 結果を前提に実行する。
+初回 check 後に得た fix 結果は観測資料であり、check 修正後の再実行なしに最終 release evidence として扱わない。
+続いて `kml fix --output json` を実行し、どの rule に対して何が適用されたかを保存する。
+fix 評価台帳にも、差分が出た file だけでなく差分 0 件の file を含め、全対象 file ごとに applied fix 数、rule 一覧、diff 有無、fix 精査結果、根拠メモ、kml 側対応要否を記録する。
+fix 評価台帳も全対象 file 数と同じ行数を持ち、`未評価` が 0 件になるまで完了扱いにしない。
+fix 後の git diff は、最適化後の check 結果と fix 結果を突き合わせて file / hunk 単位で確認する。
+check が正当で diagnostics 0 件と評価された file は、通常 fix 評価では `-` になる。
+その file に fix 差分が出た場合は、`check-fix-inconsistency` として扱い、check と fix の契約不一致を疑う。
+この突き合わせのため、JSON report には file ごとの applied fix detail を含める。
+事前 check 結果も正解として扱わず、diagnostic 自体の false-positive / false-negative 可能性を評価対象に含める。
+確認の目的は KatanA 文書側の採用判断ではなく、kml の誤検知、誤修正、意味変化リスクを見つけることである。
+大量の実ドキュメントで見つかった `check` の誤検知と `fix` の誤修正は、OSS library としての信頼性を直接下げるため release-blocking として扱う。
+差分が多い場合も file / hunk ごとに評価する。
+rule / change pattern の分類は進行管理の補助であり、最終評価は diff の周辺 Markdown 文脈を読んで行う。
+機械的な一致だけで安全判定せず、表示、リンク、見出し構造、code block、table の意味が変わる場合は kml 側の改善候補として扱う。
+
 ## Risks / Trade-offs
 
-- [Risk] KatanA 固有の文書に引きずられ、汎用 linter の境界を崩す。
+- Risk: KatanA 固有の文書に引きずられ、汎用 linter の境界を崩す。
   - Mitigation: finding は汎用 rule behavior として分類できるものだけ修正する。
-- [Risk] feedback を全部詰め込み、0.12.x が終わらない。
+- Risk: feedback を全部詰め込み、0.12.x が終わらない。
   - Mitigation: release-blocking と follow-up を明確に分ける。
-- [Risk] by-design 宣言が単なる未対応リストに見える。
+- Risk: by-design 宣言が単なる未対応リストに見える。
   - Mitigation: 各 rule に「なぜ safe-fix しないか」を短く書く。
+- Risk: 予約領域の既定除外で、意図的に lint したい生成済み Markdown を見落とす。
+  - Mitigation: 明示 opt-in option を提供し、help と regression test で挙動を固定する。
+- Risk: KatanA fix 検証で元 checkout の作業を壊す。
+  - Mitigation: `/tmp` worktree と baseline commit を使い、元 checkout には書き込まない。

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/proposal.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/proposal.md
@@ -5,7 +5,10 @@
 
 ## What Changes
 
+- CLI の再帰走査で、`node_modules` など通常 git 管理しない予約領域 directory を既定で対象外にし、明示 option で対象に戻せるようにする。
 - `v0.12.20` 完了後に KatanA 側の複数ドキュメントを external corpus として確認する。
+- `/tmp` 配下に KatanA の検証 worktree を作成し、local branch `verify` 上で git 管理外 Markdown も baseline commit に含めたうえで `kml fix` を実行する。
+- fix 後の差分を全件確認し、誤検知、誤 fix、危険な fix、docs-only の分類を残す。
 - KatanA feedback で見つかった issue は分類し、0.12.x closeout に必要なものを `v0.12.21` で修正する。
 - release-blocking ではない issue は、後続版の follow-up として明示する。
 - 残りの `Diagnostic only` / `Needs triage` ルールについて、safe-fix を実装しない理由を README、fixture matrix、関連 docs に反映する。
@@ -17,6 +20,7 @@
 
 ### Modified Capabilities
 
+- `cli-contract`: directory traversal は予約領域を既定除外し、明示 opt-in 時のみ対象に含める。
 - `dogfood-workflow`: KatanA 側ドキュメントを feedback sweep として扱い、finding を分類して `v0.12.21` の scope に取り込む。
 - `rule-coverage`: 残り diagnostic-only rule の by-design 理由を公開 rule map と fixture に反映する。
 - `release-readiness`: 0.12.x closeout から `v0.13.0` へ進む条件を明確にする。
@@ -24,6 +28,8 @@
 ## Impact
 
 - KatanA checkout を使う optional dogfood / public-confidence 実行
+- CLI directory traversal
+- CLI `check` / `fix` / `fmt` usage documentation
 - `README.md`
 - `docs/rule-fix-feasibility.md`
 - `docs/rule-coverage-dashboard.md`

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/cli-contract/spec.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/cli-contract/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: directory traversal SHALL exclude reserved directories by default
+
+CLI の directory traversal は、通常 git 管理しない予約領域 directory を既定で対象外にしなければならない（SHALL）。
+
+#### Scenario: 既定の directory traversal を実行する
+
+- **WHEN** user が `kml check`、`kml fix`、または `kml fmt` に directory path を渡す
+- **THEN** system は `.git`、`node_modules`、dependency cache、build output、coverage output のような広く共通する予約領域 directory へ既定では入らない
+- **THEN** system は予約領域配下の Markdown file を既定では診断せず、書き換えない
+- **THEN** system は `.gitignore` がなくても同じ既定除外を適用する
+
+### Requirement: reserved directory traversal SHALL require explicit opt-in
+
+予約領域 directory を lint / fix / fmt 対象に戻す場合、user の明示 opt-in が必要である（SHALL）。
+
+#### Scenario: 予約領域を明示的に対象にする
+
+- **WHEN** user が予約領域を含める CLI option を指定して directory path を渡す
+- **THEN** system は予約領域配下の Markdown file も対象候補に含める
+- **THEN** `check`、`fix`、`fmt` は同じ opt-in 意味を共有する
+- **THEN** usage documentation は既定除外と opt-in の意味を確認できる
+
+### Requirement: explicit ignored directory traversal SHALL require scoped opt-in
+
+`.gitignore` で除外された directory を明示的に対象へ戻す場合、走査全体ではなく明示 input 配下だけに効く opt-in を提供しなければならない（SHALL）。
+
+#### Scenario: gitignore 済み directory を明示的に fix する
+
+- **WHEN** user が `.gitignore` で除外された directory path を明示し、ignored path opt-in を指定して `kml fix` を実行する
+- **THEN** system はその明示 directory 配下の Markdown file を対象に含める
+- **THEN** system は他の ignored directory を広く対象に戻さない
+- **THEN** user は `--no-ignore` より狭い範囲で ignored directory を修正できる
+
+### Requirement: fix JSON SHALL expose applied fix details
+
+`fix --output json` と `check --fix --output json` は、差分評価で rule と変更内容を突き合わせられるように、file ごとの適用 fix 詳細を出力しなければならない（SHALL）。
+
+#### Scenario: safe fix が適用される
+
+- **WHEN** user が JSON output で safe fix を実行する
+- **THEN** system は file report に `fix_details` を含める
+- **THEN** 各 fix detail は少なくとも `rule_id`、適用 range、replacement、`applied` を含める
+- **THEN** 事後評価者は事前 diagnostic、fix result、git diff を file / hunk 単位で対応付けられる

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/dogfood-workflow/spec.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/dogfood-workflow/spec.md
@@ -11,6 +11,21 @@
 - **THEN** system は check-only 実行で KatanA 側ファイルを書き換えない
 - **THEN** system は finding を source path、rule、分類、対応方針とともに記録する
 
+### Requirement: KatanA fix sweep SHALL run in an isolated worktree
+
+KatanA feedback の fix sweep は、元 checkout ではなく隔離された `/tmp` worktree で実行しなければならない（SHALL）。
+
+#### Scenario: KatanA worktree で fix sweep を実行する
+
+- **WHEN** developer が `/Users/hiroyuki_furuno/works/private/katana` を external corpus として使う
+- **THEN** system は `/tmp` 配下に git worktree を作成する
+- **THEN** system は local branch `verify` 上で baseline commit を作る
+- **THEN** system は git 管理外 Markdown が検証対象に必要な場合、その Markdown も baseline commit に含める
+- **THEN** system は baseline commit 後に `kml check --output json` を実行し、fix 前 diagnostics を保存する
+- **THEN** system は `kml fix --output json` を実行し、rule ごとの適用内容を保存する
+- **THEN** system は fix 後差分を事前 diagnostics と fix result に対応づけて file / hunk 単位で確認する
+- **THEN** system は各差分を false-positive、false-negative、unsafe-fix-risk、bad-fix、fmt-policy-gap、perf-regression、docs-only に分類する
+
 ### Requirement: KatanA feedback issues SHALL be classified before v0.12.x closeout
 
 KatanA feedback で見つかった issue は、0.12.x closeout 前に分類されなければならない（SHALL）。
@@ -18,7 +33,7 @@ KatanA feedback で見つかった issue は、0.12.x closeout 前に分類さ�
 #### Scenario: feedback issue を分類する
 
 - **WHEN** KatanA feedback sweep で finding が見つかる
-- **THEN** system は finding を `false-positive`、`false-negative`、`unsafe-fix-risk`、`fmt-policy-gap`、`perf-regression`、`docs-only` のいずれかに分類する
+- **THEN** system は finding を `false-positive`、`false-negative`、`unsafe-fix-risk`、`bad-fix`、`fmt-policy-gap`、`perf-regression`、`docs-only` のいずれかに分類する
 - **THEN** system は release-blocking issue と non-blocking follow-up を分ける
 - **THEN** release-blocking issue は `v0.12.21` の bugfix 対象として tasks に残す
 

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/release-readiness/spec.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/specs/release-readiness/spec.md
@@ -11,6 +11,17 @@
 - **THEN** system は by-design 宣言対象が README と fixture matrix に反映されていることを確認する
 - **THEN** system は未分類の high-risk finding を残さない
 
+### Requirement: KatanA false positives and bad fixes SHALL block release until fixed
+
+KatanA feedback sweep で見つかった `check` の誤検知と `fix` の誤修正は、release 前に kml 側で修正されなければならない（SHALL）。
+
+#### Scenario: precision blocker を扱う
+
+- **WHEN** KatanA feedback sweep で false-positive または bad-fix が見つかる
+- **THEN** system は該当 pattern を kml repository の regression test に落とす
+- **THEN** system は production code を修正し、test 都合だけの挙動変更をしない
+- **THEN** system は該当 pattern が再発しないことを確認するまで release readiness を満たさない
+
 ### Requirement: v0.12.21 SHALL record follow-up issues separately from release blockers
 
 `v0.12.21` は、後続対応でよい issue と release blocker を混同してはならない（SHALL NOT）。

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/tasks.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/tasks.md
@@ -104,3 +104,4 @@ score が `100` 未満、または gate が失敗した場合は、この `tasks
 - [x] 7.5 `make dogfood` が `MD052` で失敗したため、字下げコードブロック内の参照風テキストを無視し、shortcut syntax 有効時も full reference を二重検出しない regression test / 実装修正を追加し、OpenSpec の `[Risk]` 表記は `Risk:` へ変更する
 - [x] 7.6 `make release-check` が coverage で失敗したため、coverage gate を `--lib --bins` 限定から workspace integration test 込みへ戻し、AST lint で再発防止する
 - [x] 7.7 最終 `release-check` 再実行で追加 failure がないことを確認する
+- [x] 7.8 PR CI の Windows job で `PathBuf::join("a/b")` 由来の path separator mismatch が出たため、test fixture path を component ごとの `join` に修正する

--- a/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/tasks.md
+++ b/openspec/changes/v0-12-21-katana-feedback-and-012x-closeout/tasks.md
@@ -1,46 +1,106 @@
 ## 0. 前提確認
 
-- [ ] 0.1 `v0.12.20` が release 済みで、`api_rule_catalog` cache 後の performance blocker が残っていないことを確認する
-- [ ] 0.2 `v0.12.19` の結果を確認し、`MD028` が safe-fix 実装済みか by-design 候補かを確定する
-- [ ] 0.3 KatanA checkout の場所を確認し、`KATANA_CHECKOUT` を使う実行方法を決める
+- [x] 0.1 `v0.12.20` が release 済みで、`api_rule_catalog` cache 後の performance blocker が残っていないことを確認する
+- [x] 0.2 `v0.12.19` の結果を確認し、`MD028` が safe-fix 実装済みか by-design 候補かを確定する
+- [x] 0.3 KatanA checkout の場所を確認し、`KATANA_CHECKOUT` を使う実行方法を決める
+- [x] 0.4 予約領域 directory の既定除外と明示 opt-in 方針を `v0.12.21` の実装対象として確定する
 
-## 1. KatanA feedback sweep
+## 1. CLI traversal default exclusions
 
-- [ ] 1.1 KatanA 側の対象 Markdown 文書群を確認する
-- [ ] 1.2 `KATANA_CHECKOUT=/path/to/katana make external-katana-dogfood` を実行する
-- [ ] 1.3 必要に応じて KatanA 側の追加ドキュメントを読み込み、再現条件を repo-local fixture に落とせるか判断する
-- [ ] 1.4 finding を `false-positive`、`false-negative`、`unsafe-fix-risk`、`fmt-policy-gap`、`perf-regression`、`docs-only` に分類する
-- [ ] 1.5 release-blocking issue がある場合、`v0.12.21` の bugfix task として明記する
-- [ ] 1.6 release-blocking ではない issue は後続版 follow-up として記録する
+- [x] 1.1 `node_modules`、`.git`、build/cache output など通常 git 管理しない directory を既定の再帰走査対象外にする仕様を確定する
+- [x] 1.2 明示 opt-in option で予約領域も対象にできる CLI 契約を定義する
+- [x] 1.3 `check`、`fix`、`fmt` の directory traversal regression test を先に追加する
+- [x] 1.4 production code を修正し、既定では予約領域配下の Markdown を読まず、書き換えないことを確認する
+- [x] 1.5 opt-in 実行時だけ予約領域配下の Markdown が対象になることを確認する
+- [x] 1.6 `fix --output json` と `check --fix --output json` が file ごとの applied fix detail を出力する regression test を追加する
+- [x] 1.7 gitignore 済み directory を明示 input として渡した場合だけ対象へ戻せる scoped opt-in を追加する
 
-## 2. Feedback 由来 bugfix
+## 2. KatanA feedback sweep
 
-- [ ] 2.1 release-blocking false-positive / false-negative がある場合、rule-local regression test を先に追加する
-- [ ] 2.2 必要に応じて document-level fixture または public confidence fixture に再発条件を追加する
-- [ ] 2.3 production code を修正し、テスト都合だけの挙動変更を避ける
-- [ ] 2.4 fix 事故がある場合、default safe-fix allowlist または fix range を見直す
+- [x] 2.1 KatanA 側の対象 Markdown 文書群を確認する
+- [x] 2.2 `/Users/hiroyuki_furuno/works/private/katana` から `/tmp` 配下へ git worktree を作成し、local branch `verify` を切る
+- [x] 2.3 元 checkout にある git 管理外 Markdown があれば検証 worktree へ取り込み、baseline commit に含める
+- [x] 2.4 `KATANA_CHECKOUT=/tmp/... make external-katana-dogfood` を実行する
+- [x] 2.5 検証 worktree で `kml check --output json` を実行し、fix 前の diagnostics と全対象 file inventory を保存する
+- [x] 2.6 check 結果は diagnostics が出た file だけでなく、diagnostics 0 件の file も含めて全対象 file を check 評価台帳に記録する
+- [x] 2.7 check 評価台帳には全対象 file ごとに「diagnostics 数」「rule 一覧」「check 精査結果」「根拠メモ」「kml 側対応要否」を記録する
+- [x] 2.8 check 評価台帳の行数が全対象 file 数と一致し、`未評価` が 0 件になるまで check 評価を完了扱いにしない
+- [x] 2.9 全対象 file について「diagnostics あり」「diagnostics なし」「check 誤検知候補」「check 見逃し候補」「未評価」を分けて check の正当性を評価する
+- [x] 2.9a markdownlint など他実装との差が仕様差か実装側 issue かを判断するため、必要な rule は upstream issue / PR も確認して台帳に根拠を残す
+- [x] 2.10 check 側に release-blocking な false-positive / false-negative がある場合、先に kml 側の bugfix を行い、再度 `kml check --output json` を実行して基準 check 結果を更新する
+- [x] 2.11 最適化後の基準 check 結果を前提に、検証 worktree で `kml fix --output json` を実行し、どの rule に対して何が適用されたかを保存する
+- [x] 2.12 fix 結果は差分が出た file だけでなく、差分 0 件の file も含めて全対象 file を fix 評価台帳に記録する
+- [x] 2.13 fix 評価台帳には全対象 file ごとに「applied fix 数」「rule 一覧」「diff 有無」「fix 精査結果」「根拠メモ」「kml 側対応要否」を記録する
+- [x] 2.14 fix 評価台帳の行数が全対象 file 数と一致し、`未評価` が 0 件になるまで fix 評価を完了扱いにしない
+- [x] 2.15 fix 後の git diff を保存し、最適化後の check 結果、fix 結果、diff を突き合わせる
+- [x] 2.16 全対象 file について check 評価と fix 評価を突き合わせ、「check 正当かつ diagnostics 0 件なのに fix 差分あり」を `check-fix-inconsistency` として検出する
+- [x] 2.17 fix 後の差分を file / hunk ごとに周辺 Markdown 文脈込みで確認し、各差分について「基準 diagnostic は正当か」「どの rule に対する fix か」「fix は正当か」「kml 側 bug か」を評価する
+- [x] 2.18 必要に応じて KatanA 側の追加ドキュメントを読み込み、再現条件を repo-local fixture に落とせるか判断する
+- [x] 2.19 finding を `false-positive`、`false-negative`、`check-fix-inconsistency`、`unsafe-fix-risk`、`bad-fix`、`fmt-policy-gap`、`perf-regression`、`docs-only` に分類する
+- [x] 2.20 release-blocking issue がある場合、`v0.12.21` の bugfix task として明記する
+- [x] 2.21 release-blocking ではない issue は後続版 follow-up として記録する
 
-## 3. by-design 宣言
+## 3. Feedback 由来 bugfix
 
-- [ ] 3.1 `MD001`、`MD013`、`MD024`、`MD033`、`MD041`、`MD042`、`MD043`、`MD045`、`MD059` の safe-fix 非提供理由を確定する
-- [ ] 3.2 `MD028` が `v0.12.19` で safe-fix 実装されなかった場合、by-design 対象に追加する
-- [ ] 3.3 `README.md` の rule map で `Needs triage` を by-design 理由付き表示へ更新する
-- [ ] 3.4 `tests/fixtures/rule-fixture-matrix.json` と `.md` を README と揃える
-- [ ] 3.5 `docs/rule-fix-feasibility.md` と `docs/rule-coverage-dashboard.md` を必要に応じて更新する
+- [x] 3.0 KatanA worktree の差分自体を成果物にせず、検出した pattern を kml 側の regression test / implementation に戻す
+- [x] 3.1 release-blocking false-positive / false-negative / bad-fix がある場合、rule-local regression test を先に追加する
+- [x] 3.2 必要に応じて document-level fixture または public confidence fixture に再発条件を追加する
+- [x] 3.3 production code を修正し、テスト都合だけの挙動変更を避ける
+- [x] 3.4 fix 事故がある場合、default safe-fix allowlist または fix range を見直す
+- [x] 3.5 KatanA 由来の false-positive / bad-fix が 0 件になるまで release-ready としない
+- [x] 3.6 作業中に検出した `MD007` 初回 bad-fix を regression test 化し、ordered list 配下の unordered child を本文開始位置に保つ
+- [x] 3.7 `make lint` で検出した needless borrow を修正し、lint 回避ではなく実装修正で解消する
+- [x] 3.8 `make ast-lint` で検出した README rule map の不整合を、rule metadata / fixture / docs の整合修正で解消する
 
-## 4. リリース記録更新
+## 4. by-design 宣言
 
-- [ ] 4.1 `CHANGELOG.md` に `v0.12.21` を追加する
-- [ ] 4.2 `Cargo.toml` を `0.12.21` に更新し、`Cargo.lock` を更新する
-- [ ] 4.3 `openspec/changes/active-roadmap.md` に 0.12.x DONE と `v0.13.0` へ進む条件を反映する
-- [ ] 4.4 KatanA feedback の release-blocking issue が 0 件であることを release evidence に残す
+- [x] 4.1 `MD001`、`MD013`、`MD024`、`MD033`、`MD041`、`MD042`、`MD043`、`MD045`、`MD059` の safe-fix 非提供理由を確定する
+- [x] 4.2 `MD028` が `v0.12.19` で safe-fix 実装されなかった場合、by-design 対象に追加する
+- [x] 4.3 `README.md` の rule map で `Needs triage` を by-design 理由付き表示へ更新する
+- [x] 4.4 `tests/fixtures/rule-fixture-matrix.json` と `.md` を README と揃える
+- [x] 4.5 `docs/rule-fix-feasibility.md` と `docs/rule-coverage-dashboard.md` を必要に応じて更新する
 
-## 5. Quality Gates
+## 5. リリース記録更新
 
-- [ ] 5.1 `make fmt-check` を実行する
-- [ ] 5.2 `make lint` を実行する
-- [ ] 5.3 `make test` を実行する
-- [ ] 5.4 `make ast-lint` を実行する
-- [ ] 5.5 `make dogfood` を実行する
-- [ ] 5.6 `make public-confidence` を実行する
-- [ ] 5.7 `make release-check VERSION=v0.12.21` を実行する
+- [x] 5.1 `CHANGELOG.md` に `v0.12.21` を追加する
+- [x] 5.2 `Cargo.toml` を `0.12.21` に更新し、`Cargo.lock` を更新する
+- [x] 5.3 `openspec/changes/active-roadmap.md` に 0.12.x DONE と `v0.13.0` へ進む条件を反映する
+- [x] 5.4 KatanA feedback の release-blocking issue が 0 件であることを release evidence に残す
+
+## 5a. 品質評価スコア
+
+Release 条件は `100/100`、release-blocking issue `0`、check / fix 台帳の `未評価` `0`、`check-fix-inconsistency` `0` とする。
+score が `100` 未満、または gate が失敗した場合は、この `tasks.md` に追加 task を記録し、修正して同じ gate を再実行する。
+
+| 項目 | 配点 | 現在 | 完了条件 |
+| --- | ---: | ---: | --- |
+| check 精度評価 | 20 | 20 | 524 files 全件評価、false-positive / false-negative release blocker 0 |
+| fix 精度評価 | 20 | 20 | 524 files / 82 hunks 全件評価、bad-fix release blocker 0 |
+| 再発防止 | 15 | 15 | KatanA 由来 pattern を regression test と production fix に戻す |
+| traversal 安全性 | 10 | 10 | reserved / ignored directory の default exclude と opt-in contract が test 済み |
+| by-design 整合 | 10 | 10 | README / fixture matrix / docs / dashboard が manual-required 理由で一致 |
+| release 記録 | 10 | 10 | CHANGELOG / version / roadmap / release evidence が更新済み |
+| 品質 gate | 15 | 15 | `fmt-check`、`lint`、`test`、`ast-lint`、`dogfood`、`public-confidence`、`release-check`、`release-task-ledger-check` が成功 |
+| 合計 | 100 | 100 | 100/100 で release-ready |
+
+## 6. Quality Gates
+
+- [x] 6.1 `make fmt-check` を実行する
+- [x] 6.2 `make lint` を実行する
+- [x] 6.3 `make test` を実行する
+- [x] 6.4 `make ast-lint` を実行する
+- [x] 6.5 `make dogfood` を実行する
+- [x] 6.6 `make public-confidence` を実行する
+- [x] 6.7 `make release-check VERSION=v0.12.21` を実行する
+- [x] 6.8 `make release-task-ledger-check VERSION=v0.12.21` を実行する
+- [x] 6.9 `scripts/openspec validate v0-12-21-katana-feedback-and-012x-closeout --strict` を実行する
+
+## 7. 作業中に検出した追加作業
+
+- [x] 7.1 古い初回 fix 証跡は残し、最終評価には `fix-after-check-review.*` を使うことを明記する
+- [x] 7.2 `vendor/egui_commonmark_upstream/**` の 2 件は kml の誤検知 / 誤修正ではなく、consumer 側の対象範囲判断として後続検討に分類する
+- [x] 7.3 `rule-fixture-matrix.json` の `manual_required` 件数を 13 に更新し、dashboard を再生成する
+- [x] 7.4 作業管理の抜け漏れを防ぐため、`make release-task-ledger-check` を追加し、`tasks.md` の未完了 task と 100/100 スコアを機械的に検査する
+- [x] 7.5 `make dogfood` が `MD052` で失敗したため、字下げコードブロック内の参照風テキストを無視し、shortcut syntax 有効時も full reference を二重検出しない regression test / 実装修正を追加し、OpenSpec の `[Risk]` 表記は `Risk:` へ変更する
+- [x] 7.6 `make release-check` が coverage で失敗したため、coverage gate を `--lib --bins` 限定から workspace integration test 込みへ戻し、AST lint で再発防止する
+- [x] 7.7 最終 `release-check` 再実行で追加 failure がないことを確認する

--- a/scripts/ci/coverage.sh
+++ b/scripts/ci/coverage.sh
@@ -20,12 +20,12 @@ BASELINE_FILE=${COVERAGE_BASELINE_FILE:-scripts/ci/coverage-baseline.txt}
 info "Cleaning up old coverage data..."
 cargo llvm-cov clean --workspace
 
-info "Running workspace lib/bin tests with llvm-cov (-j $JOBS)..."
+info "Running workspace tests with llvm-cov (-j $JOBS)..."
 if [ -n "$COVERAGE_IGNORE" ]; then
-    cargo llvm-cov --no-report --jobs "$JOBS" --workspace --lib --bins -q \
+    cargo llvm-cov --no-report --jobs "$JOBS" --workspace -q \
         -- --test-threads="$JOBS"
 else
-    cargo llvm-cov --no-report --jobs "$JOBS" --workspace --lib --bins -q \
+    cargo llvm-cov --no-report --jobs "$JOBS" --workspace -q \
         -- --test-threads="$JOBS"
 fi
 

--- a/scripts/release/verify-task-ledger.py
+++ b/scripts/release/verify-task-ledger.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Verify that the OpenSpec task ledger is release-ready."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Release version such as v0.12.21")
+    parser.add_argument("--change", help="OpenSpec change id or tasks.md path")
+    parser.add_argument(
+        "--allow-open-containing",
+        action="append",
+        default=[],
+        help="Allow an unchecked task only when its line contains this text",
+    )
+    return parser.parse_args()
+
+
+def normalized_change_prefix(version: str) -> str:
+    version_bare = version.removeprefix("v")
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version_bare):
+        raise SystemExit(f"Invalid release version: {version}")
+    return "v" + version_bare.split("+", maxsplit=1)[0].split("-", maxsplit=1)[0].replace(".", "-")
+
+
+def resolve_task_path(args: argparse.Namespace) -> pathlib.Path:
+    if args.change:
+        candidate = pathlib.Path(args.change)
+        if candidate.is_file():
+            return candidate
+        direct = pathlib.Path("openspec/changes") / args.change / "tasks.md"
+        if direct.is_file():
+            return direct
+        raise SystemExit(f"OpenSpec tasks.md was not found for --change {args.change!r}")
+
+    prefix = normalized_change_prefix(args.version)
+    active = sorted(pathlib.Path("openspec/changes").glob(f"{prefix}-*/tasks.md"))
+    archived = sorted(pathlib.Path("openspec/changes/archive").glob(f"*-{prefix}-*/tasks.md"))
+    matches = active or archived
+    if not matches:
+        raise SystemExit(f"OpenSpec tasks.md was not found for release {args.version}")
+    if len(matches) > 1:
+        paths = "\n".join(str(path) for path in matches)
+        raise SystemExit(f"Multiple OpenSpec tasks.md files matched {args.version}:\n{paths}")
+    return matches[0]
+
+
+def open_task_violations(lines: list[str], allow_open_containing: list[str]) -> list[str]:
+    violations = []
+    for line_number, line in enumerate(lines, start=1):
+        if not re.match(r"\s*-\s+\[[ /]\]", line):
+            continue
+        if any(token in line for token in allow_open_containing):
+            continue
+        violations.append(f"{line_number}: {line}")
+    return violations
+
+
+def score_violations(lines: list[str]) -> list[str]:
+    violations = []
+    total_seen = False
+    score_row = re.compile(r"^\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|")
+    for line_number, line in enumerate(lines, start=1):
+        match = score_row.match(line)
+        if not match:
+            continue
+        label = match.group(1).strip()
+        maximum = int(match.group(2))
+        current = int(match.group(3))
+        if label == "項目":
+            continue
+        if label == "合計":
+            total_seen = True
+        if current != maximum:
+            violations.append(f"{line_number}: {label} score is {current}/{maximum}")
+    if not total_seen:
+        violations.append("品質評価スコア table is missing a 合計 row")
+    return violations
+
+
+def main() -> int:
+    args = parse_args()
+    task_path = resolve_task_path(args)
+    lines = task_path.read_text(encoding="utf-8").splitlines()
+    violations = []
+    violations.extend(open_task_violations(lines, args.allow_open_containing))
+    violations.extend(score_violations(lines))
+    if violations:
+        print(f"Release task ledger is not ready: {task_path}", file=sys.stderr)
+        for violation in violations:
+            print(f"- {violation}", file=sys.stderr)
+        return 1
+    print(f"Release task ledger passed: {task_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -34,6 +34,8 @@ pub struct Cli {
     pub include: Vec<String>,
     pub exclude: Vec<String>,
     pub respect_gitignore: bool,
+    pub include_ignored: bool,
+    pub include_reserved: bool,
     pub force_exclude: bool,
     pub statistics: bool,
     pub quiet: bool,
@@ -56,6 +58,8 @@ impl Default for Cli {
             include: Vec::new(),
             exclude: Vec::new(),
             respect_gitignore: true,
+            include_ignored: false,
+            include_reserved: false,
             force_exclude: false,
             statistics: false,
             quiet: false,
@@ -78,6 +82,8 @@ pub fn parse_args(args: Vec<String>) -> Cli {
     let mut include = Vec::new();
     let mut exclude = Vec::new();
     let mut respect_gitignore = true;
+    let mut include_ignored = false;
+    let mut include_reserved = false;
     let mut force_exclude = false;
     let mut statistics = false;
     let mut quiet = false;
@@ -155,6 +161,8 @@ pub fn parse_args(args: Vec<String>) -> Cli {
             }
             "--respect-gitignore" => respect_gitignore = true,
             "--no-ignore" => respect_gitignore = false,
+            "--include-ignored" => include_ignored = true,
+            "--include-reserved" => include_reserved = true,
             "--force-exclude" => force_exclude = true,
             "--statistics" => statistics = true,
             "--quiet" => quiet = true,
@@ -177,6 +185,8 @@ pub fn parse_args(args: Vec<String>) -> Cli {
         include,
         exclude,
         respect_gitignore,
+        include_ignored,
+        include_reserved,
         force_exclude,
         statistics,
         quiet,
@@ -292,12 +302,16 @@ mod tests {
             "--exclude".to_string(),
             "**/skip.md".to_string(),
             "--no-ignore".to_string(),
+            "--include-ignored".to_string(),
+            "--include-reserved".to_string(),
             "--force-exclude".to_string(),
         ]);
 
         assert_eq!(cli.include, vec!["**/*.md"]);
         assert_eq!(cli.exclude, vec!["**/skip.md"]);
         assert!(!cli.respect_gitignore);
+        assert!(cli.include_ignored);
+        assert!(cli.include_reserved);
         assert!(cli.force_exclude);
     }
 

--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -235,7 +235,7 @@ mod tests {
             canonical_paths(&files),
             vec![
                 canonical_path(dir.join("README.md")),
-                canonical_path(dir.join("docs/guide.markdown"))
+                canonical_path(dir.join("docs").join("guide.markdown"))
             ]
         );
         let _ = fs::remove_dir_all(dir);

--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -24,6 +24,7 @@ pub(crate) fn expand_inputs(cli: &Cli) -> Result<Vec<PathBuf>, InputExpandError>
             markdown_files_in_dir(
                 &env::current_dir().map_err(|err| InputExpandError::Filesystem(err.to_string()))?,
                 cli.respect_gitignore,
+                cli.include_reserved,
             )
             .map_err(InputExpandError::Filesystem)?,
             cli,
@@ -48,8 +49,9 @@ pub(crate) fn expand_inputs(cli: &Cli) -> Result<Vec<PathBuf>, InputExpandError>
     let mut expanded = Vec::new();
     for path in paths {
         if path.is_dir() {
+            let respect_gitignore = cli.respect_gitignore && !cli.include_ignored;
             expanded.extend(
-                markdown_files_in_dir(&path, cli.respect_gitignore)
+                markdown_files_in_dir(&path, respect_gitignore, cli.include_reserved)
                     .map_err(InputExpandError::Filesystem)?,
             );
         } else {
@@ -65,9 +67,13 @@ fn has_glob_chars(input: &str) -> bool {
     input.contains('*') || input.contains('?') || input.contains('[')
 }
 
-fn markdown_files_in_dir(dir: &Path, respect_gitignore: bool) -> Result<Vec<PathBuf>, String> {
+fn markdown_files_in_dir(
+    dir: &Path,
+    respect_gitignore: bool,
+    include_reserved: bool,
+) -> Result<Vec<PathBuf>, String> {
     let mut paths = Vec::new();
-    collect_markdown_files(dir, &mut paths, respect_gitignore)?;
+    collect_markdown_files(dir, &mut paths, respect_gitignore, include_reserved)?;
     paths.sort();
     Ok(paths)
 }
@@ -76,17 +82,22 @@ fn collect_markdown_files(
     dir: &Path,
     paths: &mut Vec<PathBuf>,
     respect_gitignore: bool,
+    include_reserved: bool,
 ) -> Result<(), String> {
     let (tx, rx) = mpsc::channel();
-    let walker = WalkBuilder::new(dir)
+    let mut builder = WalkBuilder::new(dir);
+    builder
         .hidden(false)
         .parents(true)
         .ignore(respect_gitignore)
         .git_ignore(respect_gitignore)
         .git_global(respect_gitignore)
         .git_exclude(respect_gitignore)
-        .require_git(false)
-        .build_parallel();
+        .require_git(false);
+    if !include_reserved {
+        builder.filter_entry(|entry| !is_reserved_directory(entry.path()));
+    }
+    let walker = builder.build_parallel();
 
     walker.run(|| {
         let tx = tx.clone();
@@ -150,6 +161,31 @@ fn is_markdown_file(path: &Path) -> bool {
             extension == "md" || extension == "markdown"
         })
         .unwrap_or(false)
+}
+
+fn is_reserved_directory(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(is_reserved_directory_name)
+}
+
+fn is_reserved_directory_name(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | ".cache"
+            | ".next"
+            | ".turbo"
+            | "node_modules"
+            | "bower_components"
+            | "target"
+            | "dist"
+            | "build"
+            | "coverage"
+            | "out"
+    )
 }
 
 #[cfg(test)]

--- a/src/cli/reporter.rs
+++ b/src/cli/reporter.rs
@@ -104,6 +104,7 @@ pub(crate) struct FileReport {
     pub(crate) path: String,
     pub(crate) diagnostics: Vec<crate::LintResult>,
     pub(crate) applied_fixes: usize,
+    pub(crate) fix_details: Vec<crate::FixDetail>,
     pub(crate) changed: bool,
 }
 
@@ -131,6 +132,7 @@ impl LocalizedCliReport {
                         .map(|diagnostic| LocalizedDiagnostic::from_result(diagnostic, locale))
                         .collect(),
                     applied_fixes: file.applied_fixes,
+                    fix_details: file.fix_details.clone(),
                     changed: file.changed,
                 })
                 .collect(),
@@ -148,6 +150,7 @@ struct LocalizedFileReport {
     path: String,
     diagnostics: Vec<LocalizedDiagnostic>,
     applied_fixes: usize,
+    fix_details: Vec<crate::FixDetail>,
     changed: bool,
 }
 
@@ -468,6 +471,7 @@ mod tests {
                     fix: None,
                 }],
                 applied_fixes: 0,
+                fix_details: Vec::new(),
                 changed: false,
             }],
             errors: Vec::new(),
@@ -524,6 +528,7 @@ mod tests {
                     }),
                 }],
                 applied_fixes: 0,
+                fix_details: Vec::new(),
                 changed: false,
             }],
             errors: Vec::new(),
@@ -570,6 +575,7 @@ mod tests {
                     fix: None,
                 }],
                 applied_fixes: 0,
+                fix_details: Vec::new(),
                 changed: false,
             }],
             errors: Vec::new(),
@@ -615,6 +621,7 @@ mod tests {
                     }),
                 }],
                 applied_fixes: 0,
+                fix_details: Vec::new(),
                 changed: false,
             }],
             errors: Vec::new(),

--- a/src/cli/workflow/check.rs
+++ b/src/cli/workflow/check.rs
@@ -88,6 +88,7 @@ pub(super) fn run_check_like(
                 content: fixed_content,
                 diagnostics,
                 applied_fixes,
+                fix_details,
             } = apply_fixes_until_stable(
                 &content,
                 &path,
@@ -110,6 +111,7 @@ pub(super) fn run_check_like(
                 path: path.display().to_string(),
                 diagnostics,
                 applied_fixes,
+                fix_details,
                 changed,
             });
         } else {
@@ -117,6 +119,7 @@ pub(super) fn run_check_like(
                 path: path.display().to_string(),
                 diagnostics: results,
                 applied_fixes: 0,
+                fix_details: Vec::new(),
                 changed: false,
             });
         }
@@ -201,6 +204,7 @@ fn run_stdin_check_like(
                     path: "<stdin>".to_string(),
                     diagnostics: fixed.diagnostics,
                     applied_fixes: fixed.applied_fixes,
+                    fix_details: fixed.fix_details,
                     changed: fixed.content != content,
                 }],
                 errors: Vec::new(),
@@ -246,6 +250,7 @@ fn run_stdin_check_like(
             path: "<stdin>".to_string(),
             diagnostics,
             applied_fixes: 0,
+            fix_details: Vec::new(),
             changed: false,
         }],
         errors: Vec::new(),

--- a/src/cli/workflow/common.rs
+++ b/src/cli/workflow/common.rs
@@ -8,6 +8,7 @@ pub(super) struct FixedContent {
     pub(super) content: String,
     pub(super) diagnostics: Vec<crate::LintResult>,
     pub(super) applied_fixes: usize,
+    pub(super) fix_details: Vec<crate::FixDetail>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -62,6 +63,7 @@ pub(super) fn apply_fixes_until_stable(
     let mut content = content.to_string();
     let mut diagnostics = initial_results;
     let mut applied_fixes = 0;
+    let mut fix_details = Vec::new();
 
     for _ in 0..MAX_FIX_PASSES {
         if !diagnostics
@@ -81,6 +83,7 @@ pub(super) fn apply_fixes_until_stable(
         }
 
         applied_fixes += fixed.applied_fixes;
+        fix_details.extend(fixed.details);
         content = fixed.content;
         diagnostics = lint_for_path(file_path, &content, options).map_err(|err| err.to_string())?;
     }
@@ -89,6 +92,7 @@ pub(super) fn apply_fixes_until_stable(
         content,
         diagnostics,
         applied_fixes,
+        fix_details,
     })
 }
 

--- a/src/cli/workflow/fmt.rs
+++ b/src/cli/workflow/fmt.rs
@@ -72,6 +72,7 @@ pub(super) fn run_fmt(cli: &Cli, locale: Locale) -> Result<i32, String> {
             path: path.display().to_string(),
             diagnostics: Vec::new(),
             applied_fixes: formatted.applied_operations,
+            fix_details: Vec::new(),
             changed,
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,6 @@ mod tests {
         let content = "No heading here.\n\n```rust\ncode\n```\n~~~\ncode\n~~~\n    indented\n*em* and _em_\n**strong** and __strong__\nmarkdownlint and github\nlink [fragment](#frag)\n[ref][]\n[dup]: https://example.com\n[dup]: https://example.com/2\ninline [link](https://example.com)\n| a | b |\n|---|---\n  c | d\n";
         let options = LintOptions::default();
         let results = lint(content, &options).expect("lint should succeed");
-        assert!(results.iter().any(|result| result.rule_id == "MD043"));
         assert!(results.iter().any(|result| result.rule_id == "MD046"));
         assert!(results.iter().any(|result| result.rule_id == "MD048"));
         assert!(results.iter().any(|result| result.rule_id == "MD049"));

--- a/src/rules/markdown/document.rs
+++ b/src/rules/markdown/document.rs
@@ -35,6 +35,13 @@ pub struct BlockRange {
     pub fence: FenceKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FenceLineMarker {
+    pub(crate) kind: FenceKind,
+    pub(crate) length: usize,
+    pub(crate) info_start: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Heading<'a> {
     pub line: usize,
@@ -373,11 +380,11 @@ fn extract_code_blocks(lines: &[LineInfo<'_>]) -> Vec<BlockRange> {
     let mut blocks = Vec::new();
     let mut open: Option<(usize, FenceKind, usize)> = None;
     for (idx, line) in lines.iter().enumerate() {
-        let Some((kind, length)) = fence_marker(line.text.trim_start()) else {
+        let Some(marker) = fence_line_marker(line.text) else {
             continue;
         };
         if let Some((start, start_kind, start_length)) = open {
-            if start_kind == kind && length >= start_length {
+            if start_kind == marker.kind && marker.length >= start_length {
                 blocks.push(BlockRange {
                     start_line: start,
                     end_line: idx,
@@ -385,12 +392,12 @@ fn extract_code_blocks(lines: &[LineInfo<'_>]) -> Vec<BlockRange> {
                         start: lines[start].content_range.start,
                         end: line.full_range.end,
                     },
-                    fence: kind,
+                    fence: marker.kind,
                 });
                 open = None;
             }
         } else {
-            open = Some((idx, kind, length));
+            open = Some((idx, marker.kind, marker.length));
         }
     }
     if let Some((start, kind, _)) = open {
@@ -407,6 +414,45 @@ fn extract_code_blocks(lines: &[LineInfo<'_>]) -> Vec<BlockRange> {
         }
     }
     blocks
+}
+
+pub(crate) fn fence_line_marker(line: &str) -> Option<FenceLineMarker> {
+    let (rest, offset) = strip_blockquote_prefix(line);
+    direct_fence_marker(rest, offset).or_else(|| list_item_fence_marker(rest, offset))
+}
+
+fn strip_blockquote_prefix(mut rest: &str) -> (&str, usize) {
+    let mut offset = 0;
+    loop {
+        let spaces = leading_space_count(rest);
+        rest = &rest[spaces..];
+        offset += spaces;
+        let Some(after_marker) = rest.strip_prefix('>') else {
+            return (rest, offset);
+        };
+        rest = after_marker;
+        offset += 1;
+        if rest.starts_with(' ') {
+            rest = &rest[1..];
+            offset += 1;
+        }
+    }
+}
+
+fn list_item_fence_marker(rest: &str, offset: usize) -> Option<FenceLineMarker> {
+    let marker_len = list_marker_len(rest)?;
+    let after_marker = &rest[marker_len..];
+    let spaces = leading_space_count(after_marker);
+    direct_fence_marker(&after_marker[spaces..], offset + marker_len + spaces)
+}
+
+fn direct_fence_marker(rest: &str, offset: usize) -> Option<FenceLineMarker> {
+    let (kind, length) = fence_marker(rest)?;
+    Some(FenceLineMarker {
+        kind,
+        length,
+        info_start: offset + length,
+    })
 }
 
 fn fence_marker(trimmed: &str) -> Option<(FenceKind, usize)> {
@@ -426,6 +472,27 @@ fn fence_marker(trimmed: &str) -> Option<(FenceKind, usize)> {
     } else {
         None
     }
+}
+
+fn list_marker_len(rest: &str) -> Option<usize> {
+    let bytes = rest.as_bytes();
+    if let [b'-' | b'*' | b'+', b' ', ..] = bytes {
+        return Some(2);
+    }
+    let digit_count = bytes
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_count == 0 {
+        return None;
+    }
+    let marker = *bytes.get(digit_count)?;
+    let space = *bytes.get(digit_count + 1)?;
+    ((marker == b'.' || marker == b')') && space == b' ').then_some(digit_count + 2)
+}
+
+fn leading_space_count(input: &str) -> usize {
+    input.bytes().take_while(|byte| *byte == b' ').count()
 }
 
 fn extract_headings<'a>(lines: &[LineInfo<'a>], code_blocks: &[BlockRange]) -> Vec<Heading<'a>> {

--- a/src/rules/markdown/helpers.rs
+++ b/src/rules/markdown/helpers.rs
@@ -43,7 +43,11 @@ impl RuleHelpers {
 
     /// Returns the ordered list number prefix if present.
     pub fn get_ordered_number(trimmed: &str) -> Option<u32> {
-        let dot_pos = trimmed.find(". ")?;
+        let dot_pos = trimmed.find('.')?;
+        let after_marker = &trimmed[dot_pos + 1..];
+        if !after_marker.is_empty() && !after_marker.starts_with(char::is_whitespace) {
+            return None;
+        }
         let prefix = &trimmed[..dot_pos];
         prefix.parse::<u32>().ok()
     }

--- a/src/rules/markdown/rules/content.rs
+++ b/src/rules/markdown/rules/content.rs
@@ -1,6 +1,6 @@
 use crate::rules::markdown::{
-    DiagnosticRange, DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule,
-    OfficialRuleMeta, RuleParityStatus,
+    fence_line_marker, DiagnosticRange, DiagnosticSeverity, DocumentContext, MarkdownDiagnostic,
+    MarkdownRule, OfficialRuleMeta, RuleParityStatus,
 };
 use crate::types::RuleConfig;
 use std::path::Path;
@@ -45,17 +45,14 @@ impl MarkdownRule for FencedCodeLanguageRule {
         let mut diagnostics = Vec::new();
         for block in ctx.code_blocks() {
             let line = &ctx.lines()[block.start_line];
-            let trimmed = line.text.trim_start();
-            let after_fence = trimmed.trim_start_matches('`').trim_start_matches('~');
+            let Some(marker) = fence_line_marker(line.text) else {
+                continue;
+            };
+            let after_fence = &line.text[marker.info_start..];
             if !after_fence.trim().is_empty() {
                 continue;
             }
-            let indent = line.text.len() - trimmed.len();
-            let fence_len = trimmed
-                .chars()
-                .take_while(|ch| *ch == '`' || *ch == '~')
-                .count();
-            let column = indent + fence_len + 1;
+            let column = marker.info_start + 1;
             diagnostics.push(MarkdownDiagnostic {
                 file: ctx.file_path().to_path_buf(),
                 severity: DiagnosticSeverity::Warning,

--- a/src/rules/markdown/rules/fences.rs
+++ b/src/rules/markdown/rules/fences.rs
@@ -31,7 +31,9 @@ impl MarkdownRule for BlanksAroundFencesRule {
         let mut diagnostics = Vec::new();
 
         for block in ctx.code_blocks() {
-            if block.start_line > 0 && !ctx.lines()[block.start_line - 1].text.trim().is_empty() {
+            if block.start_line > 0
+                && !is_blank_around_fence(ctx.lines()[block.start_line - 1].text)
+            {
                 diagnostics.push(fence_blank_fix(
                     ctx,
                     block.start_line,
@@ -40,7 +42,7 @@ impl MarkdownRule for BlanksAroundFencesRule {
                 ));
             }
             if block.end_line + 1 < ctx.lines().len()
-                && !ctx.lines()[block.end_line + 1].text.trim().is_empty()
+                && !is_blank_around_fence(ctx.lines()[block.end_line + 1].text)
             {
                 diagnostics.push(fence_blank_fix(
                     ctx,
@@ -53,6 +55,21 @@ impl MarkdownRule for BlanksAroundFencesRule {
 
         diagnostics
     }
+}
+
+fn is_blank_around_fence(line: &str) -> bool {
+    line.trim().is_empty() || is_blank_blockquote_line(line)
+}
+
+fn is_blank_blockquote_line(line: &str) -> bool {
+    let mut rest = line.trim_start();
+    let mut saw_blockquote = false;
+    while let Some(after_marker) = rest.strip_prefix('>') {
+        saw_blockquote = true;
+        rest = after_marker.strip_prefix(' ').unwrap_or(after_marker);
+        rest = rest.trim_start();
+    }
+    saw_blockquote && rest.is_empty()
 }
 
 enum FenceBlankFix {
@@ -68,8 +85,8 @@ fn fence_blank_fix(
 ) -> MarkdownDiagnostic {
     let line = &ctx.lines()[line_idx];
     let (start_column, replacement) = match kind {
-        FenceBlankFix::Before => (1, "\n".to_string()),
-        FenceBlankFix::After => (line.text.len() + 1, "\n".to_string()),
+        FenceBlankFix::Before => (1, before_fence_blank(line.text)),
+        FenceBlankFix::After => (line.text.len() + 1, after_fence_blank(line.text)),
     };
     MarkdownDiagnostic {
         file: ctx.file_path().to_path_buf(),
@@ -90,6 +107,22 @@ fn fence_blank_fix(
             end_column: start_column,
             replacement,
         }),
+    }
+}
+
+fn before_fence_blank(fence_line: &str) -> String {
+    if fence_line.trim_start().starts_with('>') {
+        ">\n".to_string()
+    } else {
+        "\n".to_string()
+    }
+}
+
+fn after_fence_blank(fence_line: &str) -> String {
+    if fence_line.trim_start().starts_with('>') {
+        "\n>".to_string()
+    } else {
+        "\n".to_string()
     }
 }
 

--- a/src/rules/markdown/rules/heading.rs
+++ b/src/rules/markdown/rules/heading.rs
@@ -36,9 +36,10 @@ impl MarkdownRule for BlanksAroundHeadingsRule {
         for heading in ctx.headings() {
             let i = heading.line;
             let line = &ctx.lines()[i];
-            let needs_blank_before = i > 0 && !ctx.lines()[i - 1].text.trim().is_empty();
+            let needs_blank_before =
+                i > 0 && !is_blank_for_heading_spacing(ctx.lines()[i - 1].text);
             let needs_blank_after =
-                i + 1 < ctx.lines().len() && !ctx.lines()[i + 1].text.trim().is_empty();
+                i + 1 < ctx.lines().len() && !is_blank_for_heading_spacing(ctx.lines()[i + 1].text);
             if needs_blank_before || needs_blank_after {
                 let mut replacement = String::new();
                 if needs_blank_before {
@@ -68,6 +69,11 @@ impl MarkdownRule for BlanksAroundHeadingsRule {
         }
         diagnostics
     }
+}
+
+fn is_blank_for_heading_spacing(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.is_empty() || (trimmed.starts_with("<!--") && trimmed.ends_with("-->"))
 }
 
 /// MD023 / heading-start-left — Headings must start at the beginning of the line.

--- a/src/rules/markdown/rules/image.rs
+++ b/src/rules/markdown/rules/image.rs
@@ -1,6 +1,7 @@
 use crate::rules::markdown::helpers::RuleHelpers;
 use crate::rules::markdown::{
     DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta,
+    SourceRange,
 };
 use crate::types::RuleConfig;
 use std::path::Path;
@@ -33,7 +34,7 @@ impl MarkdownRule for NoAltTextRule {
             if ctx.is_code_line(i) {
                 continue;
             }
-            if line.text.contains("![]") {
+            if has_empty_alt_image_outside_inline_code(ctx, line.content_range.start, line.text) {
                 RuleHelpers::push_diag(
                     &mut diagnostics,
                     ctx.file_path(),
@@ -46,6 +47,20 @@ impl MarkdownRule for NoAltTextRule {
         }
         diagnostics
     }
+}
+
+fn has_empty_alt_image_outside_inline_code(
+    ctx: &DocumentContext<'_>,
+    line_start: usize,
+    line: &str,
+) -> bool {
+    line.match_indices("![]").any(|(index, token)| {
+        let start = line_start + index;
+        !ctx.is_inside_inline_code(SourceRange {
+            start,
+            end: start + token.len(),
+        })
+    })
 }
 
 #[cfg(test)]

--- a/src/rules/markdown/rules/list.rs
+++ b/src/rules/markdown/rules/list.rs
@@ -3,6 +3,7 @@ use crate::rules::markdown::{
     DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta,
     RuleParityStatus,
 };
+use crate::types::RuleConfig;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -88,22 +89,34 @@ impl MarkdownRule for OlPrefixRule {
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
+        let ctx = DocumentContext::new(file_path, content);
+        self.evaluate_context(&ctx, None)
+    }
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD029");
         let mut diagnostics = Vec::new();
-        let mut expected_numbers = BTreeMap::<usize, u32>::new();
-        let ctx = DocumentContext::new(file_path, content);
+        let mut expected_numbers = BTreeMap::<usize, OrderedListState>::new();
+        let style = OrderedListStyle::from_config(config);
         for (i, line) in ctx.lines().iter().enumerate() {
-            if ctx.is_code_line(i) {
-                expected_numbers.clear();
-                continue;
-            }
             let line = line.text;
             let trimmed = line.trim_start();
+            let indent = line.len() - trimmed.len();
+            if ctx.is_code_line(i) {
+                if !trimmed.is_empty() && !is_ordered_list_continuation(indent, &expected_numbers) {
+                    expected_numbers.clear();
+                }
+                continue;
+            }
             if let Some(num) = RuleHelpers::get_ordered_number(trimmed) {
-                let indent = line.len() - trimmed.len();
                 expected_numbers.retain(|level, _| *level <= indent);
-                let expected_number = expected_numbers.entry(indent).or_insert(1);
-                if num != *expected_number {
+                let state = expected_numbers.entry(indent).or_default();
+                let expected = state.expected_number(num, style);
+                if let Some(expected_number) = expected {
                     let dot_pos = line.find(". ").unwrap();
                     let start_col = line.find(|c: char| c.is_ascii_digit()).unwrap();
                     let fix = crate::rules::markdown::types::DiagnosticFix {
@@ -115,7 +128,7 @@ impl MarkdownRule for OlPrefixRule {
                     };
                     RuleHelpers::push_diag_with_fix(
                         &mut diagnostics,
-                        file_path,
+                        ctx.file_path(),
                         i,
                         line,
                         &meta,
@@ -123,9 +136,10 @@ impl MarkdownRule for OlPrefixRule {
                         Some(fix),
                     );
                 }
-                *expected_number += 1;
-            } else if !trimmed.is_empty() {
-                let indent = line.len() - trimmed.len();
+                state.content_indent = indent + ordered_marker_width(trimmed);
+            } else if !trimmed.is_empty()
+                && !is_ordered_list_lazy_continuation(indent, trimmed, &expected_numbers)
+            {
                 expected_numbers.retain(|level, _| *level < indent);
             }
         }
@@ -133,72 +147,158 @@ impl MarkdownRule for OlPrefixRule {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::OlPrefixRule;
-    use crate::rules::markdown::MarkdownRule;
-    use std::path::Path;
+#[derive(Debug, Clone, Copy)]
+struct OrderedListState {
+    next_number: u32,
+    content_indent: usize,
+    detected_style: Option<DetectedOrderedListStyle>,
+}
 
-    #[test]
-    fn md029_accepts_nested_ordered_lists_with_independent_numbering() {
-        let content = "\
-1. First item
-2. Second item
-   1. Nested 2-1
-   2. Nested 2-2
-3. Third item
-";
+impl Default for OrderedListState {
+    fn default() -> Self {
+        Self {
+            next_number: 1,
+            content_indent: 0,
+            detected_style: None,
+        }
+    }
+}
 
-        let diagnostics = OlPrefixRule.evaluate(Path::new("doc.md"), content);
-
-        assert!(diagnostics.is_empty());
+impl OrderedListState {
+    fn expected_number(&mut self, actual: u32, style: OrderedListStyle) -> Option<u32> {
+        match style {
+            OrderedListStyle::One => self.expected_constant_number(actual, 1),
+            OrderedListStyle::Ordered => self.expected_ordered_number(actual),
+            OrderedListStyle::OneOrOrdered => self.expected_one_or_ordered(actual),
+            OrderedListStyle::Zero => self.expected_constant_number(actual, 0),
+        }
     }
 
-    #[test]
-    fn md029_rejects_broken_nested_numbering_at_the_same_level() {
-        let content = "\
-1. First item
-2. Second item
-   1. Nested 2-1
-   3. Nested 2-2
-3. Third item
-";
-
-        let diagnostics = OlPrefixRule.evaluate(Path::new("doc.md"), content);
-
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].range.start_line, 4);
+    fn expected_constant_number(&mut self, actual: u32, expected: u32) -> Option<u32> {
+        self.next_number += 1;
+        mismatch_expected(actual, expected)
     }
 
-    #[test]
-    fn md029_no_false_positive_when_nested_unordered_list_interrupts_ordered() {
-        let content = "\
-1. item1
-2. item2
-3. item3
-   - sub bullet
-4. item4
-5. item5
-";
-        let diagnostics = OlPrefixRule.evaluate(Path::new("doc.md"), content);
-        assert!(
-            diagnostics.is_empty(),
-            "nested unordered list should not reset parent ordered list counter"
-        );
+    fn expected_ordered_number(&mut self, actual: u32) -> Option<u32> {
+        let expected = self.next_number;
+        self.next_number += 1;
+        mismatch_expected(actual, expected)
     }
 
-    #[test]
-    fn md029_fix_is_correct_after_nested_unordered_list() {
-        let content = "\
-1. item1
-2. item2
-   - sub
-4. item3
-";
-        let diagnostics = OlPrefixRule.evaluate(Path::new("doc.md"), content);
-        assert_eq!(diagnostics.len(), 1, "only item4 (should be 3) is wrong");
-        assert_eq!(diagnostics[0].range.start_line, 4);
-        let fix = diagnostics[0].fix_info.as_ref().expect("fix should exist");
-        assert_eq!(fix.replacement, "3");
+    fn expected_one_or_ordered(&mut self, actual: u32) -> Option<u32> {
+        if self.next_number == 1 && self.detected_style.is_none() {
+            if actual == 0 {
+                self.detected_style = Some(DetectedOrderedListStyle::Ordered);
+                return None;
+            }
+            self.next_number = 2;
+            return mismatch_expected(actual, 1);
+        }
+        match self.detected_style {
+            Some(DetectedOrderedListStyle::One) => self.expected_constant_number(actual, 1),
+            Some(DetectedOrderedListStyle::Ordered) => self.expected_ordered_number(actual),
+            None if actual == 1 => {
+                self.detected_style = Some(DetectedOrderedListStyle::One);
+                self.next_number += 1;
+                None
+            }
+            None if actual == self.next_number => {
+                self.detected_style = Some(DetectedOrderedListStyle::Ordered);
+                self.next_number += 1;
+                None
+            }
+            None => {
+                let expected = self.next_number;
+                self.detected_style = Some(DetectedOrderedListStyle::Ordered);
+                self.next_number += 1;
+                Some(expected)
+            }
+        }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OrderedListStyle {
+    One,
+    Ordered,
+    OneOrOrdered,
+    Zero,
+}
+
+impl OrderedListStyle {
+    fn from_config(config: Option<&RuleConfig>) -> Self {
+        match config
+            .and_then(|config| config.properties.get("style"))
+            .map(String::as_str)
+        {
+            Some("one") => Self::One,
+            Some("ordered") => Self::Ordered,
+            Some("zero") => Self::Zero,
+            _ => Self::OneOrOrdered,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DetectedOrderedListStyle {
+    One,
+    Ordered,
+}
+
+fn mismatch_expected(actual: u32, expected: u32) -> Option<u32> {
+    (actual != expected).then_some(expected)
+}
+
+fn ordered_marker_width(trimmed: &str) -> usize {
+    trimmed.find(". ").map_or(0, |dot_pos| dot_pos + 2)
+}
+
+fn is_ordered_list_continuation(
+    indent: usize,
+    expected_numbers: &BTreeMap<usize, OrderedListState>,
+) -> bool {
+    expected_numbers
+        .values()
+        .any(|state| state.content_indent > 0 && indent >= state.content_indent)
+}
+
+fn is_ordered_list_lazy_continuation(
+    indent: usize,
+    trimmed: &str,
+    expected_numbers: &BTreeMap<usize, OrderedListState>,
+) -> bool {
+    if is_ordered_list_boundary(trimmed) {
+        return false;
+    }
+    expected_numbers
+        .iter()
+        .any(|(level, state)| state.content_indent > 0 && indent >= *level)
+}
+
+fn is_ordered_list_boundary(trimmed: &str) -> bool {
+    trimmed.starts_with('#')
+        || trimmed.starts_with('>')
+        || trimmed.starts_with("```")
+        || trimmed.starts_with("~~~")
+        || is_thematic_break(trimmed)
+}
+
+fn is_thematic_break(trimmed: &str) -> bool {
+    let mut marker: Option<char> = None;
+    let mut count = 0;
+    for ch in trimmed.chars() {
+        if ch == ' ' || ch == '\t' {
+            continue;
+        }
+        if ch != '-' && ch != '_' && ch != '*' {
+            return false;
+        }
+        match marker {
+            Some(existing) if existing != ch => return false,
+            None => marker = Some(ch),
+            _ => {}
+        }
+        count += 1;
+    }
+    count >= 3
 }

--- a/src/rules/markdown/rules/list_ext.rs
+++ b/src/rules/markdown/rules/list_ext.rs
@@ -39,7 +39,8 @@ impl MarkdownRule for BlanksAroundListsRule {
             }
             let prev_is_problem = i > 0
                 && !ctx.lines()[i - 1].text.trim().is_empty()
-                && !RuleHelpers::is_list_item(ctx.lines()[i - 1].text.trim_start());
+                && !RuleHelpers::is_list_item(ctx.lines()[i - 1].text.trim_start())
+                && !previous_line_continues_list_item(ctx, i);
             if prev_is_problem {
                 let fix = crate::rules::markdown::types::DiagnosticFix {
                     start_line: i + 1,
@@ -60,6 +61,24 @@ impl MarkdownRule for BlanksAroundListsRule {
             }
         }
         diagnostics
+    }
+}
+
+fn previous_line_continues_list_item(ctx: &DocumentContext<'_>, index: usize) -> bool {
+    let mut previous_index = index.saturating_sub(1);
+    loop {
+        let previous = ctx.lines()[previous_index].text;
+        let previous_trimmed = previous.trim_start();
+        if previous_trimmed.trim().is_empty() {
+            return false;
+        }
+        if RuleHelpers::is_list_item(previous_trimmed) {
+            return true;
+        }
+        if previous_index == 0 {
+            return false;
+        }
+        previous_index -= 1;
     }
 }
 

--- a/src/rules/markdown/rules/list_indent.rs
+++ b/src/rules/markdown/rules/list_indent.rs
@@ -20,24 +20,47 @@ impl MarkdownRule for UnorderedListIndentRule {
         let meta = self.official_meta().expect("always Some for MD007");
         let mut diagnostics = Vec::new();
         let indent = 2;
+        let mut ordered_parent_indents = Vec::<OrderedParentIndent>::new();
+        let mut unordered_parent_indents = Vec::<UnorderedParentIndent>::new();
 
         let ctx = DocumentContext::new(file_path, content);
         for (i, line) in ctx.lines().iter().enumerate() {
-            if ctx.is_code_line(i) {
-                continue;
-            }
             let line = line.text;
             let trimmed = line.trim_start();
+            let leading = line.len() - trimmed.len();
+            if ctx.is_code_line(i) {
+                if !trimmed.is_empty()
+                    && !ordered_parent_indents
+                        .iter()
+                        .any(|list_indent| leading >= list_indent.content)
+                {
+                    ordered_parent_indents.clear();
+                }
+                continue;
+            }
 
+            if RuleHelpers::get_ordered_number(trimmed).is_some() {
+                ordered_parent_indents.retain(|list_indent| list_indent.content <= leading);
+                unordered_parent_indents.retain(|list_indent| list_indent.actual <= leading);
+                ordered_parent_indents.push(OrderedParentIndent {
+                    actual: leading,
+                    content: leading + ordered_marker_width(trimmed),
+                });
+                continue;
+            }
             if RuleHelpers::get_bullet_char(trimmed).is_some() {
-                let leading = line.len() - trimmed.len();
-                if leading % indent != 0 {
+                ordered_parent_indents.retain(|list_indent| list_indent.actual < leading);
+                let unordered_parent = nearest_unordered_parent(leading, &unordered_parent_indents);
+                let ordered_parent = nearest_ordered_parent(leading, &ordered_parent_indents);
+                let expected_indent =
+                    expected_indent(leading, indent, unordered_parent, ordered_parent);
+                if let Some(expected_indent) = expected_indent.filter(|it| leading != *it) {
                     let fix = crate::rules::markdown::types::DiagnosticFix {
                         start_line: i + 1,
                         start_column: 1,
                         end_line: i + 1,
                         end_column: leading.saturating_add(1),
-                        replacement: " ".repeat(leading / indent * indent),
+                        replacement: " ".repeat(expected_indent),
                     };
                     RuleHelpers::push_diag_with_fix(
                         &mut diagnostics,
@@ -49,9 +72,78 @@ impl MarkdownRule for UnorderedListIndentRule {
                         Some(fix),
                     );
                 }
+                let parent_expected = expected_indent.unwrap_or(leading);
+                unordered_parent_indents.retain(|list_indent| list_indent.actual <= leading);
+                if !unordered_parent_indents
+                    .iter()
+                    .any(|list_indent| list_indent.actual == leading)
+                {
+                    unordered_parent_indents.push(UnorderedParentIndent {
+                        actual: leading,
+                        expected: parent_expected,
+                    });
+                }
+            } else if !trimmed.is_empty() {
+                ordered_parent_indents.retain(|list_indent| list_indent.content <= leading);
+                unordered_parent_indents.retain(|list_indent| list_indent.actual < leading);
             }
         }
 
         diagnostics
     }
+}
+
+fn ordered_marker_width(trimmed: &str) -> usize {
+    trimmed.find('.').map_or(0, |dot_pos| dot_pos + 2)
+}
+
+#[derive(Clone, Copy)]
+struct UnorderedParentIndent {
+    actual: usize,
+    expected: usize,
+}
+
+#[derive(Clone, Copy)]
+struct OrderedParentIndent {
+    actual: usize,
+    content: usize,
+}
+
+fn expected_indent(
+    leading: usize,
+    indent: usize,
+    unordered_parent: Option<UnorderedParentIndent>,
+    ordered_parent: Option<OrderedParentIndent>,
+) -> Option<usize> {
+    match (unordered_parent, ordered_parent) {
+        (Some(unordered), Some(ordered)) if unordered.actual > ordered.actual => {
+            Some(unordered.expected + indent)
+        }
+        (Some(unordered), None) => Some(unordered.expected + indent),
+        (_, Some(ordered)) if leading < ordered.content => Some(ordered.content),
+        (_, Some(_)) => None,
+        (None, None) => Some(0),
+    }
+}
+
+fn nearest_ordered_parent(
+    leading: usize,
+    ordered_parent_indents: &[OrderedParentIndent],
+) -> Option<OrderedParentIndent> {
+    ordered_parent_indents
+        .iter()
+        .copied()
+        .filter(|list_indent| list_indent.actual < leading)
+        .max_by_key(|list_indent| list_indent.actual)
+}
+
+fn nearest_unordered_parent(
+    leading: usize,
+    unordered_parent_indents: &[UnorderedParentIndent],
+) -> Option<UnorderedParentIndent> {
+    unordered_parent_indents
+        .iter()
+        .copied()
+        .filter(|list_indent| list_indent.actual < leading)
+        .max_by_key(|list_indent| list_indent.actual)
 }

--- a/src/rules/markdown/rules/md043.rs
+++ b/src/rules/markdown/rules/md043.rs
@@ -1,6 +1,6 @@
-use crate::rules::markdown::helpers::RuleHelpers;
 use crate::rules::markdown::{
-    DiagnosticSeverity, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta,
+    DiagnosticRange, DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule,
+    OfficialRuleMeta, RuleConfig,
 };
 use std::path::Path;
 
@@ -17,21 +17,107 @@ impl MarkdownRule for RequiredHeadingsRule {
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
+        let ctx = DocumentContext::new(file_path, content);
+        self.evaluate_context(&ctx, None)
+    }
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD043");
-        let mut diagnostics = Vec::new();
-        if !content
-            .lines()
-            .any(|line| RuleHelpers::is_atx_heading(line.trim_start()))
-        {
-            RuleHelpers::push_diag(
-                &mut diagnostics,
-                file_path,
-                0,
-                content.lines().next().unwrap_or(""),
-                &meta,
-                DiagnosticSeverity::Warning,
-            );
+        let required = required_headings(config);
+        if required.is_empty() || heading_structure_matches(ctx, &required, match_case(config)) {
+            return Vec::new();
         }
-        diagnostics
+
+        vec![MarkdownDiagnostic {
+            file: ctx.file_path().to_path_buf(),
+            severity: DiagnosticSeverity::Warning,
+            range: first_problem_range(ctx),
+            message: meta.description.to_string(),
+            rule_id: meta.code.to_string(),
+            official_meta: Some(meta),
+            fix_info: None,
+        }]
+    }
+}
+
+fn required_headings(config: Option<&RuleConfig>) -> Vec<String> {
+    config
+        .and_then(|config| config.properties.get("headings"))
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .unwrap_or_default()
+}
+
+fn match_case(config: Option<&RuleConfig>) -> bool {
+    config
+        .and_then(|config| config.properties.get("match_case"))
+        .and_then(|value| value.parse::<bool>().ok())
+        .unwrap_or(false)
+}
+
+fn heading_structure_matches(
+    ctx: &DocumentContext<'_>,
+    required: &[String],
+    match_case: bool,
+) -> bool {
+    let actual = ctx
+        .headings()
+        .iter()
+        .map(|heading| format!("{} {}", "#".repeat(heading.level), heading.text))
+        .collect::<Vec<_>>();
+    let actual = normalize_headings(&actual, match_case);
+    let required = normalize_headings(required, match_case);
+    heading_pattern_matches(&actual, &required)
+}
+
+fn normalize_headings(values: &[String], match_case: bool) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| {
+            if match_case {
+                value.clone()
+            } else {
+                value.to_lowercase()
+            }
+        })
+        .collect()
+}
+
+fn heading_pattern_matches(actual: &[String], required: &[String]) -> bool {
+    if required.is_empty() {
+        return actual.is_empty();
+    }
+    match required[0].as_str() {
+        "*" => {
+            heading_pattern_matches(actual, &required[1..])
+                || (!actual.is_empty() && heading_pattern_matches(&actual[1..], required))
+        }
+        "+" => {
+            !actual.is_empty()
+                && (heading_pattern_matches(&actual[1..], &required[1..])
+                    || heading_pattern_matches(&actual[1..], required))
+        }
+        "?" => !actual.is_empty() && heading_pattern_matches(&actual[1..], &required[1..]),
+        expected => {
+            actual.first().is_some_and(|actual| actual == expected)
+                && heading_pattern_matches(&actual[1..], &required[1..])
+        }
+    }
+}
+
+fn first_problem_range(ctx: &DocumentContext<'_>) -> DiagnosticRange {
+    if let Some(heading) = ctx.headings().first() {
+        ctx.diagnostic_range(heading.marker_range)
+    } else {
+        let line = ctx.lines().last();
+        DiagnosticRange {
+            start_line: line.map_or(1, |line| line.number),
+            start_column: 1,
+            end_line: line.map_or(1, |line| line.number),
+            end_column: line.map_or(1, |line| line.text.len().max(1)),
+        }
     }
 }

--- a/src/rules/markdown/rules/md046.rs
+++ b/src/rules/markdown/rules/md046.rs
@@ -98,7 +98,27 @@ fn is_indented_code_line(ctx: &DocumentContext<'_>, line_index: usize, line: &st
     if ctx.is_code_line(line_index) || !line.starts_with("    ") || line.trim().is_empty() {
         return false;
     }
+    if is_definition_list_continuation(ctx, line_index) {
+        return false;
+    }
     !is_list_marker_line(&line[4..])
+}
+
+fn is_definition_list_continuation(ctx: &DocumentContext<'_>, line_index: usize) -> bool {
+    if line_index == 0 {
+        return false;
+    }
+    for previous_index in (0..line_index).rev() {
+        let previous = ctx.lines()[previous_index].text;
+        if previous.trim().is_empty()
+            || previous.starts_with("    ")
+            || ctx.is_code_line(previous_index)
+        {
+            continue;
+        }
+        return previous.trim_start().starts_with(':');
+    }
+    false
 }
 
 fn is_list_marker_line(s: &str) -> bool {

--- a/src/rules/markdown/rules/md049.rs
+++ b/src/rules/markdown/rules/md049.rs
@@ -65,12 +65,7 @@ impl EmphasisStyleRule {
             let has_inline_code_marker = line.text.contains('`');
             let line_start = line.content_range.start;
             for span in emphasis_spans(line.text) {
-                if has_inline_code_marker
-                    && ctx.is_inside_inline_code(SourceRange {
-                        start: line_start + span.start,
-                        end: line_start + span.end,
-                    })
-                {
+                if has_inline_code_marker && span_touches_inline_code(ctx, line_start, &span) {
                     continue;
                 }
                 let expected_marker = *expected.get_or_insert(span.marker);
@@ -173,6 +168,23 @@ fn is_intraword(line: &str, open: usize, close: usize) -> bool {
         && bytes
             .get(close + 1)
             .is_some_and(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn span_touches_inline_code(
+    ctx: &DocumentContext<'_>,
+    line_start: usize,
+    span: &EmphasisSpan<'_>,
+) -> bool {
+    ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.start,
+        end: line_start + span.start + 1,
+    }) || ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.end.saturating_sub(1),
+        end: line_start + span.end,
+    }) || ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.start,
+        end: line_start + span.end,
+    })
 }
 
 #[cfg(test)]

--- a/src/rules/markdown/rules/md050.rs
+++ b/src/rules/markdown/rules/md050.rs
@@ -65,12 +65,7 @@ impl StrongStyleRule {
             let has_inline_code_marker = line.text.contains('`');
             let line_start = line.content_range.start;
             for span in strong_spans(line.text) {
-                if has_inline_code_marker
-                    && ctx.is_inside_inline_code(SourceRange {
-                        start: line_start + span.start,
-                        end: line_start + span.end,
-                    })
-                {
+                if has_inline_code_marker && span_touches_inline_code(ctx, line_start, &span) {
                     continue;
                 }
                 let expected_marker = *expected.get_or_insert(span.marker);
@@ -166,6 +161,23 @@ fn is_intraword(line: &str, open: usize, close: usize) -> bool {
         && bytes
             .get(close + 1)
             .is_some_and(|byte| byte.is_ascii_alphanumeric())
+}
+
+fn span_touches_inline_code(
+    ctx: &DocumentContext<'_>,
+    line_start: usize,
+    span: &StrongSpan<'_>,
+) -> bool {
+    ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.start,
+        end: line_start + span.start + 1,
+    }) || ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.end.saturating_sub(1),
+        end: line_start + span.end,
+    }) || ctx.is_inside_inline_code(SourceRange {
+        start: line_start + span.start,
+        end: line_start + span.end,
+    })
 }
 
 #[cfg(test)]

--- a/src/rules/markdown/rules/md052.rs
+++ b/src/rules/markdown/rules/md052.rs
@@ -1,9 +1,9 @@
-use crate::rules::markdown::document::SourceRange;
-use crate::rules::markdown::types::DiagnosticFix;
+use crate::rules::markdown::document::{LineInfo, SourceRange};
 use crate::rules::markdown::{
     DiagnosticSeverity, DocumentContext, MarkdownDiagnostic, MarkdownRule, OfficialRuleMeta,
     RuleConfig,
 };
+use std::collections::HashSet;
 use std::path::Path;
 
 /// MD052 / reference-links-images — Reference links and images.
@@ -15,9 +15,7 @@ impl MarkdownRule for ReferenceLinksImagesRule {
     }
 
     fn official_meta(&self) -> Option<OfficialRuleMeta> {
-        let mut meta = crate::rules::markdown::catalog::get_official_meta("MD052")?;
-        meta.is_fixable = true;
-        Some(meta)
+        crate::rules::markdown::catalog::get_official_meta("MD052")
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
@@ -31,33 +29,269 @@ impl MarkdownRule for ReferenceLinksImagesRule {
         _config: Option<&RuleConfig>,
     ) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD052");
+        let definitions = reference_definition_labels(ctx);
+        let ignored_labels = ignored_labels(_config);
+        let include_shortcut = shortcut_syntax(_config);
+        let indented_code_lines = indented_code_line_indexes(ctx);
         let mut diagnostics = Vec::new();
         for link in ctx.inline_links() {
-            if link.kind.is_collapsed_reference() {
-                let range = ctx.diagnostic_range(link.full_range);
-                let fix_range = ctx.diagnostic_range(SourceRange {
-                    start: link.full_range.end - 2,
-                    end: link.full_range.end,
-                });
-                diagnostics.push(MarkdownDiagnostic {
-                    file: ctx.file_path().to_path_buf(),
-                    severity: DiagnosticSeverity::Warning,
-                    range,
-                    message: meta.description.to_string(),
-                    rule_id: meta.code.to_string(),
-                    official_meta: Some(meta.clone()),
-                    fix_info: Some(DiagnosticFix {
-                        start_line: fix_range.start_line,
-                        start_column: fix_range.start_column,
-                        end_line: fix_range.end_line,
-                        end_column: fix_range.end_column,
-                        replacement: String::new(),
-                    }),
-                });
+            if !link.kind.is_reference() {
+                continue;
+            }
+            if indented_code_lines.contains(&link.line) {
+                continue;
+            }
+            let Some(label) = link.effective_label() else {
+                continue;
+            };
+            if should_report_label(label, &definitions, &ignored_labels) {
+                diagnostics.push(diagnostic_for_range(ctx, &meta, link.full_range));
+            }
+        }
+        if include_shortcut {
+            for shortcut in shortcut_references(ctx, &indented_code_lines) {
+                if should_report_label(shortcut.label, &definitions, &ignored_labels) {
+                    diagnostics.push(diagnostic_for_range(ctx, &meta, shortcut.range));
+                }
             }
         }
         diagnostics
     }
+}
+
+struct ShortcutReference<'a> {
+    label: &'a str,
+    range: SourceRange,
+}
+
+fn reference_definition_labels(ctx: &DocumentContext<'_>) -> HashSet<String> {
+    ctx.reference_definitions()
+        .iter()
+        .map(|definition| normalize_label(definition.label))
+        .collect()
+}
+
+fn ignored_labels(config: Option<&RuleConfig>) -> HashSet<String> {
+    config
+        .and_then(|config| config.properties.get("ignored_labels"))
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .unwrap_or_else(|| vec!["x".to_string()])
+        .into_iter()
+        .map(|label| normalize_label(&label))
+        .collect()
+}
+
+fn shortcut_syntax(config: Option<&RuleConfig>) -> bool {
+    config
+        .and_then(|config| config.properties.get("shortcut_syntax"))
+        .and_then(|value| value.parse::<bool>().ok())
+        .unwrap_or(false)
+}
+
+fn should_report_label(
+    label: &str,
+    definitions: &HashSet<String>,
+    ignored_labels: &HashSet<String>,
+) -> bool {
+    let normalized = normalize_label(label);
+    !normalized.is_empty()
+        && !definitions.contains(&normalized)
+        && !ignored_labels.contains(&normalized)
+}
+
+fn indented_code_line_indexes(ctx: &DocumentContext<'_>) -> HashSet<usize> {
+    let mut indexes = HashSet::new();
+    let mut in_block = false;
+    for (line_index, line) in ctx.lines().iter().enumerate() {
+        if ctx.is_code_line(line_index) {
+            in_block = false;
+            continue;
+        }
+        if line.text.trim().is_empty() {
+            continue;
+        }
+        if !line.text.starts_with("    ") {
+            in_block = false;
+            continue;
+        }
+        if is_list_marker_line(&line.text[4..]) || is_definition_list_continuation(ctx, line_index)
+        {
+            in_block = false;
+            continue;
+        }
+        if in_block || previous_line_allows_indented_code(ctx, line_index) {
+            indexes.insert(line_index);
+            in_block = true;
+        } else {
+            in_block = false;
+        }
+    }
+    indexes
+}
+
+fn previous_line_allows_indented_code(ctx: &DocumentContext<'_>, line_index: usize) -> bool {
+    line_index == 0 || ctx.lines()[line_index - 1].text.trim().is_empty()
+}
+
+fn is_definition_list_continuation(ctx: &DocumentContext<'_>, line_index: usize) -> bool {
+    if line_index == 0 {
+        return false;
+    }
+    for previous_index in (0..line_index).rev() {
+        let previous = ctx.lines()[previous_index].text;
+        if previous.trim().is_empty()
+            || previous.starts_with("    ")
+            || ctx.is_code_line(previous_index)
+        {
+            continue;
+        }
+        return previous.trim_start().starts_with(':');
+    }
+    false
+}
+
+fn is_list_marker_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("- ")
+        || trimmed.starts_with("* ")
+        || trimmed.starts_with("+ ")
+        || trimmed == "-"
+        || trimmed == "*"
+        || trimmed == "+"
+    {
+        return true;
+    }
+    let digit_count = trimmed
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    digit_count > 0
+        && trimmed
+            .get(digit_count..)
+            .is_some_and(|rest| rest.starts_with(". ") || rest.starts_with(") "))
+}
+
+fn normalize_label(label: &str) -> String {
+    label
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn diagnostic_for_range(
+    ctx: &DocumentContext<'_>,
+    meta: &OfficialRuleMeta,
+    source_range: SourceRange,
+) -> MarkdownDiagnostic {
+    MarkdownDiagnostic {
+        file: ctx.file_path().to_path_buf(),
+        severity: DiagnosticSeverity::Warning,
+        range: ctx.diagnostic_range(source_range),
+        message: meta.description.to_string(),
+        rule_id: meta.code.to_string(),
+        official_meta: Some(meta.clone()),
+        fix_info: None,
+    }
+}
+
+fn shortcut_references<'a>(
+    ctx: &DocumentContext<'a>,
+    indented_code_lines: &HashSet<usize>,
+) -> Vec<ShortcutReference<'a>> {
+    let definition_lines = ctx
+        .reference_definitions()
+        .iter()
+        .map(|definition| definition.line)
+        .collect::<HashSet<_>>();
+    let mut references = Vec::new();
+    for (line_index, line) in ctx.lines().iter().enumerate() {
+        if ctx.is_code_line(line_index)
+            || indented_code_lines.contains(&line_index)
+            || definition_lines.contains(&line_index)
+        {
+            continue;
+        }
+        references.extend(shortcut_references_on_line(ctx, line));
+    }
+    references
+}
+
+fn shortcut_references_on_line<'a>(
+    ctx: &DocumentContext<'_>,
+    line: &LineInfo<'a>,
+) -> Vec<ShortcutReference<'a>> {
+    let bytes = line.text.as_bytes();
+    let mut references = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == b'[' && cursor > 0 && bytes[cursor - 1] == b']' {
+            cursor += 1;
+            continue;
+        }
+        let (full_start, label_open) = match bytes[cursor] {
+            b'!' if bytes.get(cursor + 1) == Some(&b'[') => (cursor, cursor + 1),
+            b'[' => (cursor, cursor),
+            _ => {
+                cursor += 1;
+                continue;
+            }
+        };
+        let Some(label_close) = matching_bracket(line.text, label_open) else {
+            cursor = label_open + 1;
+            continue;
+        };
+        let after_label = label_close + 1;
+        if matches!(bytes.get(after_label), Some(b'(' | b'[' | b':')) {
+            cursor = after_label;
+            continue;
+        }
+        let label_start = label_open + 1;
+        if label_start == label_close {
+            cursor = after_label;
+            continue;
+        }
+        let range = SourceRange {
+            start: line.content_range.start + full_start,
+            end: line.content_range.start + after_label,
+        };
+        if !ctx.is_inside_inline_code(range) {
+            references.push(ShortcutReference {
+                label: &line.text[label_start..label_close],
+                range,
+            });
+        }
+        cursor = after_label;
+    }
+    references
+}
+
+fn matching_bracket(line: &str, open_bracket: usize) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut cursor = open_bracket + 1;
+    let mut depth = 1usize;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' {
+            cursor += 2;
+            continue;
+        }
+        match bytes[cursor] {
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
+            }
+            _ => {}
+        }
+        cursor += 1;
+    }
+    None
 }
 
 #[cfg(test)]
@@ -90,39 +324,29 @@ mod tests {
     }
 
     #[test]
-    fn fix_removes_trailing_brackets() {
+    fn reports_missing_full_references() {
         let rule = ReferenceLinksImagesRule;
-        let diagnostics = rule.evaluate(Path::new("doc.md"), "[ref][]\n");
+        let diagnostics = rule.evaluate(Path::new("doc.md"), "[ref][missing]\n");
 
         assert_eq!(diagnostics.len(), 1);
-        let fix = diagnostics[0]
-            .fix_info
-            .as_ref()
-            .expect("fix_info must be Some");
-        assert_eq!(fix.replacement, "");
-        assert_eq!(fix.start_line, 1);
-        assert_eq!(fix.end_line, 1);
-        assert_eq!(fix.start_column, fix.end_column - 2);
+        assert!(diagnostics[0].fix_info.is_none());
     }
 
     #[test]
-    fn fix_image_removes_trailing_brackets() {
+    fn ignores_defined_collapsed_reference() {
         let rule = ReferenceLinksImagesRule;
-        let diagnostics = rule.evaluate(Path::new("doc.md"), "![alt][]\n");
+        let diagnostics = rule.evaluate(
+            Path::new("doc.md"),
+            "[ref][]\n\n[ref]: https://example.com\n",
+        );
 
-        assert_eq!(diagnostics.len(), 1);
-        let fix = diagnostics[0]
-            .fix_info
-            .as_ref()
-            .expect("fix_info must be Some");
-        assert_eq!(fix.replacement, "");
-        assert_eq!(fix.start_line, 1);
+        assert!(diagnostics.is_empty());
     }
 
     #[test]
-    fn is_fixable_in_catalog() {
+    fn is_not_fixable_in_catalog() {
         let rule = ReferenceLinksImagesRule;
         let meta = rule.official_meta().expect("meta must be Some");
-        assert!(meta.is_fixable, "MD052 must advertise is_fixable=true");
+        assert!(!meta.is_fixable, "MD052 must not advertise a safe fix");
     }
 }

--- a/src/rules/markdown/rules/md060.rs
+++ b/src/rules/markdown/rules/md060.rs
@@ -4,6 +4,7 @@ use crate::rules::markdown::{
 };
 use crate::types::RuleConfig;
 use std::path::Path;
+use unicode_width::UnicodeWidthStr;
 
 /// MD060 / table-column-style - Table column style.
 pub struct TableColumnStyleRule;
@@ -124,11 +125,11 @@ fn matches_style<'a>(ctx: &DocumentContext<'a>, table: &TableBlock<'a>, style: T
         TableStyle::Compact => table
             .rows
             .iter()
-            .all(|row| line_text(ctx, row).trim() == format_simple_row(row, " ")),
+            .all(|row| line_text(ctx, row).trim() == format_simple_row_for_match(row, " ")),
         TableStyle::Tight => table
             .rows
             .iter()
-            .all(|row| line_text(ctx, row).trim() == format_simple_row(row, "")),
+            .all(|row| line_text(ctx, row).trim() == format_simple_row_for_match(row, "")),
     }
 }
 
@@ -224,6 +225,24 @@ fn format_simple_row(row: &TableRow<'_>, padding: &str) -> String {
     output
 }
 
+fn format_simple_row_for_match(row: &TableRow<'_>, padding: &str) -> String {
+    let cells = row
+        .cells
+        .iter()
+        .map(|cell| cell.text.to_string())
+        .collect::<Vec<_>>();
+    let separator = format!("{padding}|{padding}");
+    let mut output = cells.join(&separator);
+    if row.leading_pipe {
+        output = format!("|{padding}{output}");
+    }
+    if row.trailing_pipe {
+        output.push_str(padding);
+        output.push('|');
+    }
+    output
+}
+
 fn format_aligned_row(table: &TableBlock<'_>, row: &TableRow<'_>) -> String {
     let widths = column_widths(table);
     let mut cells = Vec::new();
@@ -234,7 +253,7 @@ fn format_aligned_row(table: &TableBlock<'_>, row: &TableRow<'_>) -> String {
         } else {
             cell.text.to_string()
         };
-        cells.push(format!("{text:<width$}"));
+        cells.push(pad_to_width(&text, width));
     }
     let mut output = cells.join(" | ");
     if row.leading_pipe {
@@ -251,7 +270,7 @@ fn column_widths(table: &TableBlock<'_>) -> Vec<usize> {
     let mut widths = vec![3; column_count];
     for row in &table.rows {
         for (idx, cell) in row.cells.iter().enumerate() {
-            widths[idx] = widths[idx].max(cell.text.chars().count());
+            widths[idx] = widths[idx].max(display_width(cell.text));
         }
     }
     widths
@@ -288,14 +307,23 @@ fn delimiter_aligned_with_header<'a>(ctx: &DocumentContext<'a>, table: &TableBlo
 }
 
 fn pipe_positions(line: &str) -> Vec<usize> {
-    line.bytes()
-        .enumerate()
-        .filter_map(|(idx, byte)| (byte == b'|').then_some(idx))
+    line.char_indices()
+        .filter_map(|(idx, char)| (char == '|').then_some(display_width(&line[..idx])))
         .collect()
 }
 
 fn line_text<'a>(ctx: &DocumentContext<'a>, row: &TableRow<'a>) -> &'a str {
     ctx.lines()[row.line].text
+}
+
+fn display_width(text: &str) -> usize {
+    UnicodeWidthStr::width(text)
+}
+
+fn pad_to_width(text: &str, width: usize) -> String {
+    let mut output = text.to_string();
+    output.push_str(&" ".repeat(width.saturating_sub(display_width(text))));
+    output
 }
 
 #[cfg(test)]

--- a/src/rules/markdown/rules/spaces_in_code.rs
+++ b/src/rules/markdown/rules/spaces_in_code.rs
@@ -31,6 +31,9 @@ impl MarkdownRule for NoSpaceInCodeRule {
             if !(inner_text.starts_with(' ') || inner_text.ends_with(' ')) {
                 continue;
             }
+            if trim_requires_padding_space(inner_text) {
+                continue;
+            }
             let marker = "`".repeat(span.marker_len);
             let replacement = format!("{marker}{}{marker}", inner_text.trim());
             let range = ctx.diagnostic_range(span.full_range);
@@ -56,6 +59,11 @@ impl MarkdownRule for NoSpaceInCodeRule {
     }
 }
 
+fn trim_requires_padding_space(inner_text: &str) -> bool {
+    let trimmed = inner_text.trim();
+    trimmed.starts_with('`') || trimmed.ends_with('`')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +85,14 @@ mod tests {
     fn ignores_unclosed_code_span() {
         let rule = NoSpaceInCodeRule;
         let diagnostics = rule.evaluate(Path::new("doc.md"), "` spaced\n");
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_padding_spaces_needed_to_show_backtick_literals() {
+        let rule = NoSpaceInCodeRule;
+        let diagnostics = rule.evaluate(Path::new("doc.md"), "` ``` ` and ` ```mermaid `");
 
         assert!(diagnostics.is_empty());
     }

--- a/src/rules/markdown/rules/style.rs
+++ b/src/rules/markdown/rules/style.rs
@@ -25,9 +25,18 @@ impl MarkdownRule for NoEmphasisAsHeadingRule {
     }
 
     fn evaluate(&self, file_path: &Path, content: &str) -> Vec<MarkdownDiagnostic> {
+        let ctx = DocumentContext::new(file_path, content);
+        self.evaluate_context(&ctx, None)
+    }
+
+    fn evaluate_context(
+        &self,
+        ctx: &DocumentContext<'_>,
+        config: Option<&RuleConfig>,
+    ) -> Vec<MarkdownDiagnostic> {
         let meta = self.official_meta().expect("always Some for MD036");
         let mut diagnostics = Vec::new();
-        let ctx = DocumentContext::new(file_path, content);
+        let punctuation = configured_md036_punctuation(config);
         let ctx_lines = ctx.lines();
         for (i, line_info) in ctx_lines.iter().enumerate() {
             if ctx.is_code_line(i) {
@@ -35,9 +44,9 @@ impl MarkdownRule for NoEmphasisAsHeadingRule {
             }
             let line = line_info.text;
             let trimmed = line.trim();
-            if let Some(heading_text) = emphasis_heading_text(trimmed, ctx_lines, i) {
+            if let Some(heading_text) = emphasis_heading_text(trimmed, ctx_lines, i, &punctuation) {
                 diagnostics.push(MarkdownDiagnostic {
-                    file: file_path.to_path_buf(),
+                    file: ctx.file_path().to_path_buf(),
                     severity: DiagnosticSeverity::Warning,
                     range: DiagnosticRange {
                         start_line: i + 1,
@@ -174,10 +183,18 @@ fn leading_spaces(line: &str) -> &str {
     &line[..count]
 }
 
+fn configured_md036_punctuation(config: Option<&RuleConfig>) -> String {
+    config
+        .and_then(|config| config.properties.get("punctuation"))
+        .cloned()
+        .unwrap_or_else(|| ".,;:!?。，；：！？".to_string())
+}
+
 fn emphasis_heading_text<'a>(
     trimmed: &'a str,
     lines: &[LineInfo<'_>],
     idx: usize,
+    punctuation: &str,
 ) -> Option<&'a str> {
     let heading_text = ["**", "__", "*", "_"].into_iter().find_map(|marker| {
         let text = trimmed.strip_prefix(marker)?.strip_suffix(marker)?;
@@ -186,9 +203,23 @@ fn emphasis_heading_text<'a>(
     if heading_text.trim().is_empty() {
         return None;
     }
+    if heading_text
+        .chars()
+        .last()
+        .is_some_and(|char| punctuation.contains(char))
+    {
+        return None;
+    }
+    if contains_inline_markdown_token(heading_text) {
+        return None;
+    }
     let blank_before = idx == 0 || lines[idx - 1].text.trim().is_empty();
     let blank_after = idx + 1 >= lines.len() || lines[idx + 1].text.trim().is_empty();
     (blank_before && blank_after).then_some(heading_text)
+}
+
+fn contains_inline_markdown_token(text: &str) -> bool {
+    text.contains(['`', '[', ']', '<', '>'])
 }
 
 fn is_horizontal_rule(trimmed: &str) -> bool {

--- a/src/rules/markdown/rules/whitespace.rs
+++ b/src/rules/markdown/rules/whitespace.rs
@@ -56,6 +56,30 @@ impl MarkdownRule for NoMultipleBlanksRule {
                 consecutive_blanks = 0;
             }
         }
+        if content.ends_with("\n\n") && consecutive_blanks == 1 {
+            diagnostics.push(MarkdownDiagnostic {
+                file: file_path.to_path_buf(),
+                severity: DiagnosticSeverity::Warning,
+                range: DiagnosticRange {
+                    start_line: ctx.lines().len() + 1,
+                    start_column: 1,
+                    end_line: ctx.lines().len() + 1,
+                    end_column: 1,
+                },
+                message: meta.description.to_string(),
+                rule_id: meta.code.to_string(),
+                official_meta: Some(meta),
+                fix_info: ctx.lines().last().map(|line| {
+                    crate::rules::markdown::types::DiagnosticFix {
+                        start_line: line.number,
+                        start_column: 1,
+                        end_line: line.number + 1,
+                        end_column: 1,
+                        replacement: String::new(),
+                    }
+                }),
+            });
+        }
         diagnostics
     }
 }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -279,11 +279,14 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let release_notes = read_workspace_file("scripts/release/release-notes.sh");
     let crate_guard = read_workspace_file("scripts/release/assert-crate-not-published.sh");
     let published_verifier = read_workspace_file("scripts/release/verify-release-published.sh");
+    let task_ledger_verifier = read_workspace_file("scripts/release/verify-task-ledger.py");
     let required = [
         ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke action-smoke"),
+        ("Makefile", &makefile, "release-task-ledger-check:"),
         ("Makefile", &makefile, "release-test:"),
         ("Makefile", &makefile, "cargo test --all-features --locked"),
         ("Makefile", &makefile, "scripts/release/assert-crate-not-published.sh"),
+        ("Makefile", &makefile, "scripts/release/verify-task-ledger.py"),
         ("Makefile", &makefile, "release-verify:"),
         ("Makefile", &makefile, "scripts/release/verify-release-published.sh"),
         (".github/workflows/release.yml", &workflow, "run: make lint"),
@@ -304,6 +307,9 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_title="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_target="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "crates_io_version="),
+        ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "Verify that the OpenSpec task ledger is release-ready."),
+        ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "Release task ledger is not ready"),
+        ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "品質評価スコア table is missing a 合計 row"),
     ];
     let violations = required
         .iter()
@@ -312,6 +318,30 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         .collect();
 
     assert_no_violations("release-local-ci-parity-and-retry-safety", violations);
+}
+
+#[test]
+fn ast_linter_coverage_gate_counts_integration_tests() {
+    let coverage = read_workspace_file("scripts/ci/coverage.sh");
+    let violations = [
+        (
+            coverage.contains("cargo llvm-cov --no-report --jobs \"$JOBS\" --workspace -q"),
+            "scripts/ci/coverage.sh: coverage must run workspace tests, including integration tests",
+        ),
+        (
+            !coverage.contains("--workspace --lib --bins"),
+            "scripts/ci/coverage.sh: remove --lib --bins so integration-test coverage is counted",
+        ),
+        (
+            coverage.contains("Running workspace tests with llvm-cov"),
+            "scripts/ci/coverage.sh: status text must describe the actual coverage scope",
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(ok, message)| (!ok).then_some(message.to_string()))
+    .collect();
+
+    assert_no_violations("coverage-gate-integration-tests", violations);
 }
 
 #[test]

--- a/tests/check_precision_regressions.rs
+++ b/tests/check_precision_regressions.rs
@@ -1,0 +1,156 @@
+use katana_markdown_linter::{fix, implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn only_rule(rule_id: &str) -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id.to_string(),
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        rule_id.to_string(),
+        RuleConfig {
+            enabled: true,
+            properties: HashMap::new(),
+        },
+    );
+    options
+}
+
+#[test]
+fn md032_accepts_wrapped_list_item_before_next_item() {
+    let content = "- First item wraps\n  onto the next source line\n- Second item\n";
+    let diagnostics = lint(content, &only_rule("MD032")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md032_accepts_lazy_continuation_before_next_item() {
+    let content = "- First item wraps\nwithout indentation\n- Second item\n";
+    let diagnostics = lint(content, &only_rule("MD032")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md032_accepts_empty_ordered_item_before_nested_item() {
+    let content = "1.\n    1. Nested\n    2. Nested sibling\n";
+    let diagnostics = lint(content, &only_rule("MD032")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md022_treats_html_comment_line_as_blank() {
+    let content = "### New Capabilities\n<!-- none -->\n\n### Modified Capabilities\n";
+    let diagnostics = lint(content, &only_rule("MD022")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md007_reports_unordered_item_indented_too_shallow_for_ordered_parent() {
+    let content = "1. Verify:\n  - Sub-item\n";
+    let diagnostics = lint(content, &only_rule("MD007")).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 2);
+}
+
+#[test]
+fn md007_fix_keeps_unordered_child_inside_ordered_parent() {
+    let content = "1. Verify:\n  - Sub-item\n";
+    let fixed = fix(content, &only_rule("MD007")).expect("fix should run");
+
+    assert_eq!(fixed.content, "1. Verify:\n   - Sub-item\n");
+}
+
+#[test]
+fn md007_does_not_pull_nested_unordered_child_out_of_ordered_parent() {
+    let content = "- Parent\n    1. Ordered\n        - Task\n";
+    let fixed = fix(content, &only_rule("MD007")).expect("fix should run");
+
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md007_fix_updates_descendants_after_unordered_parent_indent_changes() {
+    let content = "- Parent\n    - Child\n        - Grandchild\n";
+    let fixed = fix(content, &only_rule("MD007")).expect("fix should run");
+
+    assert_eq!(fixed.content, "- Parent\n  - Child\n    - Grandchild\n");
+}
+
+#[test]
+fn md007_drops_stale_ordered_parent_before_top_level_unordered_list() {
+    let content =
+        "- A\n    1. B\n        - Task\n    2. C\n- D\n    - Child\n        - Grandchild\n";
+    let fixed = fix(content, &only_rule("MD007")).expect("fix should run");
+
+    assert_eq!(
+        fixed.content,
+        "- A\n    1. B\n        - Task\n    2. C\n- D\n  - Child\n    - Grandchild\n"
+    );
+}
+
+#[test]
+fn md007_reports_unordered_sublist_indented_too_deep() {
+    let content = "- Parent\n    - Child\n        - Grandchild\n";
+    let diagnostics = lint(content, &only_rule("MD007")).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(diagnostics[0].line, 2);
+    assert_eq!(diagnostics[1].line, 3);
+}
+
+#[test]
+fn md012_reports_extra_trailing_blank_line() {
+    let diagnostics = lint("# Title\n\n", &only_rule("MD012")).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 3);
+}
+
+#[test]
+fn md045_ignores_inline_code_that_looks_like_empty_alt_text() {
+    let diagnostics =
+        lint("Use `vec![]` for values.\n", &only_rule("MD045")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md036_ignores_emphasis_with_inline_markdown_tokens() {
+    let content =
+        "**[Risk] `egui_kittest` cannot expose `Response.rect` directly**\n\n- Mitigation\n";
+    let diagnostics = lint(content, &only_rule("MD036")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md033_ignores_rust_generic_type_in_prose() {
+    let content = "Avoid Box<dyn Any> in typed Rust APIs.\n";
+    let diagnostics = lint(content, &only_rule("MD033")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn md060_accepts_aligned_table_using_emoji_visual_width() {
+    let content = "\
+| Feature | Status | Notes |
+| --------- | -------- | ------- |
+| Markdown | ✅ | Full support |
+| Mermaid | ✅ | Requires mmdc |
+";
+    let diagnostics = lint(content, &only_rule("MD060")).expect("lint should run");
+
+    assert!(diagnostics.is_empty());
+}

--- a/tests/cli_core_contract.rs
+++ b/tests/cli_core_contract.rs
@@ -69,6 +69,8 @@ fn check_fix_json_keeps_check_command_identity() {
     assert_eq!(json["command"], "check");
     assert_eq!(json["files"][0]["changed"], true);
     assert_eq!(json["files"][0]["applied_fixes"], 1);
+    assert_eq!(json["files"][0]["fix_details"][0]["rule_id"], "MD018");
+    assert_eq!(json["files"][0]["fix_details"][0]["applied"], true);
     assert_eq!(json["summary"]["total_issues"], 0);
 }
 

--- a/tests/cli_include_ignored_contract.rs
+++ b/tests/cli_include_ignored_contract.rs
@@ -1,0 +1,130 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn explicit_ignored_directory_can_be_included_for_fixing() {
+    let workspace = IgnoredWorkspace::new();
+
+    let default_output = run_kml([
+        "check",
+        "--output",
+        "json",
+        "--config",
+        workspace.config_text().as_str(),
+        workspace.root_text().as_str(),
+    ]);
+    assert_eq!(
+        report_paths(&stdout_json(&default_output)),
+        vec![workspace.docs_text()]
+    );
+
+    let fix_output = run_kml([
+        "fix",
+        "--include-ignored",
+        "--output",
+        "json",
+        "--config",
+        workspace.config_text().as_str(),
+        workspace.ignored_dir_text().as_str(),
+    ]);
+    assert!(fix_output.status.success());
+    assert_eq!(read_file(&workspace.ignored_file), "# Title\n");
+    assert_eq!(read_file(&workspace.docs_file), "#Title\n");
+}
+
+fn run_kml<const N: usize>(args: [&str; N]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kml"))
+        .args(args)
+        .output()
+        .expect("kml should run")
+}
+
+fn stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("stdout should be json")
+}
+
+fn report_paths(report: &Value) -> Vec<String> {
+    report["files"]
+        .as_array()
+        .expect("files should be an array")
+        .iter()
+        .map(|file| {
+            file["path"]
+                .as_str()
+                .expect("path should be string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn read_file(path: &Path) -> String {
+    fs::read_to_string(path).expect("fixture should be readable")
+}
+
+struct IgnoredWorkspace {
+    root: PathBuf,
+    ignored_dir: PathBuf,
+    ignored_file: PathBuf,
+    docs_file: PathBuf,
+    config: PathBuf,
+}
+
+impl IgnoredWorkspace {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "katana-markdown-linter-ignored-dir-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time should be available")
+                .as_nanos()
+        ));
+        let ignored_dir = root.join(".agents");
+        let ignored_file = ignored_dir.join("bad.md");
+        let docs_file = root.join("docs/bad.md");
+        let config = root.join(".markdownlint.json");
+        create_bad_markdown(&ignored_file);
+        create_bad_markdown(&docs_file);
+        fs::write(root.join(".gitignore"), ".agents/\n").expect("gitignore should be written");
+        fs::write(&config, "{ \"default\": false, \"MD018\": true }\n")
+            .expect("config should be written");
+        Self {
+            root,
+            ignored_dir,
+            ignored_file,
+            docs_file,
+            config,
+        }
+    }
+
+    fn root_text(&self) -> String {
+        self.root.display().to_string()
+    }
+
+    fn ignored_dir_text(&self) -> String {
+        self.ignored_dir.display().to_string()
+    }
+
+    fn docs_text(&self) -> String {
+        self.docs_file.display().to_string()
+    }
+
+    fn config_text(&self) -> String {
+        self.config.display().to_string()
+    }
+}
+
+impl Drop for IgnoredWorkspace {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn create_bad_markdown(path: &Path) {
+    fs::create_dir_all(path.parent().expect("path should have parent"))
+        .expect("directory should be created");
+    fs::write(path, "#Title\n").expect("fixture should be written");
+}

--- a/tests/cli_include_ignored_contract.rs
+++ b/tests/cli_include_ignored_contract.rs
@@ -84,7 +84,7 @@ impl IgnoredWorkspace {
         ));
         let ignored_dir = root.join(".agents");
         let ignored_file = ignored_dir.join("bad.md");
-        let docs_file = root.join("docs/bad.md");
+        let docs_file = root.join("docs").join("bad.md");
         let config = root.join(".markdownlint.json");
         create_bad_markdown(&ignored_file);
         create_bad_markdown(&docs_file);

--- a/tests/cli_reserved_directory_contract.rs
+++ b/tests/cli_reserved_directory_contract.rs
@@ -1,0 +1,187 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn check_skips_reserved_directories_by_default() {
+    let workspace = ReservedWorkspace::new("reserved-check-default");
+
+    let output = run_kml([
+        "check",
+        "--output",
+        "json",
+        "--config",
+        workspace.config_text().as_str(),
+        workspace.root_text().as_str(),
+    ]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let report = stdout_json(&output);
+    let paths = report_paths(&report);
+    assert_eq!(paths, vec![workspace.docs_file_text()]);
+}
+
+#[test]
+fn check_can_include_reserved_directories_with_opt_in() {
+    let workspace = ReservedWorkspace::new("reserved-check-opt-in");
+
+    let output = run_kml([
+        "check",
+        "--include-reserved",
+        "--output",
+        "json",
+        "--config",
+        workspace.config_text().as_str(),
+        workspace.root_text().as_str(),
+    ]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let report = stdout_json(&output);
+    let paths = report_paths(&report);
+    assert_eq!(
+        paths,
+        vec![workspace.docs_file_text(), workspace.reserved_file_text()]
+    );
+}
+
+#[test]
+fn fix_does_not_rewrite_reserved_directories_by_default() {
+    let workspace = ReservedWorkspace::new("reserved-fix-default");
+
+    let output = run_kml([
+        "fix",
+        "--output",
+        "json",
+        "--config",
+        workspace.config_text().as_str(),
+        workspace.root_text().as_str(),
+    ]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(read_file(workspace.docs_file()), "# Title\n");
+    assert_eq!(read_file(workspace.reserved_file()), "#Title\n");
+}
+
+#[test]
+fn fmt_does_not_rewrite_reserved_directories_by_default() {
+    let workspace = ReservedWorkspace::new("reserved-fmt-default");
+    fs::write(workspace.docs_file(), "# Title\r\nText\n\n\n")
+        .expect("docs file should be rewritten for fmt fixture");
+    fs::write(workspace.reserved_file(), "# Title\r\nText\n\n\n")
+        .expect("reserved file should be rewritten for fmt fixture");
+
+    let output = run_kml(["fmt", "--output", "json", workspace.root_text().as_str()]);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(read_file(workspace.docs_file()), "# Title\n\nText\n");
+    assert_eq!(
+        read_file(workspace.reserved_file()),
+        "# Title\r\nText\n\n\n"
+    );
+}
+
+fn run_kml<const N: usize>(args: [&str; N]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kml"))
+        .args(args)
+        .output()
+        .expect("kml should run")
+}
+
+fn stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout should be json: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn report_paths(report: &Value) -> Vec<String> {
+    report["files"]
+        .as_array()
+        .expect("files should be an array")
+        .iter()
+        .map(|file| {
+            file["path"]
+                .as_str()
+                .expect("file path should be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn read_file(path: &Path) -> String {
+    fs::read_to_string(path).expect("fixture should be readable")
+}
+
+struct ReservedWorkspace {
+    root: PathBuf,
+    docs_file: PathBuf,
+    reserved_file: PathBuf,
+    config: PathBuf,
+}
+
+impl ReservedWorkspace {
+    fn new(name: &str) -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be available")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "katana-markdown-linter-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        let docs_dir = root.join("docs");
+        let reserved_dir = root.join("node_modules/package");
+        fs::create_dir_all(&docs_dir).expect("docs directory should be created");
+        fs::create_dir_all(&reserved_dir).expect("reserved directory should be created");
+
+        let docs_file = docs_dir.join("bad.md");
+        let reserved_file = reserved_dir.join("bad.md");
+        let config = root.join(".markdownlint.json");
+        fs::write(&docs_file, "#Title\n").expect("docs file should be written");
+        fs::write(&reserved_file, "#Title\n").expect("reserved file should be written");
+        fs::write(&config, "{ \"default\": false, \"MD018\": true }\n")
+            .expect("config should be written");
+
+        Self {
+            root,
+            docs_file,
+            reserved_file,
+            config,
+        }
+    }
+
+    fn root_text(&self) -> String {
+        self.root.display().to_string()
+    }
+
+    fn docs_file(&self) -> &Path {
+        &self.docs_file
+    }
+
+    fn docs_file_text(&self) -> String {
+        self.docs_file.display().to_string()
+    }
+
+    fn reserved_file(&self) -> &Path {
+        &self.reserved_file
+    }
+
+    fn reserved_file_text(&self) -> String {
+        self.reserved_file.display().to_string()
+    }
+
+    fn config_text(&self) -> String {
+        self.config.display().to_string()
+    }
+}
+
+impl Drop for ReservedWorkspace {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}

--- a/tests/cli_reserved_directory_contract.rs
+++ b/tests/cli_reserved_directory_contract.rs
@@ -135,7 +135,7 @@ impl ReservedWorkspace {
             std::process::id()
         ));
         let docs_dir = root.join("docs");
-        let reserved_dir = root.join("node_modules/package");
+        let reserved_dir = root.join("node_modules").join("package");
         fs::create_dir_all(&docs_dir).expect("docs directory should be created");
         fs::create_dir_all(&reserved_dir).expect("reserved directory should be created");
 

--- a/tests/container_code_block_regressions.rs
+++ b/tests/container_code_block_regressions.rs
@@ -1,0 +1,96 @@
+use katana_markdown_linter::{fix, implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn only_rule(rule_id: &str) -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id.to_string(),
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        rule_id.to_string(),
+        RuleConfig {
+            enabled: true,
+            properties: HashMap::new(),
+        },
+    );
+    options
+}
+
+#[test]
+fn md027_ignores_code_lines_inside_blockquote_fences() {
+    let content = "\
+> ```rust
+> fn main() {
+>     println!(\"Hello\");
+> }
+> ```
+";
+    let options = only_rule("MD027");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md040_recognizes_fences_opened_after_list_markers() {
+    let content = "\
+- ```rs
+  let x = 3.14;
+  ```
+- Code blocks can be in lists too
+";
+    let options = only_rule("MD040");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md031_treats_blockquote_marker_lines_as_blank_lines() {
+    let content = "\
+> Quote with a fenced block
+>
+> ```rust
+> let quoted_code = true;
+> ```
+";
+    let options = only_rule("MD031");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md046_keeps_definition_list_continuation_paragraphs() {
+    let content = "\
+:   Definition 2
+
+    ```rs
+    let x = 3
+    ```
+
+    Third paragraph of definition 2.
+";
+    let options = only_rule("MD046");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}

--- a/tests/document_false_positive_regressions.rs
+++ b/tests/document_false_positive_regressions.rs
@@ -159,7 +159,7 @@ fn context_sensitive_rules_still_report_real_markdown_violations() {
         ("MD039", "[ text ](https://example.com)\n"),
         ("MD049", "*one* and _two_\n"),
         ("MD050", "**one** and __two__\n"),
-        ("MD052", "[ref][]\n"),
+        ("MD052", "[ref][missing]\n"),
         (
             "MD053",
             "[ref]: https://example.com\n[ref]: https://example.org\n",

--- a/tests/emphasis_regressions.rs
+++ b/tests/emphasis_regressions.rs
@@ -1,0 +1,48 @@
+use katana_markdown_linter::{fix, implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn only_rule(rule_id: &str) -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id.to_string(),
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        rule_id.to_string(),
+        RuleConfig {
+            enabled: true,
+            properties: HashMap::new(),
+        },
+    );
+    options
+}
+
+#[test]
+fn md049_ignores_markers_that_start_and_end_in_separate_inline_code_spans() {
+    let content = "Use `_ui.rs` for rendering and exclude it from coverage (`COVERAGE_IGNORE`).\n";
+    let options = only_rule("MD049");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md050_ignores_markers_that_start_and_end_in_separate_inline_code_spans() {
+    let content =
+        "Use `__ui.rs` for rendering and exclude it from coverage (`COVERAGE__IGNORE`).\n";
+    let options = only_rule("MD050");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}

--- a/tests/fixtures/rule-fixture-matrix.json
+++ b/tests/fixtures/rule-fixture-matrix.json
@@ -5,7 +5,7 @@
     "rules_with_examples": 53,
     "rules_with_fix_metadata": 37,
     "rules_with_parameters": 34,
-    "manual_required": 3,
+    "manual_required": 13,
     "missing_fixtures": 0,
     "stale_fixtures": 0
   },
@@ -73,7 +73,9 @@
           "expected": null
         }
       ],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: changing heading levels can change document structure and anchors"
+      ]
     },
     {
       "rule_id": "MD003",
@@ -344,7 +346,7 @@
         {
           "name": "normalize_unordered_indent",
           "source": "   - item\n",
-          "expected": "  - item\n"
+          "expected": "- item\n"
         }
       ],
       "config_valid": [
@@ -900,7 +902,9 @@
           "expected": "MD013"
         }
       ],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: line wrapping can change prose, code, tables, or inline references"
+      ]
     },
     {
       "rule_id": "MD014",
@@ -1343,7 +1347,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: duplicate heading fixes require choosing new heading text"
+      ]
     },
     {
       "rule_id": "MD025",
@@ -2002,7 +2008,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: removing or replacing inline HTML changes rendered output"
+      ]
     },
     {
       "rule_id": "MD034",
@@ -2509,7 +2517,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: first heading text cannot be inferred safely"
+      ]
     },
     {
       "rule_id": "MD042",
@@ -2551,7 +2561,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: empty link or image targets require author-provided destinations"
+      ]
     },
     {
       "rule_id": "MD043",
@@ -2578,16 +2590,35 @@
       "fixable": null,
       "check_pass": [
         {
-          "name": "has_heading",
-          "source": "# Title\n",
+          "name": "default_without_required_headings",
+          "source": "No heading here.\n",
           "expected": null
+        },
+        {
+          "name": "configured_required_headings",
+          "source": "# Title\n",
+          "expected": null,
+          "config": {
+            "MD043": {
+              "headings": [
+                "# Title"
+              ]
+            }
+          }
         }
       ],
       "check_fail": [
         {
-          "name": "missing_heading",
-          "source": "No heading here.\n",
-          "expected": "MD043"
+          "name": "configured_required_heading_mismatch",
+          "source": "# Other\n",
+          "expected": "MD043",
+          "config": {
+            "MD043": {
+              "headings": [
+                "# Title"
+              ]
+            }
+          }
         }
       ],
       "fix": [],
@@ -2626,7 +2657,10 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "check requires configured MD043.headings; default markdownlint headings is empty",
+        "fix requires author intent: required headings require author-provided sections and order"
+      ]
     },
     {
       "rule_id": "MD044",
@@ -2798,7 +2832,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: alt text requires image-specific author knowledge"
+      ]
     },
     {
       "rule_id": "MD046",
@@ -3284,7 +3320,7 @@
           "values": []
         }
       ],
-      "fixable": true,
+      "fixable": false,
       "check_pass": [
         {
           "name": "inline_link",
@@ -3294,23 +3330,12 @@
       ],
       "check_fail": [
         {
-          "name": "shortcut_reference_link",
+          "name": "missing_collapsed_reference_label",
           "source": "[ref][]\n",
           "expected": "MD052"
         }
       ],
-      "fix": [
-        {
-          "name": "fix_collapsed_reference_link",
-          "source": "[ref][]\n",
-          "expected": "[ref]\n"
-        },
-        {
-          "name": "fix_collapsed_reference_image",
-          "source": "![alt][]\n",
-          "expected": "![alt]\n"
-        }
-      ],
+      "fix": [],
       "config_valid": [
         {
           "name": "rule_enabled_valid",
@@ -3346,7 +3371,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "safe fix is not provided because the missing reference destination cannot be inferred"
+      ]
     },
     {
       "rule_id": "MD053",
@@ -3578,7 +3605,7 @@
       ],
       "edge": [],
       "manual_required": [
-        "check requires a disabled MD054 style such as MD054.collapsed=false",
+        "check requires a disabled link style such as MD054.collapsed=false",
         "fix requires: disabled style and an inline-safe reference definition"
       ]
     },
@@ -3812,7 +3839,9 @@
         }
       ],
       "edge": [],
-      "manual_required": []
+      "manual_required": [
+        "fix requires author intent: descriptive link text requires replacement wording"
+      ]
     },
     {
       "rule_id": "MD060",

--- a/tests/fixtures/rule-fixture-matrix.md
+++ b/tests/fixtures/rule-fixture-matrix.md
@@ -2,13 +2,13 @@
 
 - upstream source: DavidAnson/markdownlint default branch
 - total rules: 53
-- manual required: 3
+- manual required: 13
 - missing fixtures: 0
 - stale fixtures: 0
 
 | Rule | Check Pass | Check Fail | Fix | Unsafe Fix | Config Valid | Config Invalid | Edge | Manual Required |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| MD001 | 1 | 1 | 0 | 0 | 2 | 2 | 1 |  |
+| MD001 | 1 | 1 | 0 | 0 | 2 | 2 | 1 | fix requires author intent: changing heading levels can change document structure and anchors |
 | MD003 | 1 | 1 | 2 | 0 | 2 | 2 | 2 |  |
 | MD004 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
 | MD005 | 1 | 1 | 1 | 0 | 1 | 1 | 1 |  |
@@ -17,7 +17,7 @@
 | MD010 | 1 | 1 | 1 | 0 | 4 | 4 | 0 |  |
 | MD011 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD012 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
-| MD013 | 1 | 1 | 0 | 0 | 9 | 9 | 1 |  |
+| MD013 | 1 | 1 | 0 | 0 | 9 | 9 | 1 | fix requires author intent: line wrapping can change prose, code, tables, or inline references |
 | MD014 | 2 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD018 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD019 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
@@ -25,7 +25,7 @@
 | MD021 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD022 | 1 | 1 | 1 | 0 | 3 | 3 | 0 |  |
 | MD023 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
-| MD024 | 1 | 1 | 0 | 0 | 2 | 2 | 0 |  |
+| MD024 | 1 | 1 | 0 | 0 | 2 | 2 | 0 | fix requires author intent: duplicate heading fixes require choosing new heading text |
 | MD025 | 1 | 1 | 1 | 0 | 3 | 3 | 0 |  |
 | MD026 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
 | MD027 | 1 | 1 | 1 | 0 | 3 | 2 | 0 |  |
@@ -34,7 +34,7 @@
 | MD030 | 1 | 1 | 2 | 0 | 5 | 5 | 1 |  |
 | MD031 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
 | MD032 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
-| MD033 | 1 | 1 | 0 | 0 | 3 | 3 | 0 |  |
+| MD033 | 1 | 1 | 0 | 0 | 3 | 3 | 0 | fix requires author intent: removing or replacing inline HTML changes rendered output |
 | MD034 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD035 | 1 | 1 | 1 | 0 | 2 | 2 | 1 |  |
 | MD036 | 1 | 1 | 0 | 1 | 2 | 2 | 0 |  |
@@ -42,22 +42,22 @@
 | MD038 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD039 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD040 | 1 | 1 | 1 | 0 | 3 | 3 | 0 |  |
-| MD041 | 1 | 1 | 0 | 0 | 4 | 4 | 0 |  |
-| MD042 | 1 | 1 | 0 | 0 | 1 | 1 | 0 |  |
-| MD043 | 1 | 1 | 0 | 0 | 3 | 3 | 0 |  |
+| MD041 | 1 | 1 | 0 | 0 | 4 | 4 | 0 | fix requires author intent: first heading text cannot be inferred safely |
+| MD042 | 1 | 1 | 0 | 0 | 1 | 1 | 0 | fix requires author intent: empty link or image targets require author-provided destinations |
+| MD043 | 2 | 1 | 0 | 0 | 3 | 3 | 0 | check requires configured MD043.headings; default markdownlint headings is empty<br>fix requires author intent: required headings require author-provided sections and order |
 | MD044 | 2 | 1 | 1 | 0 | 4 | 4 | 0 | check requires configured MD044.names; default markdownlint names is empty; fix requires: configured MD044.names to avoid guessing product capitalization |
-| MD045 | 1 | 1 | 0 | 0 | 1 | 1 | 0 |  |
+| MD045 | 1 | 1 | 0 | 0 | 1 | 1 | 0 | fix requires author intent: alt text requires image-specific author knowledge |
 | MD046 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
 | MD047 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD048 | 1 | 1 | 1 | 0 | 2 | 2 | 1 |  |
 | MD049 | 1 | 1 | 2 | 0 | 2 | 2 | 0 |  |
 | MD050 | 1 | 1 | 2 | 0 | 2 | 2 | 0 |  |
 | MD051 | 5 | 1 | 1 | 0 | 3 | 3 | 0 |  |
-| MD052 | 1 | 1 | 2 | 0 | 3 | 3 | 0 |  |
+| MD052 | 1 | 1 | 0 | 0 | 3 | 3 | 0 | safe fix is not provided because the missing reference destination cannot be inferred |
 | MD053 | 1 | 1 | 1 | 0 | 2 | 2 | 0 |  |
 | MD054 | 2 | 1 | 1 | 0 | 7 | 7 | 0 | check requires a disabled link style such as MD054.collapsed=false; fix requires: disabled style and an inline-safe reference definition |
 | MD055 | 1 | 1 | 1 | 0 | 2 | 2 | 1 |  |
 | MD056 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
 | MD058 | 1 | 1 | 1 | 0 | 1 | 1 | 0 |  |
-| MD059 | 1 | 1 | 0 | 0 | 2 | 2 | 0 |  |
+| MD059 | 1 | 1 | 0 | 0 | 2 | 2 | 0 | fix requires author intent: descriptive link text requires replacement wording |
 | MD060 | 3 | 1 | 3 | 0 | 3 | 5 | 3 |  |

--- a/tests/list_regressions.rs
+++ b/tests/list_regressions.rs
@@ -1,0 +1,190 @@
+use katana_markdown_linter::{fix, implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn only_rule(rule_id: &str) -> LintOptions {
+    only_rule_with_properties(rule_id, HashMap::new())
+}
+
+fn only_rule_with_properties(rule_id: &str, properties: HashMap<String, String>) -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id.to_string(),
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        rule_id.to_string(),
+        RuleConfig {
+            enabled: true,
+            properties,
+        },
+    );
+    options
+}
+
+#[test]
+fn md029_keeps_ordered_list_numbering_across_indented_code_blocks() {
+    let content = "\
+1. First step:
+
+   ```sh
+   cargo build --release
+   ```
+
+2. Second step:
+
+   ```sh
+   ./target/release/KatanA
+   ```
+
+3. Verify:
+   - Sub-item A
+   - Sub-item B
+";
+    let options = only_rule("MD029");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md029_reports_broken_nested_numbering_at_the_same_level() {
+    let content = "\
+1. First item
+2. Second item
+   1. Nested 2-1
+   3. Nested 2-2
+3. Third item
+";
+    let diagnostics = lint(content, &only_rule("MD029")).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].line, 4);
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("fix should exist")
+            .replacement,
+        "2"
+    );
+}
+
+#[test]
+fn md029_default_accepts_all_one_ordered_list_style() {
+    let content = "\
+1. First
+1. Second
+1. Third
+";
+    let options = only_rule("MD029");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md029_default_accepts_zero_based_ordered_list_style() {
+    let content = "\
+0. Prepare
+1. Apply
+2. Verify
+";
+    let options = only_rule("MD029");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md029_keeps_ordered_numbering_after_lazy_continuation_lines() {
+    let content = "\
+1.
+    1. First item text wraps
+    onto the next source line
+    2. Second item keeps its number
+";
+    let options = only_rule("MD029");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md029_default_does_not_continue_numbering_across_section_boundaries() {
+    let content = "\
+1. Open
+2. Confirm
+
+---
+
+## New section
+
+1. First
+1. Second
+1. Third
+";
+    let options = only_rule("MD029");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md029_configured_ordered_rewrites_all_one_ordered_list_style() {
+    let content = "\
+1. First
+1. Second
+1. Third
+";
+    let options = only_rule_with_properties(
+        "MD029",
+        HashMap::from([("style".to_string(), "ordered".to_string())]),
+    );
+    let diagnostics = lint(content, &options).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(
+        diagnostics[0]
+            .fix
+            .as_ref()
+            .expect("fix should exist")
+            .replacement,
+        "2"
+    );
+}
+
+#[test]
+fn md007_accepts_unordered_sublist_aligned_to_ordered_item_content() {
+    let content = "\
+1. Verify:
+   - Sub-item A
+   - Sub-item B
+";
+    let options = only_rule("MD007");
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+    let fixed = fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}

--- a/tests/md036_regressions.rs
+++ b/tests/md036_regressions.rs
@@ -1,0 +1,47 @@
+use katana_markdown_linter::{implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn md036_options() -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id,
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        "MD036".to_string(),
+        RuleConfig {
+            enabled: true,
+            properties: HashMap::new(),
+        },
+    );
+    options
+}
+
+#[test]
+fn ignores_emphasized_labels_that_end_with_default_punctuation() {
+    let content = "**Goals:**\n\n- item\n\n**重要：**\n\n本文\n";
+    let diagnostics = lint(content, &md036_options()).expect("lint should run");
+
+    assert!(diagnostics.is_empty(), "MD036 diagnostics: {diagnostics:?}");
+}
+
+#[test]
+fn configured_punctuation_controls_emphasis_heading_detection() {
+    let mut options = md036_options();
+    options
+        .rules
+        .get_mut("MD036")
+        .expect("MD036 should be enabled")
+        .properties
+        .insert("punctuation".to_string(), String::new());
+
+    let diagnostics = lint("**Goals:**\n\n- item\n", &options).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_id, "MD036");
+}

--- a/tests/md043_regressions.rs
+++ b/tests/md043_regressions.rs
@@ -1,0 +1,60 @@
+use katana_markdown_linter::{implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn md043_options(properties: HashMap<String, String>) -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id,
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        "MD043".to_string(),
+        RuleConfig {
+            enabled: true,
+            properties,
+        },
+    );
+    options
+}
+
+#[test]
+fn default_empty_required_headings_does_not_require_any_heading() {
+    let diagnostics =
+        lint("No heading here.\n", &md043_options(HashMap::new())).expect("lint should run");
+
+    assert!(diagnostics.is_empty(), "MD043 diagnostics: {diagnostics:?}");
+}
+
+#[test]
+fn configured_required_headings_report_mismatch() {
+    let diagnostics = lint(
+        "# Other\n",
+        &md043_options(HashMap::from([(
+            "headings".to_string(),
+            "[\"# Title\"]".to_string(),
+        )])),
+    )
+    .expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_id, "MD043");
+}
+
+#[test]
+fn configured_required_headings_accept_matching_structure() {
+    let diagnostics = lint(
+        "# Title\n\n## Details\n",
+        &md043_options(HashMap::from([(
+            "headings".to_string(),
+            "[\"# Title\", \"## Details\"]".to_string(),
+        )])),
+    )
+    .expect("lint should run");
+
+    assert!(diagnostics.is_empty(), "MD043 diagnostics: {diagnostics:?}");
+}

--- a/tests/md052_regressions.rs
+++ b/tests/md052_regressions.rs
@@ -1,0 +1,143 @@
+use katana_markdown_linter::{fix, implemented_rules, lint, LintOptions, RuleConfig};
+use std::collections::HashMap;
+
+fn md052_options() -> LintOptions {
+    let mut options = LintOptions::default();
+    for rule in implemented_rules() {
+        options.rules.insert(
+            rule.id,
+            RuleConfig {
+                enabled: false,
+                properties: HashMap::new(),
+            },
+        );
+    }
+    options.rules.insert(
+        "MD052".to_string(),
+        RuleConfig {
+            enabled: true,
+            properties: HashMap::new(),
+        },
+    );
+    options
+}
+
+#[test]
+fn reports_missing_full_and_collapsed_reference_definitions() {
+    let content = concat!("[text][missing]\n", "![alt][missing-image]\n", "[ref][]\n");
+    let diagnostics = lint(content, &md052_options()).expect("lint should run");
+
+    let locations = diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.rule_id.as_str(), diagnostic.line))
+        .collect::<Vec<_>>();
+
+    assert_eq!(locations, vec![("MD052", 1), ("MD052", 2), ("MD052", 3)]);
+}
+
+#[test]
+fn ignores_defined_reference_labels() {
+    let content = concat!(
+        "[text][target]\n",
+        "![alt][image-target]\n",
+        "[ref][]\n",
+        "\n",
+        "[target]: https://example.com\n",
+        "[image-target]: https://example.com/image.png\n",
+        "[ref]: https://example.com/ref\n",
+    );
+    let diagnostics = lint(content, &md052_options()).expect("lint should run");
+
+    assert!(diagnostics.is_empty(), "MD052 diagnostics: {diagnostics:?}");
+}
+
+#[test]
+fn reports_shortcut_syntax_only_when_enabled() {
+    let mut options = md052_options();
+    options
+        .rules
+        .get_mut("MD052")
+        .expect("MD052 should be enabled")
+        .properties
+        .insert("shortcut_syntax".to_string(), "true".to_string());
+
+    let diagnostics = lint("## [0.22.8] - released\n", &options).expect("lint should run");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_id, "MD052");
+
+    let diagnostics = lint("## [0.22.8] - released\n", &md052_options()).expect("lint should run");
+    assert!(diagnostics.is_empty(), "MD052 diagnostics: {diagnostics:?}");
+}
+
+#[test]
+fn does_not_double_report_full_reference_when_shortcut_syntax_is_enabled() {
+    let mut options = md052_options();
+    options
+        .rules
+        .get_mut("MD052")
+        .expect("MD052 should be enabled")
+        .properties
+        .insert("shortcut_syntax".to_string(), "true".to_string());
+
+    let diagnostics = lint("[text][missing]\n", &options).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_id, "MD052");
+    assert_eq!(diagnostics[0].line, 1);
+}
+
+#[test]
+fn ignores_reference_like_text_inside_indented_code_blocks() {
+    let mut options = md052_options();
+    options
+        .rules
+        .get_mut("MD052")
+        .expect("MD052 should be enabled")
+        .properties
+        .insert("shortcut_syntax".to_string(), "true".to_string());
+
+    let content = concat!(
+        "Example:\n",
+        "\n",
+        "    [mcp_servers.kml]\n",
+        "    args = [\"--workspace-root\", \"/workspace\"]\n",
+        "    [ref][missing]\n",
+        "    [ref][]\n",
+        "\n",
+        "[text][missing]\n",
+    );
+
+    let diagnostics = lint(content, &options).expect("lint should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_id, "MD052");
+    assert_eq!(diagnostics[0].line, 8);
+}
+
+#[test]
+fn respects_ignored_labels_for_shortcut_syntax() {
+    let mut options = md052_options();
+    let config = options
+        .rules
+        .get_mut("MD052")
+        .expect("MD052 should be enabled");
+    config
+        .properties
+        .insert("shortcut_syntax".to_string(), "true".to_string());
+    config.properties.insert(
+        "ignored_labels".to_string(),
+        "[\"x\", \"!tip\"]".to_string(),
+    );
+
+    let diagnostics = lint("> [!TIP]\n> text\n- [x] done\n", &options).expect("lint should run");
+
+    assert!(diagnostics.is_empty(), "MD052 diagnostics: {diagnostics:?}");
+}
+
+#[test]
+fn does_not_apply_unsafe_missing_reference_fix() {
+    let result = fix("[ref][]\n", &md052_options()).expect("fix should run");
+
+    assert_eq!(result.content, "[ref][]\n");
+    assert_eq!(result.applied_fixes, 0);
+}

--- a/tests/rule_fixture_harness.rs
+++ b/tests/rule_fixture_harness.rs
@@ -106,7 +106,7 @@ fn fixture_matrix_can_be_loaded_by_harness() {
         .filter_map(|rule| rule.official_meta().map(|meta| meta.code.to_string()))
         .collect::<HashSet<_>>();
 
-    assert_eq!(matrix["summary"]["manual_required"].as_u64(), Some(3));
+    assert_eq!(matrix["summary"]["manual_required"].as_u64(), Some(13));
     assert!(rules(&matrix)
         .iter()
         .all(|rule| active.contains(rule_id(rule))));
@@ -310,7 +310,7 @@ fn config_property_error_shapes_are_fixed() {
 fn edge_cases_cover_empty_no_newline_long_code_fence_and_html() {
     let options = LintOptions::default();
     let empty = lint("", &options).expect("lint should run");
-    assert!(empty.iter().any(|diagnostic| diagnostic.rule_id == "MD043"));
+    assert!(empty.iter().all(|diagnostic| diagnostic.rule_id != "MD043"));
 
     let missing_newline = lint("text", &options).expect("lint should run");
     assert!(missing_newline


### PR DESCRIPTION
## Summary
- Prepare v0.12.21 release
- Add default exclusions and opt-in traversal contracts
- Complete KatanA feedback sweep and release-readiness scoring
- Add task-ledger release gate

## Verification
- make release-check VERSION=v0.12.21
- make release-task-ledger-check VERSION=v0.12.21
- git diff --check