### PR TITLE
Support npm token bootstrap publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish npm wrapper
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
         working-directory: wrappers/npm
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -197,6 +197,12 @@ wrapper metadata first if the package name is changed before publication.
 GitHub OIDC Registry authentication does not require a dedicated secret, but the
 Release workflow must keep `id-token: write`.
 
+For the first npm wrapper publication, npm can require a traditional publish
+token because trusted publishing is configured from an existing package. If the
+package does not exist yet, create a short-lived granular token with publish
+permission, store it as `NPM_TOKEN`, publish the first wrapper version, then
+configure npm trusted publishing and revoke the token.
+
 ## Quality Gates and Branch Protection
 
 See `docs/quality-gates.md` for the authoritative mapping between local `make` targets, CI required checks, and branch protection.


### PR DESCRIPTION
## Summary
- Allow the npm wrapper publish job to use an optional `NPM_TOKEN` secret for first-time npm package bootstrap
- Document that npm trusted publishing needs an existing package and the token should be revoked after bootstrap

## Verification
- make ast-lint
- make wrapper-publish-gate
- git diff --check