### PR TITLE
Add OpenSpec roadmap plans

### DIFF
--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -33,9 +33,20 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.16.1`: KatanA 本体と同じ locale set に合わせ、description 系 API と rule document Markdown の i18n 欠落を閉じる。
 - `v0.16.2`: `v0.17.0` の配布拡張を凍結したまま、document answer fix evaluation で `kml check --fix` の byte-for-byte 正しさを固める。
 - `v0.17.0`: released distribution expansion with standalone binary artifacts, Homebrew formula generation, and deferred npm/pip wrapper publication gates.
+- `v0.17.1`: post-release distribution closeout として npm / PyPI wrapper を公式 install channel に昇格し、Homebrew tap 更新、npm trusted publishing 後始末、`release-verify` の wrapper / tap 検証拡張を扱う。
+- `v0.18.0`: config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
+- `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
+- `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
+- `v0.18.3`: editor extension hardening を進める。VS Code / Zed の install docs、smoke tests、release verification、将来の Neovim docs-only sample をまとめて整える。
 
 | Priority | Work Area | Change | Why Now |
 | --- | --- | --- | --- |
+| P0 | Distribution closeout for `v0.17.1` | `v0-17-1-distribution-closeout` | `v0.17.0` already published GitHub Release, crates.io, npm, and PyPI. The roadmap should now close the remaining operational gap: mark wrappers official, update `docs/distribution.md` and `docs/release-runbook.md`, update the Homebrew tap from generated formula output, configure npm trusted publishing, remove the temporary `NPM_TOKEN`, and teach `release-verify` to check npm / PyPI / Homebrew state. |
+| P1 | Schema publication for `v0.18.0` | `v0-18-0-schema-publication` | `kml config schema` already exists, but distribution docs still defer schema publication. The next durable step is a versioned schema contract, fixture-backed schema compatibility checks, and docs that editor integrations can rely on. |
+| P1 | VS Code extension MVP for `v0.18.1` | `v0-18-1-vscode-extension-mvp` | The LSP entrypoint and schema command already exist. VS Code should become the first real editor target because the extension surface can stay thin: launch `kml lsp`, associate the config schema, and expose diagnostics / format / safe quick-fix without moving lint logic into the extension. |
+| P2 | Zed extension MVP for `v0.18.2` | `v0-18-2-zed-extension-mvp` | Zed is the second target. Keep it behind VS Code so the shared `kml lsp` contract is already stable, then validate only the Zed-specific extension boundary and installation flow. |
+| P2 | Editor extension hardening for `v0.18.3` | `v0-18-3-editor-extension-hardening` | After both target editors have MVPs, harden install docs, smoke tests, release verification, marketplace packaging, and optional docs-only Neovim configuration without expanding the core engine. |
+| P2 | Release verification hardening | TBD: `release-verification-hardening` | `v0.17.0` exposed that external registry verification is broader than GitHub Release + crates.io. Add npm, PyPI, wrapper launch, and tap formula checks to the post-release verification path before the next distribution release. |
 | Done | Golden and edge coverage for `v0.4.0` | `golden-edge-coverage-expansion` | Completed for `v0.4.0`; dashboard now derives golden status from the locked baseline and records edge coverage. |
 | Done | Safe check/fix expansion for `v0.4.0` | `safe-fix-strategy-expansion` | Completed for `v0.4.0`; `MD005` and `MD030` safe subsets are locked, while `MD060` remains diagnostic/manual-required because official metadata marks it non-fixable. |
 | Done | Table strategy for `v0.5.0` | `v0-5-0-table-strategy-md060` | Completed for `v0.5.0`; `MD060` now has table-block parsing, official style checks, and safe fix subsets. |
@@ -115,7 +126,12 @@ Archived completed changes:
 
 ## Suggested Order
 
-No active release-train changes remain in this roadmap section.
+1. `v0-17-1-distribution-closeout`: close the published-channel gaps first because npm / PyPI are already public and Homebrew tap state is the remaining user-visible distribution gap.
+2. `v0-18-0-schema-publication`: make the existing config schema command a stable published contract before more editor polish depends on it.
+3. `v0-18-1-vscode-extension-mvp`: build the first thin editor wrapper on the stable schema and existing LSP entrypoint.
+4. `v0-18-2-zed-extension-mvp`: reuse the shared LSP contract and validate the Zed-specific extension boundary.
+5. `v0-18-3-editor-extension-hardening`: harden docs, smoke tests, release checks, and packaging after both target editor MVPs exist.
+6. `release-verification-hardening`: can run alongside the above if its write set stays limited to release scripts, `Makefile`, and release docs.
 
 ## Deferred Until v0.12.8 Stable Acceptance
 

--- a/openspec/changes/v0-17-1-distribution-closeout/.openspec.yaml
+++ b/openspec/changes/v0-17-1-distribution-closeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/v0-17-1-distribution-closeout/design.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/design.md
@@ -1,0 +1,91 @@
+# Distribution Closeout Design
+
+## Context
+
+`v0.17.0` の wrapper 公開後、npm と PyPI は実際に利用できる状態になった。
+しかし `docs/distribution.md` には deferred 表記が残り、`release-verify` は
+GitHub Release / crates.io / binary assets 中心の確認に留まっている。
+
+npm の初回公開では `NPM_TOKEN` を使ったため、次の release までに
+trusted publishing へ戻し、token を不要にする必要がある。
+PyPI は trusted publisher が設定済みで、GitHub Actions 側は `pypi` environment を使う。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- npm / PyPI wrapper を公式 install channel として docs に反映する
+- npm publish job から `NPM_TOKEN` 前提を取り除く
+- `release-verify` で npm / PyPI / wrapper 起動 / Homebrew formula を確認する
+- `homebrew-katana` tap 更新を release 本体と分離した review 可能な差分にする
+- 公式導線と検証 gate の説明を README / docs / changelog で一致させる
+
+**Non-Goals:**
+
+- wrapper に Markdown lint logic を実装すること
+- package manager ごとに CLI option や exit code を変えること
+- Homebrew tap を未検証のまま自動 push すること
+- `kml lsp` や editor extension の機能追加
+- 新しい distribution channel の追加
+
+## Decisions
+
+### D-1: wrapper は公式 binary の launcher のまま維持する
+
+npm / PyPI package は、引き続き GitHub Release の binary archive を取得して
+`kml` を起動する薄いラッパー（thin wrapper）にする。
+wrapper 側に rule、formatter、LSP logic は持たせない。
+
+### D-2: npm publish は trusted publishing を標準に戻す
+
+`NPM_TOKEN` は初回公開用の暫定手段だった。
+`v0.17.1` では npm package 側の trusted publishing 設定を前提にし、
+GitHub Actions の publish job は OIDC を使う。
+token が必要な経路は release docs から通常手順として削除する。
+
+### D-3: post-release verification は外部 registry まで見る
+
+`make release-verify VERSION=vX.Y.Z` は次を確認する。
+
+- GitHub Release の tag / title / target / draft 状態
+- supported target の binary archive と checksum
+- crates.io version
+- npm package version と `npx --yes katana-markdown-linter@X.Y.Z --version`
+- PyPI JSON version と `uvx --from katana-markdown-linter==X.Y.Z kml --version`
+- generated Homebrew formula の version、URL、checksum、test block
+
+### D-4: Homebrew tap 更新は別 repository の review flow に残す
+
+この repository は formula 生成と検証を担当する。
+`homebrew-katana` への反映は sibling repository で差分を作り、
+`brew audit` / `brew test` 相当の結果を確認してから commit / push する。
+
+### D-5: docs は公開済み channel だけを公式として書く
+
+README と docs は、実際に verified できる channel だけを公式導線として扱う。
+deferred / provisional / token-required の古い表現は残さない。
+
+## Risks / Trade-offs
+
+- npm trusted publishing の設定値が workflow filename とずれる
+  - `docs/release-runbook.md` と release workflow の workflow filename を一致させる
+- `uvx` や `npx` の network 状態で verification が失敗する
+  - `release-verify` は post-release gate とし、失敗時は registry 状態を明示して止める
+- Homebrew tap 更新が別 repository の状態に影響される
+  - formula 生成結果と tap 差分を分け、tap 側で通常の branch / PR flow を使う
+- token cleanup を急ぎすぎると次回 npm publish が止まる
+  - npm trusted publishing 設定の存在を確認してから `NPM_TOKEN` 依存を削除する
+
+## Migration Plan
+
+1. npm trusted publishing 設定値を docs と workflow で固定する
+2. `release.yml` の npm publish job から `NODE_AUTH_TOKEN` / `NPM_TOKEN` 依存を取り除く
+3. `release-verify` に npm / PyPI / wrapper launch / Homebrew formula checks を追加する
+4. Homebrew formula を `homebrew-katana` tap に反映する差分を作る
+5. README / distribution docs / release runbook / quality gates / changelog を更新する
+6. `v0.17.1` release check と post-release verification を実行する
+
+## Open Questions
+
+- npm trusted publishing の package 側設定が完了しているかは、implementation 開始時に確認する
+- Homebrew tap 更新は direct push か PR か、tap repository の branch protection を見て決める

--- a/openspec/changes/v0-17-1-distribution-closeout/proposal.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/proposal.md
@@ -1,0 +1,51 @@
+# Distribution Closeout
+
+## Target Version
+
+`v0.17.1`
+
+## Why
+
+`v0.17.0` で GitHub Release、crates.io、npm、PyPI への公開は完了した。
+一方で README / docs / release verification / Homebrew tap / npm token 後始末がまだ
+公開済み状態に追いついていない。
+
+この change では、公開済み wrapper を公式 install channel として扱える状態にし、
+次の開発へ進む前に配布導線の運用差分を閉じる。
+
+## What Changes
+
+- npm / PyPI wrapper を公式 install channel として README と docs に反映する
+- Homebrew formula を `homebrew-katana` tap へ反映するための差分と検証手順を固定する
+- npm publish を一時的な `NPM_TOKEN` 依存から trusted publishing 前提へ戻す
+- PyPI trusted publisher 設定と GitHub Actions の `pypi` environment 前提を release docs に固定する
+- `make release-verify` が npm、PyPI、wrapper 起動、Homebrew formula まで確認するようにする
+- `docs/distribution.md` と `docs/release-runbook.md` の deferred 表記を公開済み状態に合わせる
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `binary-distribution`: npm / PyPI wrapper と Homebrew formula の公式化条件を更新する
+- `release-cicd`: wrapper publish job と trusted publishing の責務を更新する
+- `release-readiness`: post-release verification の対象を external registry と tap まで広げる
+
+## Impact
+
+- `.github/workflows/release.yml`
+- `Makefile`
+- `scripts/release/verify-release-published.sh`
+- `scripts/release/wrapper-publish-gate.sh`
+- `scripts/release/homebrew_formula.py`
+- `wrappers/npm/**`
+- `wrappers/python/**`
+- `README.md`
+- `docs/distribution.md`
+- `docs/release-runbook.md`
+- `docs/quality-gates.md`
+- `CHANGELOG.md`
+- sibling repository: `/Users/hiroyuki_furuno/works/private/homebrew-katana`

--- a/openspec/changes/v0-17-1-distribution-closeout/specs/binary-distribution/spec.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/specs/binary-distribution/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: npm and PyPI wrappers SHALL be official only after registry verification
+
+npm / PyPI wrapper は、registry 公開状態と wrapper 起動検証が揃った場合だけ公式 install channel として扱わなければならない（SHALL）。
+
+#### Scenario: wrapper channel is documented as official
+
+- **WHEN** repository docs list npm or PyPI as an official install channel
+- **THEN** system verifies the registry package version matches the release version
+- **AND** system verifies the wrapper launches `kml --version` for that release
+- **AND** system does not describe unpublished or unverified wrapper paths as official
+
+### Requirement: Homebrew formula SHALL be updated from verified release artifacts
+
+Homebrew formula は、GitHub Release の verified binary archive と checksum から生成された内容を tap に反映しなければならない（SHALL）。
+
+#### Scenario: tap formula is prepared
+
+- **WHEN** developer prepares the Homebrew tap update for `vX.Y.Z`
+- **THEN** system uses the generated formula output for that release
+- **AND** formula URLs point to GitHub Release binary archives for `vX.Y.Z`
+- **AND** formula checksum values match the release checksum files
+- **AND** tap mutation remains reviewable as a separate repository diff

--- a/openspec/changes/v0-17-1-distribution-closeout/specs/release-cicd/spec.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/specs/release-cicd/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: npm wrapper publication SHALL use trusted publishing
+
+npm wrapper publication は、通常 release path で repository secret token に依存してはならない（SHALL NOT）。
+
+#### Scenario: npm wrapper publish job runs
+
+- **WHEN** release workflow publishes the npm wrapper
+- **THEN** job uses GitHub Actions OIDC trusted publishing
+- **AND** job does not require `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+- **AND** job fails before publish when trusted publishing is not available
+
+### Requirement: PyPI wrapper publication SHALL keep environment-scoped OIDC
+
+PyPI wrapper publication は、`pypi` environment と trusted publisher の組み合わせで実行されなければならない（SHALL）。
+
+#### Scenario: PyPI wrapper publish job runs
+
+- **WHEN** release workflow publishes the PyPI wrapper
+- **THEN** job runs under the `pypi` GitHub environment
+- **AND** job uses `pypa/gh-action-pypi-publish`
+- **AND** job does not require username, password, or API token secrets
+
+### Requirement: wrapper publish gate SHALL match workflow behavior
+
+wrapper publish gate は、workflow の実際の publish 条件と同じ前提を検証しなければならない（SHALL）。
+
+#### Scenario: local release check evaluates wrapper publication
+
+- **WHEN** developer runs the release gate with wrapper publication enabled
+- **THEN** system reports that trusted publishing is required
+- **AND** local gate does not pretend to publish registry packages
+- **AND** workflow-only behavior is documented as a post-merge release action

--- a/openspec/changes/v0-17-1-distribution-closeout/specs/release-readiness/spec.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/specs/release-readiness/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: release verification SHALL include public package registries
+
+公開後検証（post-release verification）は、GitHub Release と crates.io だけでなく、npm と PyPI の公開状態を確認しなければならない（SHALL）。
+
+#### Scenario: release verification checks registry versions
+
+- **WHEN** developer runs `make release-verify VERSION=vX.Y.Z`
+- **THEN** system verifies crates.io contains `katana-markdown-linter` version `X.Y.Z`
+- **AND** system verifies npm contains `katana-markdown-linter` version `X.Y.Z`
+- **AND** system verifies PyPI contains `katana-markdown-linter` version `X.Y.Z`
+- **AND** system fails with a registry-specific error when a version is missing
+
+### Requirement: release verification SHALL execute wrapper launch smoke tests
+
+公開後検証は、公開済み wrapper から `kml` が起動することを確認しなければならない（SHALL）。
+
+#### Scenario: release verification launches wrappers
+
+- **WHEN** developer runs `make release-verify VERSION=vX.Y.Z`
+- **THEN** system runs the npm wrapper through `npx --yes katana-markdown-linter@X.Y.Z --version`
+- **AND** system runs the PyPI wrapper through `uvx --from katana-markdown-linter==X.Y.Z kml --version`
+- **AND** both commands must print `X.Y.Z`
+
+### Requirement: release verification SHALL include Homebrew formula evidence
+
+公開後検証は、Homebrew formula が release artifact と一致していることを確認しなければならない（SHALL）。
+
+#### Scenario: release verification checks formula output
+
+- **WHEN** developer runs `make release-verify VERSION=vX.Y.Z`
+- **THEN** system renders or reads the Homebrew formula for `vX.Y.Z`
+- **AND** system verifies formula URL values reference the expected release archives
+- **AND** system verifies formula checksum values match generated checksum files
+- **AND** system verifies formula test block executes `kml --version`

--- a/openspec/changes/v0-17-1-distribution-closeout/tasks.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/tasks.md
@@ -1,0 +1,68 @@
+# Tasks
+
+## Definition of Ready
+
+- [ ] 0.1 npm package `katana-markdown-linter` の trusted publishing 設定を確認する
+- [ ] 0.2 PyPI project `katana-markdown-linter` の trusted publisher と `pypi` environment を確認する
+- [ ] 0.3 `homebrew-katana` tap の local checkout と branch protection を確認する
+- [ ] 0.4 `v0.17.0` の npm / PyPI / GitHub Release / crates.io 公開状態を再確認する
+- [ ] 0.5 `NPM_TOKEN` を次回 release の通常手順から外せることを確認する
+
+## 1. npm / PyPI Wrapper Officialization
+
+- [ ] 1.1 npm wrapper の install command と `npx` 実行例を README / docs に公式導線として反映する
+- [ ] 1.2 PyPI wrapper の install command と `uvx` 実行例を README / docs に公式導線として反映する
+- [ ] 1.3 wrapper が binary launcher であり、独自 lint logic を持たないことを docs に明記する
+- [ ] 1.4 `docs/distribution.md` の npm / pip deferred 表記を公開済み状態へ更新する
+
+## 2. Trusted Publishing Cleanup
+
+- [ ] 2.1 `.github/workflows/release.yml` の npm publish job から `NPM_TOKEN` / `NODE_AUTH_TOKEN` 依存を削除する
+- [ ] 2.2 npm publish job が trusted publishing 前提で失敗する場合の error message を明確にする
+- [ ] 2.3 PyPI publish job が `pypi` environment と OIDC publish を維持していることを検証する
+- [ ] 2.4 `scripts/release/wrapper-publish-gate.sh` の文言と実際の workflow 条件を一致させる
+- [ ] 2.5 `docs/release-runbook.md` から初回公開用 token 手順を通常手順として扱う記述を外す
+
+## 3. Release Verification
+
+- [ ] 3.1 `scripts/release/verify-release-published.sh` に npm registry version check を追加する
+- [ ] 3.2 `scripts/release/verify-release-published.sh` に PyPI JSON version check を追加する
+- [ ] 3.3 `scripts/release/verify-release-published.sh` に `npx` wrapper smoke を追加する
+- [ ] 3.4 `scripts/release/verify-release-published.sh` に `uvx` wrapper smoke を追加する
+- [ ] 3.5 `scripts/release/verify-release-published.sh` に Homebrew formula URL / checksum / test block check を追加する
+- [ ] 3.6 `make release-verify VERSION=v0.17.1` が追加検証を呼ぶことを確認する
+
+## 4. Homebrew Tap Update
+
+- [ ] 4.1 `make homebrew-formula VERSION=v0.17.1` で生成される formula を確認する
+- [ ] 4.2 `homebrew-katana` tap に `Formula/kml.rb` 差分を作る
+- [ ] 4.3 tap 側で `brew audit` / `brew test` 相当の確認を行う
+- [ ] 4.4 tap 更新の commit / push / PR 方針を branch protection に合わせて実行する
+- [ ] 4.5 tap 更新結果を release runbook に追記する
+
+## 5. Documentation and Release Metadata
+
+- [ ] 5.1 README の install section を Cargo / GitHub Release / npm / PyPI / Homebrew の現状に合わせる
+- [ ] 5.2 `docs/release-runbook.md` の wrapper publish と post-release verification を更新する
+- [ ] 5.3 `docs/quality-gates.md` に registry / wrapper / Homebrew verification を追加する
+- [ ] 5.4 `CHANGELOG.md` に `v0.17.1` の配布後始末を追加する
+- [ ] 5.5 version metadata を `0.17.1` に更新する
+
+## 6. Verification
+
+- [ ] 6.1 `make fmt-check`
+- [ ] 6.2 `make lint`
+- [ ] 6.3 `make ast-lint`
+- [ ] 6.4 `cargo test --workspace --locked`
+- [ ] 6.5 `make dogfood`
+- [ ] 6.6 `git diff --check`
+- [ ] 6.7 `make release-check VERSION=v0.17.1`
+- [ ] 6.8 `make release-task-ledger-check VERSION=v0.17.1`
+
+## Definition of Done
+
+- [ ] 7.1 npm / PyPI wrapper が README と docs で公式 install channel として扱われている
+- [ ] 7.2 npm publish job が通常 release path で `NPM_TOKEN` を要求しない
+- [ ] 7.3 `make release-verify` が npm / PyPI / wrapper launch / Homebrew formula を確認する
+- [ ] 7.4 Homebrew tap 更新が review 可能な差分として完了している
+- [ ] 7.5 `v0.17.1` release 後の public registry state が verification で確認できる

--- a/openspec/changes/v0-18-0-schema-publication/.openspec.yaml
+++ b/openspec/changes/v0-18-0-schema-publication/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/v0-18-0-schema-publication/design.md
+++ b/openspec/changes/v0-18-0-schema-publication/design.md
@@ -1,0 +1,91 @@
+# Config Schema Publication Design
+
+## Context
+
+現在の schema は `src/config/schema.rs` から生成され、`kml config schema` と
+`schema/markdownlint.schema.json` によって確認できる。
+README と `docs/editor-integration.md` は stable schema ID として
+`https://schemas.katana.tools/kml/markdownlint.schema.json` を示している。
+
+ただし、release 時に committed schema と CLI 出力の一致を保証する gate が弱く、
+versioned artifact と compatibility policy も明文化されていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `schema/markdownlint.schema.json` を published schema の canonical file として扱う
+- `kml config schema --output json` と canonical file の byte-for-byte または semantic equality を検証する
+- release asset または stable hosting に versioned schema artifact を含める
+- schema compatibility policy を docs と tests に固定する
+- editor extension が schema URL と local schema file のどちらにも依存できるようにする
+
+**Non-Goals:**
+
+- Markdown rule の追加や safe fix の変更
+- VS Code / Zed extension の実装
+- 外部 website repository の大規模改修
+- markdownlint upstream と完全同一の schema 表現に寄せること
+- schema だけで全 config error の line / column precision を保証すること
+
+## Decisions
+
+### D-1: canonical schema は repository 内の generated file にする
+
+`schema/markdownlint.schema.json` を canonical schema file とする。
+`kml config schema --output json` は同じ JSON 構造を出力しなければならない。
+差分がある場合は、rule metadata 変更に伴う schema 更新漏れとして release gate で失敗させる。
+
+### D-2: stable ID と versioned artifact を分ける
+
+`$id` は stable URL のまま維持する。
+release では versioned artifact を別名で添付し、editor docs は stable URL と
+release-pinned URL の両方を説明する。
+
+例:
+
+- stable: `https://schemas.katana.tools/kml/markdownlint.schema.json`
+- pinned: `markdownlint.schema.vX.Y.Z.json`
+
+### D-3: compatibility は additive-first にする
+
+既存 rule property の型、enum、default、description key を無断で破壊しない。
+rule 追加や property 追加は additive change として許容する。
+breaking schema change が必要な場合は、OpenSpec change で明示し、docs に migration note を残す。
+
+### D-4: editor validation docs は schema の消費方法だけを扱う
+
+`docs/editor-integration.md` は `.markdownlint.json` / `.markdownlint.jsonc` の
+schema mapping を説明する。
+VS Code / Zed extension の起動や marketplace packaging は後続 change に送る。
+
+### D-5: release gate は local と CI で同じ script を使う
+
+schema generation / comparison / validation は script 化し、
+`make schema-check` と release workflow の両方から呼ぶ。
+AST lint には、release gate から schema check が外れないことを確認する guard を追加する。
+
+## Risks / Trade-offs
+
+- stable URL の hosting が外部 repository に依存する
+  - この change では versioned release artifact も作り、外部 hosting 不備でも pinned schema を参照できるようにする
+- schema diff が property order だけで失敗する
+  - comparison は stable serializer か semantic equality を使う
+- rule metadata の typo が schema と docs の両方へ広がる
+  - fixture-backed regression と `kml rule` metadata との整合性を確認する
+- editor ごとの schema association 設定が違う
+  - extension 実装ではなく、schema file と URL contract だけをここで固定する
+
+## Migration Plan
+
+1. schema generation check script を追加する
+2. committed schema file と CLI 出力の一致テストを追加する
+3. schema compatibility fixture を追加する
+4. release workflow に schema artifact と schema check を追加する
+5. README / editor integration docs / distribution docs を更新する
+6. `make release-check VERSION=v0.18.0` に schema gate を通す
+
+## Open Questions
+
+- stable URL の実体をこの repository の GitHub Pages で持つか、別 site で持つかは implementation 開始時に確認する
+- versioned artifact 名は release asset 一覧の既存 naming と合わせて最終決定する

--- a/openspec/changes/v0-18-0-schema-publication/proposal.md
+++ b/openspec/changes/v0-18-0-schema-publication/proposal.md
@@ -1,0 +1,50 @@
+# Config Schema Publication
+
+## Target Version
+
+`v0.18.0`
+
+## Why
+
+`kml config schema` と `schema/markdownlint.schema.json` は存在するが、
+公開 URL、versioned schema、回帰検証、editor docs が release gate としてまだ固定されていない。
+
+VS Code / Zed extension を作る前に、editor が依存できる設定スキーマ（schema）の
+公開契約を固める。
+
+## What Changes
+
+- committed schema file と `kml config schema` 出力が一致することを検証する
+- stable schema URL と versioned schema artifact の扱いを固定する
+- schema regression test を追加し、rule metadata 変更時の意図しない schema 差分を検出する
+- `.markdownlint.json` / `.markdownlint.jsonc` の editor validation docs を更新する
+- release workflow と local release gate に schema publication check を追加する
+- schema の compatibility policy を docs に明記する
+
+## Capabilities
+
+### New Capabilities
+
+- `config-schema-publication`: published config schema、versioned artifact、compatibility check を扱う
+
+### Modified Capabilities
+
+- `cli`: `kml config schema` の published schema contract を固定する
+- `release-readiness`: release gate に schema publication evidence を追加する
+
+## Impact
+
+- `schema/markdownlint.schema.json`
+- `src/config/schema.rs`
+- `src/cli/workflow/config_cmd.rs`
+- `tests/cli_core_contract.rs`
+- `tests/ast_linter.rs`
+- `.github/workflows/release.yml`
+- `.github/workflows/release-preflight.yml`
+- `Makefile`
+- `scripts/release/**`
+- `README.md`
+- `docs/editor-integration.md`
+- `docs/distribution.md`
+- `docs/quality-gates.md`
+- `docs/release-runbook.md`

--- a/openspec/changes/v0-18-0-schema-publication/specs/cli/spec.md
+++ b/openspec/changes/v0-18-0-schema-publication/specs/cli/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: CLI config schema output SHALL match published schema
+
+CLI は、published schema と一致する config schema を出力しなければならない（SHALL）。
+
+#### Scenario: schema command prints JSON schema
+
+- **WHEN** user runs `kml config schema --output json`
+- **THEN** CLI prints a valid JSON Schema document
+- **AND** `$id` matches the stable schema URL
+- **AND** output is semantically equal to `schema/markdownlint.schema.json`
+
+### Requirement: CLI config schema output SHALL remain editor-consumable
+
+CLI の config schema output は、editor の JSON schema integration でそのまま使える構造でなければならない（SHALL）。
+
+#### Scenario: editor consumes generated schema
+
+- **WHEN** user saves `kml config schema --output json` to a local file
+- **THEN** JSON Schema validators accept the document
+- **AND** schema includes rule descriptions, defaults, and supported property shapes
+- **AND** schema rejects unknown top-level rule keys through `additionalProperties: false`

--- a/openspec/changes/v0-18-0-schema-publication/specs/config-schema-publication/spec.md
+++ b/openspec/changes/v0-18-0-schema-publication/specs/config-schema-publication/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: repository SHALL publish a canonical markdownlint config schema
+
+repository は、`.markdownlint.json` と `.markdownlint.jsonc` 用の canonical schema file を保持しなければならない（SHALL）。
+
+#### Scenario: canonical schema is checked
+
+- **WHEN** developer runs the schema check
+- **THEN** system reads `schema/markdownlint.schema.json`
+- **AND** system compares it with `kml config schema --output json`
+- **AND** system fails when the canonical file is missing or stale
+
+### Requirement: schema publication SHALL provide stable and versioned references
+
+schema publication は、stable URL と release-pinned artifact の両方を提供しなければならない（SHALL）。
+
+#### Scenario: schema is published for a release
+
+- **WHEN** release workflow publishes `vX.Y.Z`
+- **THEN** system includes a versioned schema artifact for that release
+- **AND** canonical schema `$id` remains the stable schema URL
+- **AND** docs explain when to use stable URL and when to use pinned artifact URL
+
+### Requirement: schema compatibility SHALL be regression-tested
+
+schema compatibility は、意図しない破壊的変更を検出する regression test で守られなければならない（SHALL）。
+
+#### Scenario: rule metadata changes
+
+- **WHEN** rule metadata or config property metadata changes
+- **THEN** system detects schema output changes during tests
+- **AND** additive rule or property additions are allowed when fixtures are updated
+- **AND** type, enum, or default value removals require an explicit OpenSpec decision
+
+### Requirement: editor validation docs SHALL reference the published schema contract
+
+editor validation docs は、published schema contract に沿って書かれなければならない（SHALL）。
+
+#### Scenario: user configures editor schema validation
+
+- **WHEN** user follows editor integration docs
+- **THEN** docs show schema association for `.markdownlint.json`
+- **AND** docs show schema association for `.markdownlint.jsonc`
+- **AND** docs do not require installing an editor extension only to validate config files

--- a/openspec/changes/v0-18-0-schema-publication/specs/release-readiness/spec.md
+++ b/openspec/changes/v0-18-0-schema-publication/specs/release-readiness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: release readiness SHALL include schema publication checks
+
+release readiness は、schema publication の検証を含まなければならない（SHALL）。
+
+#### Scenario: release check validates schema publication
+
+- **WHEN** developer runs `make release-check VERSION=vX.Y.Z`
+- **THEN** system verifies canonical schema file and CLI schema output match
+- **AND** system verifies schema regression fixtures are current
+- **AND** system verifies release workflow includes the versioned schema artifact step
+
+### Requirement: release notes SHALL describe schema compatibility when schema changes
+
+schema が変更される release note は、互換性の扱いを説明しなければならない（SHALL）。
+
+#### Scenario: release includes schema changes
+
+- **WHEN** schema output differs from the previous release
+- **THEN** release metadata records whether the change is additive or breaking
+- **AND** breaking schema changes include migration notes
+- **AND** additive schema changes can be released without migration notes

--- a/openspec/changes/v0-18-0-schema-publication/tasks.md
+++ b/openspec/changes/v0-18-0-schema-publication/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+## Definition of Ready
+
+- [ ] 0.1 `schema/markdownlint.schema.json` が現在の `kml config schema --output json` と一致しているか確認する
+- [ ] 0.2 stable schema URL の実体をどこで配信するか確認する
+- [ ] 0.3 versioned schema artifact 名を release asset naming に合わせて決める
+- [ ] 0.4 editor extension 実装はこの change に含めないことを確認する
+
+## 1. Schema Generation and Regression
+
+- [ ] 1.1 schema generation / comparison script を追加する
+- [ ] 1.2 `make schema-check` を追加する
+- [ ] 1.3 `kml config schema --output json` と `schema/markdownlint.schema.json` の一致テストを追加する
+- [ ] 1.4 schema compatibility fixture を追加する
+- [ ] 1.5 rule metadata 変更時に schema fixture 更新漏れで失敗する test を追加する
+
+## 2. Published Schema Contract
+
+- [ ] 2.1 `$id` と stable schema URL の扱いを docs に固定する
+- [ ] 2.2 versioned schema artifact を release output に追加する
+- [ ] 2.3 stable URL と pinned release artifact URL の使い分けを docs に書く
+- [ ] 2.4 schema compatibility policy を `docs/editor-integration.md` または `docs/distribution.md` に追加する
+
+## 3. Release Gate
+
+- [ ] 3.1 `make release-check VERSION=v0.18.0` に schema check を追加する
+- [ ] 3.2 release workflow に schema artifact upload または publication step を追加する
+- [ ] 3.3 release preflight workflow に schema check を追加する
+- [ ] 3.4 AST lint で release gate から schema check が外れないことを検証する
+- [ ] 3.5 release notes が schema diff の有無を説明できるようにする
+
+## 4. Editor Documentation
+
+- [ ] 4.1 README の config schema section を published schema contract に合わせる
+- [ ] 4.2 `docs/editor-integration.md` の VS Code schema mapping を更新する
+- [ ] 4.3 `docs/editor-integration.md` の Zed schema mapping を更新する
+- [ ] 4.4 local schema file を使う fallback 手順を更新する
+- [ ] 4.5 editor extension 実装予定は後続 change への参照に留める
+
+## 5. Verification
+
+- [ ] 5.1 `make fmt-check`
+- [ ] 5.2 `make lint`
+- [ ] 5.3 `make ast-lint`
+- [ ] 5.4 `cargo test --workspace --locked`
+- [ ] 5.5 `make dogfood`
+- [ ] 5.6 `git diff --check`
+- [ ] 5.7 `make schema-check`
+- [ ] 5.8 `make release-check VERSION=v0.18.0`
+
+## Definition of Done
+
+- [ ] 6.1 committed schema file と CLI schema output の一致が機械的に検証される
+- [ ] 6.2 stable URL と versioned schema artifact の両方が docs で説明されている
+- [ ] 6.3 release gate が schema publication を検証する
+- [ ] 6.4 editor integration docs が extension なしの config validation を説明している
+- [ ] 6.5 `v0.18.1` の VS Code extension が依存できる schema contract が固定されている

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/.openspec.yaml
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/design.md
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/design.md
@@ -1,0 +1,92 @@
+# VS Code Extension MVP Design
+
+## Context
+
+`kml lsp` は stdio の Language Server Protocol server として、
+diagnostics、formatting、range formatting、code actions を返せる。
+`docs/editor-integration.md` は VS Code の schema mapping を説明しているが、
+Markdown file に `kml lsp` を attach する専用 extension はまだない。
+
+この change では VS Code extension を最初の editor product surface とする。
+extension は editor との接続だけを担当し、lint engine は `kml` binary に残す。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- VS Code extension を repository 内に追加する
+- extension が installed `kml` binary を見つけ、`kml lsp` を起動する
+- Markdown diagnostics / format / safe quick-fix が VS Code から動く
+- config file は published schema に関連付ける
+- extension package と LSP 接続を smoke test できるようにする
+
+**Non-Goals:**
+
+- extension へ Rust binary や lint engine を bundle すること
+- VS Code Marketplace への公開自動化
+- Zed extension の実装
+- Neovim plugin の実装
+- `kml lsp` protocol の大規模な新機能追加
+
+## Decisions
+
+### D-1: extension は thin wrapper にする
+
+extension は `kml lsp` を起動し、VS Code の Language Client と接続するだけにする。
+rule、formatter、config validation の本体は Rust 側へ残す。
+
+これにより CLI、LSP、npm / PyPI wrapper、future editor extensions が同じ実装を共有できる。
+
+### D-2: 初期 binary discovery は `PATH` と明示設定に限定する
+
+MVP では extension が binary download を行わない。
+`kml` が `PATH` にある場合はそれを使い、必要に応じて user setting で absolute path を指定できるようにする。
+
+自動 download、npx fallback、uvx fallback は security / latency / offline behavior が絡むため、
+`v0.18.3` の hardening 候補に送る。
+
+### D-3: extension code は TypeScript で小さく保つ
+
+VS Code extension は TypeScript で実装する。
+entrypoint、configuration reader、language client factory、schema association helper を責務で分ける。
+`any` / `unknown` の濫用は避け、extension API の型で表現できない境界は専用型に閉じ込める。
+
+### D-4: schema association は extension と docs の両方で扱う
+
+extension は `.markdownlint.json` / `.markdownlint.jsonc` に published schema を関連付ける。
+docs には extension を使わない manual mapping も残す。
+これにより extension 未導入の利用者も config validation を使える。
+
+### D-5: smoke test は UI 操作ではなく protocol と package contract を確認する
+
+MVP の test は次を確認する。
+
+- extension package が build できる
+- extension manifest が Markdown と config file に activation できる
+- test workspace で `kml lsp` が initialize できる
+- diagnostics / format / quick-fix の protocol contract が既存 Rust test と一致する
+
+## Risks / Trade-offs
+
+- `kml` が未 install の場合に extension が無言で動かない
+  - 明示的な error message と binary path setting を用意する
+- extension package manager が Rust release flow とずれる
+  - `Makefile` に editor-specific check target を追加し、release gate に含める
+- schema association が user settings と競合する
+  - extension の既定値は上書きしすぎず、manual setting を docs に残す
+- marketplace 公開まで含めると scope が広がる
+  - MVP は local package と smoke test までに限定する
+
+## Migration Plan
+
+1. VS Code extension scaffold を追加する
+2. TypeScript test を先に追加し、binary missing / binary path / LSP launch の期待を固定する
+3. Language Client 起動 logic を実装する
+4. schema association と configuration を追加する
+5. Makefile / CI に extension build と smoke target を追加する
+6. README / editor integration docs を更新する
+
+## Open Questions
+
+- extension directory は `editors/vscode` と `extensions/vscode` のどちらにするか implementation 開始時に決める
+- Marketplace 公開用 publisher 名は `v0.18.3` までに確定する

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/proposal.md
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/proposal.md
@@ -1,0 +1,47 @@
+# VS Code Extension MVP
+
+## Target Version
+
+`v0.18.1`
+
+## Why
+
+`kml lsp` と published config schema が揃うと、VS Code では専用拡張機能（extension）を
+薄い起動ラッパーとして実装できる。
+
+最初の editor target は VS Code に絞り、lint logic を extension 側へ移さず、
+`kml` CLI / LSP を共有エンジンとして使う。
+
+## What Changes
+
+- VS Code extension package を repository に追加する
+- extension は Markdown file で `kml lsp` を stdio 起動する
+- extension は `.markdownlint.json` / `.markdownlint.jsonc` に published schema を関連付ける
+- extension は diagnostics、format、range format、safe quick-fix を LSP 経由で公開する
+- extension smoke test を追加し、`kml lsp` と extension package の接続を検証する
+- README / docs に VS Code extension MVP の install と設定を追加する
+
+## Capabilities
+
+### New Capabilities
+
+- `vscode-extension`: VS Code extension package、activation、configuration、schema association を扱う
+- `editor-lsp-contract`: editor wrapper が依存する `kml lsp` の最小 contract を扱う
+
+### Modified Capabilities
+
+なし。
+
+## Impact
+
+- `editors/vscode/**` または `extensions/vscode/**`
+- `package.json` / VS Code extension manifest
+- VS Code extension source and tests
+- `src/lsp/**`
+- `tests/cli_lsp_contract.rs`
+- `Makefile`
+- `.github/workflows/**`
+- `README.md`
+- `docs/editor-integration.md`
+- `docs/quality-gates.md`
+- `CHANGELOG.md`

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/specs/editor-lsp-contract/spec.md
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/specs/editor-lsp-contract/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: editor wrappers SHALL depend on kml lsp protocol capabilities
+
+editor wrapper は、`kml lsp` の protocol capabilities に依存しなければならない（SHALL）。
+
+#### Scenario: editor initializes kml lsp
+
+- **WHEN** editor wrapper sends `initialize`
+- **THEN** `kml lsp` returns server name `katana-markdown-linter`
+- **AND** `kml lsp` advertises document formatting support
+- **AND** `kml lsp` advertises range formatting support
+- **AND** `kml lsp` advertises code action support
+
+### Requirement: kml lsp SHALL publish diagnostics for opened and changed documents
+
+`kml lsp` は、opened / changed document に対して diagnostics を返さなければならない（SHALL）。
+
+#### Scenario: markdown document changes
+
+- **WHEN** editor wrapper sends `textDocument/didOpen` or `textDocument/didChange`
+- **THEN** `kml lsp` publishes diagnostics for that document URI
+- **AND** diagnostic codes match the same lint rules used by `kml check`
+
+### Requirement: kml lsp SHALL keep editor actions safe by default
+
+`kml lsp` の editor action は、default-safe behavior を維持しなければならない（SHALL）。
+
+#### Scenario: editor requests code actions
+
+- **WHEN** editor wrapper requests `textDocument/codeAction`
+- **THEN** `kml lsp` returns only safe quick-fix actions by default
+- **AND** unsafe fix behavior is not exposed without explicit opt-in

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/specs/vscode-extension/spec.md
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/specs/vscode-extension/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: VS Code extension SHALL launch kml LSP as a thin wrapper
+
+VS Code extension は、`kml lsp` を起動する薄いラッパー（thin wrapper）でなければならない（SHALL）。
+
+#### Scenario: markdown document opens
+
+- **WHEN** user opens a Markdown document in VS Code
+- **THEN** extension starts `kml lsp` over stdio
+- **AND** extension attaches the language client to Markdown documents
+- **AND** extension does not implement markdownlint rules in TypeScript
+
+### Requirement: VS Code extension SHALL expose diagnostics and safe editor actions
+
+VS Code extension は、LSP 経由で diagnostics、format、safe quick-fix を公開しなければならない（SHALL）。
+
+#### Scenario: user edits Markdown
+
+- **WHEN** `kml lsp` publishes diagnostics for an open Markdown document
+- **THEN** VS Code displays those diagnostics in the editor
+- **AND** format document uses `textDocument/formatting`
+- **AND** range format uses `textDocument/rangeFormatting`
+- **AND** quick fix uses `textDocument/codeAction`
+
+### Requirement: VS Code extension SHALL support explicit kml path configuration
+
+VS Code extension は、`kml` executable の path を明示設定できなければならない（SHALL）。
+
+#### Scenario: kml is not on PATH
+
+- **WHEN** user configures an absolute `kml` path
+- **THEN** extension launches that executable with the `lsp` argument
+- **AND** extension reports a clear error when the configured executable cannot run
+- **AND** extension does not silently fallback to an unrelated binary
+
+### Requirement: VS Code extension SHALL associate markdownlint config files with schema
+
+VS Code extension は、markdownlint config files に published schema を関連付けなければならない（SHALL）。
+
+#### Scenario: user opens markdownlint config
+
+- **WHEN** user opens `.markdownlint.json` or `.markdownlint.jsonc`
+- **THEN** VS Code can use the published schema for completion and validation
+- **AND** extension keeps manual schema mapping documented for users who do not install it

--- a/openspec/changes/v0-18-1-vscode-extension-mvp/tasks.md
+++ b/openspec/changes/v0-18-1-vscode-extension-mvp/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+## Definition of Ready
+
+- [ ] 0.1 `v0.18.0` の schema publication change が完了している
+- [ ] 0.2 `kml lsp` の diagnostics / format / quick-fix contract が現行 test で確認できる
+- [ ] 0.3 VS Code extension の directory 名を決める
+- [ ] 0.4 VS Code extension の publisher / package name は MVP では公開しない前提にする
+
+## 1. Extension Test Scaffold
+
+- [ ] 1.1 VS Code extension package scaffold を追加する
+- [ ] 1.2 TypeScript compile check を追加する
+- [ ] 1.3 binary missing 時の error test を追加する
+- [ ] 1.4 explicit `kml` path 設定の test を追加する
+- [ ] 1.5 LSP initialize smoke test を追加する
+
+## 2. LSP Client Implementation
+
+- [ ] 2.1 extension activation を Markdown document と config file に限定する
+- [ ] 2.2 configuration reader を実装する
+- [ ] 2.3 Language Client factory を実装する
+- [ ] 2.4 `kml lsp` を stdio 起動する
+- [ ] 2.5 output channel に起動失敗理由を出す
+- [ ] 2.6 extension 側に lint logic を置かないことを test または static check で確認する
+
+## 3. Schema Association
+
+- [ ] 3.1 `.markdownlint.json` の schema association を追加する
+- [ ] 3.2 `.markdownlint.jsonc` の schema association を追加する
+- [ ] 3.3 published schema URL を extension manifest または configuration で参照する
+- [ ] 3.4 manual schema mapping docs を残す
+
+## 4. Build and CI
+
+- [ ] 4.1 `make vscode-extension-check` を追加する
+- [ ] 4.2 release preflight または CI に extension check を追加する
+- [ ] 4.3 extension package の file list が不要物を含まないことを検証する
+- [ ] 4.4 `make release-check VERSION=v0.18.1` に extension check を組み込む
+
+## 5. Documentation
+
+- [ ] 5.1 README に VS Code extension MVP の install / setup を追加する
+- [ ] 5.2 `docs/editor-integration.md` に VS Code extension と manual schema mapping の違いを書く
+- [ ] 5.3 binary path setting と troubleshooting を docs に追加する
+- [ ] 5.4 Marketplace 公開は後続 hardening change に送ることを明記する
+- [ ] 5.5 `CHANGELOG.md` に `v0.18.1` の editor MVP を追加する
+
+## 6. Verification
+
+- [ ] 6.1 `make fmt-check`
+- [ ] 6.2 `make lint`
+- [ ] 6.3 `make ast-lint`
+- [ ] 6.4 `cargo test --workspace --locked`
+- [ ] 6.5 `make dogfood`
+- [ ] 6.6 `git diff --check`
+- [ ] 6.7 `make vscode-extension-check`
+- [ ] 6.8 `make release-check VERSION=v0.18.1`
+
+## Definition of Done
+
+- [ ] 7.1 VS Code extension が `kml lsp` を起動できる
+- [ ] 7.2 Markdown diagnostics / format / safe quick-fix が LSP 経由で使える
+- [ ] 7.3 `.markdownlint.json` / `.markdownlint.jsonc` が published schema に関連付く
+- [ ] 7.4 extension package check が local と CI で実行できる
+- [ ] 7.5 lint logic は Rust 側に残り、extension は thin wrapper のままになっている

--- a/openspec/changes/v0-18-2-zed-extension-mvp/.openspec.yaml
+++ b/openspec/changes/v0-18-2-zed-extension-mvp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/v0-18-2-zed-extension-mvp/design.md
+++ b/openspec/changes/v0-18-2-zed-extension-mvp/design.md
@@ -1,0 +1,83 @@
+# Zed Extension MVP Design
+
+## Context
+
+`v0.18.1` で VS Code extension が `kml lsp` を thin wrapper として起動する。
+Zed も同じ `kml lsp` contract に乗せたいが、extension format と language server registration は
+VS Code と異なる。
+
+この change は Zed 固有の boundary を検証する。
+共有 engine と LSP behavior は Rust 側へ残し、Zed extension は起動と登録だけを担当する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Zed extension scaffold を repository に追加する
+- Zed extension から `kml lsp` を起動する
+- Markdown file に diagnostics / format / safe quick-fix を接続する
+- schema-backed config editing の docs を Zed 向けに更新する
+- Zed extension build / smoke check を local と CI で実行できるようにする
+
+**Non-Goals:**
+
+- Zed extension へ lint logic を実装すること
+- Zed marketplace 公開自動化
+- VS Code extension の設計変更
+- `kml lsp` の editor-specific fork
+- Neovim plugin 実装
+
+## Decisions
+
+### D-1: Zed extension は VS Code extension の LSP contract を再利用する
+
+Zed extension は `kml lsp` の initialize / diagnostics / formatting / codeAction contract に依存する。
+Zed 固有の処理は language server registration と configuration に限定する。
+
+### D-2: implementation 開始時に Zed の公式 extension API を確認する
+
+Zed extension API は editor 側の仕様に依存する。
+この change の実装開始時に、公式 docs で manifest、language server registration、
+local development command を確認してから scaffold を確定する。
+
+### D-3: binary discovery は VS Code MVP と同じ方針にする
+
+MVP は installed `kml` を使う。
+`PATH` と明示 path setting だけを対象にし、binary download、npx fallback、uvx fallback は
+hardening change に送る。
+
+### D-4: Zed schema support は docs と extension の責務を分ける
+
+Zed の JSON schema mapping は docs に明記する。
+extension が schema association を直接管理できる場合は追加するが、
+MVP の必須条件は Markdown LSP 接続とする。
+
+### D-5: smoke check は package boundary と LSP 起動を重視する
+
+Zed extension の UI 操作自動化は MVP の必須にしない。
+代わりに extension package check、manifest validation、`kml lsp` launch contract を確認する。
+
+## Risks / Trade-offs
+
+- Zed extension API の変更で scaffold が壊れる
+  - implementation 開始時に公式 docs を確認し、tasks に検証結果を残す
+- Zed の schema association が extension から直接設定できない
+  - docs-based config を MVP の受け入れ条件に含める
+- VS Code と Zed で configuration key がずれる
+  - user-facing docs では editor ごとの設定名を分け、Rust 側 contract は共有する
+- marketplace 公開を含めると scope が広がる
+  - MVP は local package と smoke check までに限定する
+
+## Migration Plan
+
+1. Zed official docs で extension scaffold と language server registration を確認する
+2. Zed extension scaffold を追加する
+3. `kml` binary path 設定と LSP 起動を実装する
+4. package / manifest / launch smoke check を追加する
+5. README / editor integration docs を Zed extension 向けに更新する
+6. CI と release gate に Zed extension check を追加する
+
+## Open Questions
+
+- Zed extension directory は VS Code extension と同じ parent directory に揃える
+- Zed package の公開名と公開先は `v0.18.3` で確定する

--- a/openspec/changes/v0-18-2-zed-extension-mvp/proposal.md
+++ b/openspec/changes/v0-18-2-zed-extension-mvp/proposal.md
@@ -1,0 +1,43 @@
+# Zed Extension MVP
+
+## Target Version
+
+`v0.18.2`
+
+## Why
+
+VS Code extension MVP で `kml lsp` を editor wrapper から起動する契約が固まる。
+次は Zed を second target とし、Zed 固有の extension 境界だけを検証する。
+
+Zed 側でも lint logic は持たず、`kml lsp` を共有エンジンとして使う。
+
+## What Changes
+
+- Zed extension package を repository に追加する
+- extension は Markdown file に対して `kml lsp` を起動する
+- extension は `.markdownlint.json` / `.markdownlint.jsonc` の schema 利用手順を docs に固定する
+- Zed extension build / package / smoke check を追加する
+- VS Code extension と同じ editor-facing behavior を Zed で確認する
+
+## Capabilities
+
+### New Capabilities
+
+- `zed-extension`: Zed extension package、language server registration、configuration、smoke check を扱う
+
+### Modified Capabilities
+
+なし。
+
+## Impact
+
+- `editors/zed/**` または `extensions/zed/**`
+- Zed extension manifest and source
+- `src/lsp/**`
+- `tests/cli_lsp_contract.rs`
+- `Makefile`
+- `.github/workflows/**`
+- `README.md`
+- `docs/editor-integration.md`
+- `docs/quality-gates.md`
+- `CHANGELOG.md`

--- a/openspec/changes/v0-18-2-zed-extension-mvp/specs/zed-extension/spec.md
+++ b/openspec/changes/v0-18-2-zed-extension-mvp/specs/zed-extension/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Zed extension SHALL register kml as a Markdown language server
+
+Zed extension は、`kml lsp` を Markdown 用 language server として登録しなければならない（SHALL）。
+
+#### Scenario: markdown workspace opens in Zed
+
+- **WHEN** user opens a Markdown document in Zed
+- **THEN** extension starts `kml lsp` over stdio
+- **AND** extension registers it for Markdown documents
+- **AND** extension does not implement markdownlint rules in extension code
+
+### Requirement: Zed extension SHALL preserve the shared editor LSP contract
+
+Zed extension は、VS Code extension と同じ editor-facing LSP contract を利用しなければならない（SHALL）。
+
+#### Scenario: kml lsp returns editor features
+
+- **WHEN** Zed extension initializes `kml lsp`
+- **THEN** diagnostics are sourced from `textDocument/publishDiagnostics`
+- **AND** formatting is sourced from `textDocument/formatting`
+- **AND** range formatting is sourced from `textDocument/rangeFormatting`
+- **AND** safe quick fixes are sourced from `textDocument/codeAction`
+
+### Requirement: Zed extension SHALL support explicit kml path configuration
+
+Zed extension は、`kml` executable の path を明示設定できなければならない（SHALL）。
+
+#### Scenario: user configures kml path
+
+- **WHEN** user sets the `kml` executable path for the Zed extension
+- **THEN** extension launches that executable with the `lsp` argument
+- **AND** extension reports a clear setup error when the executable cannot run
+- **AND** extension does not fallback to a different executable without user consent
+
+### Requirement: Zed docs SHALL cover schema-backed config editing
+
+Zed docs は、markdownlint config の schema-backed editing を説明しなければならない（SHALL）。
+
+#### Scenario: user configures schema validation in Zed
+
+- **WHEN** user follows Zed editor integration docs
+- **THEN** docs show how `.markdownlint.json` and `.markdownlint.jsonc` use the published schema
+- **AND** docs distinguish schema validation from Markdown LSP diagnostics
+- **AND** docs explain when the Zed extension is required

--- a/openspec/changes/v0-18-2-zed-extension-mvp/tasks.md
+++ b/openspec/changes/v0-18-2-zed-extension-mvp/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+## Definition of Ready
+
+- [ ] 0.1 `v0.18.1` の VS Code extension MVP が完了している
+- [ ] 0.2 `editor-lsp-contract` の requirements が満たされている
+- [ ] 0.3 Zed の公式 extension API と local development command を確認する
+- [ ] 0.4 Zed extension の directory 名を VS Code extension と揃える
+
+## 1. Zed Extension Scaffold
+
+- [ ] 1.1 Zed extension manifest を追加する
+- [ ] 1.2 Zed extension source を追加する
+- [ ] 1.3 extension が `kml lsp` を起動する最小実装を追加する
+- [ ] 1.4 explicit `kml` path setting を追加する
+- [ ] 1.5 binary missing 時の setup error を追加する
+
+## 2. LSP Registration
+
+- [ ] 2.1 Markdown file へ `kml lsp` を登録する
+- [ ] 2.2 diagnostics が `kml lsp` から表示されることを smoke で確認する
+- [ ] 2.3 format / range format の provider 設定を確認する
+- [ ] 2.4 safe quick-fix の code action provider 設定を確認する
+- [ ] 2.5 extension 側に lint logic を置かないことを確認する
+
+## 3. Schema and Documentation
+
+- [ ] 3.1 Zed の schema mapping docs を published schema contract に合わせて更新する
+- [ ] 3.2 Zed extension が必要な範囲と不要な範囲を docs で分ける
+- [ ] 3.3 binary path setting と troubleshooting を docs に追加する
+- [ ] 3.4 Marketplace 公開は後続 hardening change に送ることを明記する
+
+## 4. Build and CI
+
+- [ ] 4.1 `make zed-extension-check` を追加する
+- [ ] 4.2 Zed extension manifest validation を追加する
+- [ ] 4.3 package / build check を local で実行できるようにする
+- [ ] 4.4 release preflight または CI に Zed extension check を追加する
+- [ ] 4.5 `make release-check VERSION=v0.18.2` に Zed extension check を組み込む
+
+## 5. Verification
+
+- [ ] 5.1 `make fmt-check`
+- [ ] 5.2 `make lint`
+- [ ] 5.3 `make ast-lint`
+- [ ] 5.4 `cargo test --workspace --locked`
+- [ ] 5.5 `make dogfood`
+- [ ] 5.6 `git diff --check`
+- [ ] 5.7 `make zed-extension-check`
+- [ ] 5.8 `make release-check VERSION=v0.18.2`
+
+## Definition of Done
+
+- [ ] 6.1 Zed extension が `kml lsp` を Markdown language server として起動できる
+- [ ] 6.2 diagnostics / format / safe quick-fix が shared LSP contract に従っている
+- [ ] 6.3 Zed schema validation docs が published schema contract を参照している
+- [ ] 6.4 Zed extension check が local と CI で実行できる
+- [ ] 6.5 extension は thin wrapper のままになっている

--- a/openspec/changes/v0-18-3-editor-extension-hardening/.openspec.yaml
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/v0-18-3-editor-extension-hardening/design.md
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/design.md
@@ -1,0 +1,90 @@
+# Editor Extension Hardening Design
+
+## Context
+
+`v0.18.1` は VS Code extension MVP、`v0.18.2` は Zed extension MVP を扱う。
+どちらも thin wrapper として `kml lsp` を起動する。
+
+MVP の後は、install docs、package metadata、release gate、post-release verification を揃え、
+extension が「動く試作」ではなく「保守できる配布物」として扱える状態にする。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- VS Code / Zed extension package check を release gate に固定する
+- extension package と `kml` CLI の compatibility policy を定義する
+- install / upgrade / troubleshooting docs を整える
+- Marketplace / registry 公開に必要な metadata を準備する
+- post-release verification で extension package と `kml lsp` launch を確認する
+- Neovim は docs-only LSP configuration sample として維持する
+
+**Non-Goals:**
+
+- editor extension へ lint engine を移すこと
+- editor ごとに異なる rule behavior を作ること
+- automatic binary download を必須機能にすること
+- Neovim plugin を repository に実装すること
+- external marketplace への未検証 publish を自動実行すること
+
+## Decisions
+
+### D-1: extension version は CLI compatibility を明示する
+
+extension package metadata は、対応する `kml` CLI version range を明示する。
+MVP では `kml` を bundle しないため、extension 起動時に `kml --version` を確認し、
+非対応 version の場合は明確な error を出す。
+
+### D-2: release gate は package と launch の両方を見る
+
+local と CI の gate は、extension package が build できることに加えて、
+test fixture の `kml` binary path で `kml lsp` が initialize できることを確認する。
+
+### D-3: marketplace publish は manual-ready に留める
+
+この change では公開に必要な metadata、icon、README、license、package content を揃える。
+Marketplace / registry への実 publish は、account / publisher 名 / review policy が確定してから
+別 step として実施する。
+
+### D-4: binary fallback は opt-in にする
+
+extension は installed `kml` を使う方針を維持する。
+npx / uvx fallback や automatic download は便利だが、起動遅延、network、security の判断が必要になる。
+導入する場合は explicit opt-in の設定とし、default にはしない。
+
+### D-5: editor docs は実際の操作別に整理する
+
+docs は次を分ける。
+
+- config schema validation
+- Markdown diagnostics
+- format / range format
+- safe quick-fix
+- binary path setting
+- unsupported version troubleshooting
+- Neovim docs-only sample
+
+## Risks / Trade-offs
+
+- marketplace account や publisher 名が未確定で release が止まる
+  - this change は manual-ready metadata までを必須にし、publish 自体は確認済み条件に分ける
+- extension が CLI version とずれて誤動作する
+  - startup で `kml --version` を確認し、compatibility policy と一致させる
+- package check が editor runtime に依存して CI で不安定になる
+  - protocol smoke と package validation を分け、UI-dependent check は必須にしない
+- fallback 経路を増やすと挙動が読みにくくなる
+  - fallback は opt-in にし、default は explicit binary path / PATH のみにする
+
+## Migration Plan
+
+1. VS Code / Zed extension metadata を release-ready に整える
+2. compatibility check を extension startup と tests に追加する
+3. package validation target を Makefile と CI に固定する
+4. release verification script に extension package / LSP launch check を追加する
+5. README / editor docs / release runbook を更新する
+6. Marketplace / registry publish 手順を manual-ready runbook として残す
+
+## Open Questions
+
+- VS Code publisher 名と Zed extension 公開先は implementation 開始時に確定する
+- extension icon は KML icon を使うか、editor-specific variant を作るか確認する

--- a/openspec/changes/v0-18-3-editor-extension-hardening/proposal.md
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/proposal.md
@@ -1,0 +1,47 @@
+# Editor Extension Hardening
+
+## Target Version
+
+`v0.18.3`
+
+## Why
+
+VS Code と Zed の extension MVP が揃った後は、利用者が install し、
+release ごとに検証できる状態へ仕上げる必要がある。
+
+この change では editor extension を product surface として扱い、
+package、docs、smoke tests、release verification をまとめて固める。
+
+## What Changes
+
+- VS Code / Zed extension の package verification を release gate に固定する
+- extension と `kml` CLI version compatibility を明文化する
+- install docs、troubleshooting、binary path 設定を整理する
+- Marketplace / registry 公開準備に必要な metadata を追加する
+- release verification が extension package と `kml lsp` launch を確認する
+- Neovim は plugin 実装ではなく docs-only sample として整理する
+
+## Capabilities
+
+### New Capabilities
+
+- `editor-extension-release`: editor extension package、compatibility、release verification、公開準備を扱う
+
+### Modified Capabilities
+
+- `release-readiness`: release gate に editor extension verification を追加する
+
+## Impact
+
+- `editors/vscode/**` or `extensions/vscode/**`
+- `editors/zed/**` or `extensions/zed/**`
+- `src/lsp/**`
+- `tests/cli_lsp_contract.rs`
+- `Makefile`
+- `.github/workflows/**`
+- `scripts/release/**`
+- `README.md`
+- `docs/editor-integration.md`
+- `docs/quality-gates.md`
+- `docs/release-runbook.md`
+- `CHANGELOG.md`

--- a/openspec/changes/v0-18-3-editor-extension-hardening/specs/editor-extension-release/spec.md
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/specs/editor-extension-release/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: editor extensions SHALL declare kml CLI compatibility
+
+editor extension は、対応する `kml` CLI version range を明示しなければならない（SHALL）。
+
+#### Scenario: extension starts language server
+
+- **WHEN** extension starts `kml lsp`
+- **THEN** extension verifies the configured `kml` executable version
+- **AND** extension accepts versions in the documented compatibility range
+- **AND** extension reports a clear error for unsupported versions
+
+### Requirement: editor extension packages SHALL be release-verifiable
+
+editor extension package は、release 前に機械的に検証できなければならない（SHALL）。
+
+#### Scenario: release check validates extension packages
+
+- **WHEN** developer runs `make release-check VERSION=vX.Y.Z`
+- **THEN** system validates the VS Code extension package
+- **AND** system validates the Zed extension package
+- **AND** system verifies package contents exclude generated junk and local-only files
+- **AND** system verifies each extension can launch `kml lsp` in smoke mode
+
+### Requirement: editor extension docs SHALL separate setup workflows
+
+editor extension docs は、利用者が実際に操作する workflow ごとに分かれていなければならない（SHALL）。
+
+#### Scenario: user reads editor integration docs
+
+- **WHEN** user wants config validation only
+- **THEN** docs show schema mapping without requiring extension install
+- **WHEN** user wants Markdown diagnostics or formatting
+- **THEN** docs show extension install and `kml` binary setup
+- **WHEN** user uses Neovim
+- **THEN** docs show LSP configuration sample without claiming a maintained plugin exists
+
+### Requirement: marketplace publish SHALL be gated by account and package verification
+
+Marketplace / registry publish は、account 設定と package verification が揃うまで実行してはならない（SHALL NOT）。
+
+#### Scenario: extension publish is requested
+
+- **WHEN** release workflow or runbook publishes editor extensions
+- **THEN** system confirms publisher account and package name are configured
+- **AND** system confirms package validation passed for the exact release version
+- **AND** system does not publish unverified packages automatically

--- a/openspec/changes/v0-18-3-editor-extension-hardening/specs/release-readiness/spec.md
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/specs/release-readiness/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: release readiness SHALL include editor extension checks
+
+release readiness は、editor extension package と LSP launch の検証を含まなければならない（SHALL）。
+
+#### Scenario: release check runs editor extension gates
+
+- **WHEN** developer runs `make release-check VERSION=vX.Y.Z`
+- **THEN** system runs VS Code extension check
+- **AND** system runs Zed extension check
+- **AND** system verifies both checks use the same `kml` release version
+
+### Requirement: post-release verification SHALL cover editor extension artifacts when published
+
+公開後検証は、editor extension artifact が公開された場合にその状態を確認しなければならない（SHALL）。
+
+#### Scenario: extension artifact is published
+
+- **WHEN** developer runs `make release-verify VERSION=vX.Y.Z`
+- **THEN** system checks published extension artifact version
+- **AND** system verifies extension metadata references the compatible `kml` version
+- **AND** system reports a clear skip reason when extension publish is intentionally manual or deferred

--- a/openspec/changes/v0-18-3-editor-extension-hardening/tasks.md
+++ b/openspec/changes/v0-18-3-editor-extension-hardening/tasks.md
@@ -1,0 +1,61 @@
+# Tasks
+
+## Definition of Ready
+
+- [ ] 0.1 `v0.18.1` の VS Code extension MVP が完了している
+- [ ] 0.2 `v0.18.2` の Zed extension MVP が完了している
+- [ ] 0.3 VS Code publisher 名と package name を確認する
+- [ ] 0.4 Zed extension の公開先と package name を確認する
+- [ ] 0.5 extension icon と metadata の方針を確認する
+
+## 1. Compatibility and Startup Checks
+
+- [ ] 1.1 VS Code extension startup で `kml --version` を確認する
+- [ ] 1.2 Zed extension startup で `kml --version` を確認する
+- [ ] 1.3 supported CLI version range を extension metadata と docs に書く
+- [ ] 1.4 unsupported version error を test で固定する
+- [ ] 1.5 explicit binary path / PATH の default behavior を docs と一致させる
+
+## 2. Package Verification
+
+- [ ] 2.1 VS Code extension package の content check を追加する
+- [ ] 2.2 Zed extension package の content check を追加する
+- [ ] 2.3 package に local-only files が入らないことを検証する
+- [ ] 2.4 package validation target を `make editor-extension-check` にまとめる
+- [ ] 2.5 CI と release preflight に editor extension check を追加する
+
+## 3. Release and Publish Runbook
+
+- [ ] 3.1 `scripts/release` に editor extension verification を追加する
+- [ ] 3.2 `make release-verify` が published / deferred の状態を説明できるようにする
+- [ ] 3.3 VS Code Marketplace publish 手順を runbook に追加する
+- [ ] 3.4 Zed extension publish 手順を runbook に追加する
+- [ ] 3.5 account 未設定時は publish を止める gate を追加する
+
+## 4. Documentation
+
+- [ ] 4.1 README の editor section を VS Code / Zed / Neovim に分けて更新する
+- [ ] 4.2 `docs/editor-integration.md` を setup workflow 別に整理する
+- [ ] 4.3 schema validation と Markdown diagnostics の違いを docs に書く
+- [ ] 4.4 binary path setting、unsupported version、missing binary の troubleshooting を追加する
+- [ ] 4.5 Neovim は docs-only sample として扱い、maintained plugin と誤解されないようにする
+- [ ] 4.6 `CHANGELOG.md` に `v0.18.3` の editor hardening を追加する
+
+## 5. Verification
+
+- [ ] 5.1 `make fmt-check`
+- [ ] 5.2 `make lint`
+- [ ] 5.3 `make ast-lint`
+- [ ] 5.4 `cargo test --workspace --locked`
+- [ ] 5.5 `make dogfood`
+- [ ] 5.6 `git diff --check`
+- [ ] 5.7 `make editor-extension-check`
+- [ ] 5.8 `make release-check VERSION=v0.18.3`
+
+## Definition of Done
+
+- [ ] 6.1 VS Code / Zed extension package が release gate で検証される
+- [ ] 6.2 extension と `kml` CLI の compatibility policy が docs と metadata で一致している
+- [ ] 6.3 post-release verification が editor extension artifact の published / deferred 状態を説明できる
+- [ ] 6.4 Marketplace / registry publish は account と package verification なしに進まない
+- [ ] 6.5 Neovim は docs-only LSP sample として整理されている


### PR DESCRIPTION
## Summary
- Add OpenSpec changes for v0.17.1 distribution closeout and v0.18.x schema/editor roadmap
- Split editor work into VS Code MVP, Zed MVP, and extension hardening
- Update active roadmap to point to the concrete change IDs

## Verification
- scripts/openspec validate --changes --strict
- make dogfood
- make ast-lint
- git diff --check