### PR TITLE
Trigger v0.17.0 release

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -105,6 +105,9 @@ The workflow creates or updates:
 - `.mcpb.sha256` checksum
 - rendered MCP Registry `server.json`
 
+The `x86_64-apple-darwin` artifact uses GitHub Actions `macos-15-intel`
+because the older `macos-13` image is no longer supported.
+
 The root `action.yml` is the official GitHub Action channel from `v0.11.0`.
 Release preflight must keep `make action-smoke` passing before publishing a tag.
 


### PR DESCRIPTION
## Summary
- trigger the v0.17.0 release workflow after updating the Intel macOS runner label

## Verification
- v0.17.0 release implementation already passed PR #61 checks
- runner fix passed PR #62 checks
- current tag, GitHub Release, and crates.io v0.17.0 are not published yet