### PR TITLE
Prepare v0.13.0 release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.13.0
+
+- Completes MCP Registry and hub distribution planning without publishing
+  registry metadata yet. The selected package targets are MCPB from GitHub
+  Releases and an OCI image on GHCR, with npm and PyPI wrappers deferred.
+- Adds `docs/mcp-distribution-plan.md` and extends `docs/mcp-server.md` with a
+  `server.json` draft plus a registry security checklist for workspace-safe
+  stdio use.
+- Updates the OpenSpec roadmap and `v0.13.0` task ledger so publication work is
+  explicitly handed off to `v0.14.0`, while remote MCP transport remains split
+  into `v0.15.0`.
+- Extends release preflight triggers to include README, docs, and OpenSpec
+  changes so required checks run for documentation-only release planning PRs.
+
 ## v0.12.21
 
 - Excludes reserved and normally ignored directories from recursive CLI input by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.12.21"
+version = "0.13.0"
 dependencies = [
  "glob",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.12.21"
+version = "0.13.0"
 
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fix the failed post-merge Release workflow from PR #52 by aligning Cargo.toml and Cargo.lock with `v0.13.0`
- Add the `v0.13.0` CHANGELOG entry used by release notes generation

## Verification
- `scripts/release/verify-version.sh v0.13.0`
- `scripts/release/release-notes.sh 0.13.0`
- `cargo check --locked`
- `make ast-lint`
- `make dogfood`
- `make release-task-ledger-check VERSION=v0.13.0`
- `git diff --check`
- `make release-check VERSION=v0.13.0`

## Cause
PR #52 was merged from `release/v0.13.0`, so the Release workflow correctly treated it as a `v0.13.0` release branch. The branch only contained planning docs, leaving `Cargo.toml` at `0.12.21`, so `scripts/release/verify-version.sh v0.13.0` failed during the post-merge release run.