### PR TITLE
Fix release verification on macOS bash

### DIFF
--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -41,7 +41,7 @@ if [[ "${release_target}" != "${local_target}" ]]; then
 fi
 
 cargo_info="$(cargo info "${PACKAGE}@${VERSION_BARE}" --registry crates-io)"
-crate_version="$(awk -F ': ' '/^version:/ { print $2; exit }' <<< "${cargo_info}")"
+crate_version="$(printf '%s\n' "${cargo_info}" | sed -n 's/^version: //p')"
 if [[ "${crate_version}" != "${VERSION_BARE}" ]]; then
   echo "crates.io version mismatch: expected ${VERSION_BARE}, got ${crate_version:-missing}" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Avoid a macOS bash hang in release verification when parsing cargo info output

## Verification
- bash -n scripts/release/verify-release-published.sh
- git diff --check
- make release-verify VERSION=v0.16.2
