### PR TITLE
Align npm wrapper repository metadata

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -16,6 +16,7 @@ on:
       - 'scripts/**'
       - 'server.json'
       - 'tests/**'
+      - 'wrappers/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -17,6 +17,7 @@ on:
       - 'openspec/**'
       - 'scripts/**'
       - 'tests/**'
+      - 'wrappers/**'
   pull_request:
     branches: [main, master]
     paths:
@@ -33,6 +34,7 @@ on:
       - 'openspec/**'
       - 'scripts/**'
       - 'tests/**'
+      - 'wrappers/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HiroyukiFuruno/katana-markdown-linter.git"
+    "url": "https://github.com/HiroyukiFuruno/katana-markdown-linter.git"
   },
   "bin": {
     "kml": "bin/kml.js"


### PR DESCRIPTION
## Summary
- Align npm wrapper repository URL with the GitHub repository URL for npm trusted publishing validation

## Verification
- make wrapper-publish-gate
- npm pack --dry-run --json
- git diff --check