### PR TITLE
Fix v0.17.0 Intel macOS release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -311,6 +311,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (".github/workflows/release.yml", &workflow, "MCP Registry metadata"),
         (".github/workflows/release.yml", &workflow, "run: make document-answer-fix"),
         (".github/workflows/release.yml", &workflow, "Binary artifact (${{ matrix.target }})"),
+        (".github/workflows/release.yml", &workflow, "macos-15-intel"),
         (".github/workflows/release.yml", &workflow, "Generate Homebrew formula"),
         (".github/workflows/release.yml", &workflow, "Publish npm wrapper"),
         (".github/workflows/release.yml", &workflow, "node-version: \"24\""),


### PR DESCRIPTION
## Summary
- replace retired macos-13 release runner with macos-15-intel for x86_64-apple-darwin artifacts
- add an AST lint guard so the release workflow keeps the supported Intel runner label

## Verification
- make ast-lint
- git diff --check
- release workflow YAML parse