### PR TITLE
Prepare v0.17.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,10 +355,16 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Verify npm trusted publishing context
+        shell: bash
+        run: |
+          if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            echo "npm trusted publishing is unavailable. Configure npm trusted publisher for HiroyukiFuruno/katana-markdown-linter with workflow release.yml and keep id-token: write." >&2
+            exit 1
+          fi
+
       - name: Publish npm wrapper
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: wrappers/npm
 
   publish-pypi-wrapper:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.17.1
+
+- Promotes the npm and PyPI wrappers to official install channels after public
+  registry and wrapper launch verification.
+- Removes npm wrapper publication from the temporary token path and relies on
+  GitHub Actions trusted publishing for the normal release workflow.
+- Extends `make release-verify` to check npm, PyPI, wrapper launch output, and
+  Homebrew formula evidence in addition to GitHub Release and crates.io state.
+- Updates distribution docs, release runbook, and quality gate docs to match the
+  published wrapper and Homebrew closeout flow.
+
 ## v0.17.0
 
 - Adds standalone `kml` binary archives for Linux x86_64, macOS x86_64,
@@ -8,8 +19,8 @@
   packaging, archive extraction smoke tests, Homebrew formula rendering, and
   post-release binary asset verification.
 - Adds thin npm and Python wrapper sources plus local wrapper smoke coverage.
-  Wrapper publication remains deferred until `NPM_TOKEN` and `PYPI_API_TOKEN`
-  are registered and explicit workflow publish flags are enabled.
+  Wrapper publication remained deferred until registry publisher setup and
+  explicit workflow publish flags were ready.
 - Documents the binary archive install path, the separated Homebrew tap update
   flow, and the wrapper publication state without listing unpublished wrappers
   as official install channels.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.0"
+version = "0.17.1"
 
 edition = "2021"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,11 @@ release-publish: release-tag ## Dispatch GitHub Release workflow with crates.io 
 	scripts/release/verify-version.sh "$(VERSION)"
 	scripts/release/assert-crate-not-published.sh "$(VERSION_BARE)"
 	gh secret list --repo $(RELEASE_REPO) | grep -q '^CARGO_REGISTRY_TOKEN[[:space:]]' || (echo "CARGO_REGISTRY_TOKEN secret is required" >&2; exit 1)
-	gh workflow run release.yml --repo $(RELEASE_REPO) --ref main -f version="$(TAG)" -f publish_crate=true
+	gh workflow run release.yml --repo $(RELEASE_REPO) --ref main \
+		-f version="$(TAG)" \
+		-f publish_crate=true \
+		-f publish_npm_wrapper=true \
+		-f publish_pypi_wrapper=true
 
 .PHONY: release
 release: release-publish ## Dispatch the full release workflow (GitHub Release + crates.io, VERSION=vX.Y.Z)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Desktop.
 - **`kml` CLI** with JSON output, stdin support, ignore handling, and statistics
 - **Editor integration** through a stdio Language Server Protocol server
 - **MCP server** for agents and tools that need structured lint access
-- **Multi-channel distribution** through Cargo, GitHub Releases, npm, and PyPI
+- **Multi-channel distribution** through Cargo, GitHub Releases, npm, PyPI, and Homebrew
 
 ## Library API
 
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.0 check README.md
+npx --yes katana-markdown-linter@0.17.1 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.0 kml check README.md
+uvx --from katana-markdown-linter==0.17.1 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,10 +137,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.0/kml-v0.17.0-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.0/kml-v0.17.0-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.0-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.0-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/kml-v0.17.1-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/kml-v0.17.1-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.17.1-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.17.1-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -158,8 +158,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.0
-  with: { version: "0.17.0", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.1
+  with: { version: "0.17.1", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -416,7 +416,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.0
+make mcpb-smoke VERSION=v0.17.1
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the
@@ -431,8 +431,8 @@ See [MCP server documentation](docs/mcp-server.md), the
 - `Cargo.toml` package version is the release version source of truth.
 - Run `make release-check VERSION=vX.Y.Z` before publication.
 - Run `make release-github VERSION=vX.Y.Z` to create or update only the GitHub Release.
-- Run `make release VERSION=vX.Y.Z` only when crates.io publication is intended.
-- Run `make release-verify VERSION=vX.Y.Z` after publication to compare the tag target, GitHub Release target, crates.io version, and binary release assets.
+- Run `make release VERSION=vX.Y.Z` only when registry publication is intended.
+- Run `make release-verify VERSION=vX.Y.Z` after publication to compare the tag target, GitHub Release target, crates.io, npm, PyPI, wrapper launch, Homebrew formula, and binary release assets.
 - GitHub Releases require a signed annotated `vX.Y.Z` tag that GitHub reports as `Verified`.
 - `make release` stops before dispatch when the requested version already exists on crates.io.
 - crates.io publication requires the `CARGO_REGISTRY_TOKEN` GitHub secret.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,8 +5,10 @@
 | Channel | Status | Verification | Policy |
 | --- | --- | --- | --- |
 | Cargo crate | Official | `make release-check`, install smoke test, crates.io publish verification | Primary library and CLI package |
-| Standalone binary artifacts | Official from `v0.17.0` | `make binary-smoke`, release asset checksum, `make release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
-| Homebrew formula | Release-prepared from `v0.17.0` | `make homebrew-formula-check`, release archive checksum, formula test block | Tap update is reviewed separately in `homebrew-katana` after release assets exist |
+| Standalone binary artifacts | Official from `v0.17.1` | `make binary-smoke`, release asset checksum, `make release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
+| npm wrapper | Official from `v0.17.1` | npm registry version, `npx` launch smoke, `make release-verify` | Thin launcher over GitHub Release binary archives |
+| PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, `make release-verify` | Thin launcher over GitHub Release binary archives |
+| Homebrew formula | Official from `v0.17.1` | `make homebrew-formula-check`, release archive checksum, formula test block, tap review | Tap update is reviewed separately in `homebrew-katana` after release assets exist |
 | GitHub Action | Official from `v0.11.0` | `make action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
 | MCPB bundle | Official from `v0.14.0` | `make mcpb-smoke`, `make server-json-validate`, release asset checksum | Local stdio MCP package for `kml-mcp` |
 | MCP Registry metadata | Official from `v0.14.0` | rendered `server.json`, MCPB checksum, registry publish verification | Discovery metadata for the MCPB bundle |
@@ -17,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.0
-  with: { version: "0.17.0", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.1
+  with: { version: "0.17.1", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -31,15 +33,17 @@ waiting for crates.io publication.
 | Channel | Decision | Reason |
 | --- | --- | --- |
 | pre-commit hook repository | Deferred | A dedicated hook repository adds release ownership. Local hooks can call `kml` or the GitHub Action can protect CI first. |
-| npm wrapper | Deferred | Source and local smoke are present, but npm trusted publishing and explicit publish enablement are required before this becomes an official install channel. |
-| pip/uv wrapper | Deferred | Source and local smoke are present, but PyPI trusted publishing and explicit publish enablement are required before this becomes an official install channel. |
 | config schema publication | Deferred | Schema output needs versioned config metadata and editor validation tests before it can be treated as stable. |
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.0-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.17.1-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
 and must keep tap mutation separate from this repository's release workflow.
+
+The npm and PyPI packages do not contain independent lint logic. They download
+the matching GitHub Release archive for the package version, verify the archive
+checksum, and launch the bundled `kml` binary.
 
 `kml-mcp-remote` is not a hosted service and is not described by the MCPB
 Registry metadata. Operators deploy it themselves, keep bearer authentication

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.0
+    make mcpb-smoke VERSION=v0.17.1
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.0.mcpb
-    katana-markdown-linter-0.17.0.mcpb.sha256
+    katana-markdown-linter-0.17.1.mcpb
+    katana-markdown-linter-0.17.1.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.0` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.17.1` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.0
+    make server-json-validate VERSION=v0.17.1
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -29,7 +29,7 @@
 | `make mcpb-smoke` | Build the MCPB bundle and run the bundled `kml-mcp` binary through stdio smoke | Yes for release gates |
 | `make server-json-validate` | Render and validate MCP Registry metadata for the release MCPB artifact | Yes for release gates |
 | `make release-check` | Run local release preflight gates except live upstream clone | Yes |
-| `make release-verify` | Verify published tag, GitHub Release, and crates.io state | Yes after publication |
+| `make release-verify` | Verify published tag, GitHub Release, crates.io, npm, PyPI, wrapper launch, and Homebrew formula state | Yes after publication |
 
 `make lint` is intentionally limited to Clippy. Repository-specific checks belong in `make ast-lint` so Rust style warnings and project invariants can be triaged independently.
 
@@ -90,10 +90,10 @@ without declaring remote MCP transport.
 `make binary-smoke` builds the current platform archive, verifies the checksum,
 extracts the archive, checks `kml --version`, and runs a small `kml check`
 fixture. `make homebrew-formula-check` renders `target/homebrew/kml.rb` from
-the same archive checksums. `make wrapper-smoke` verifies the npm and Python
-launchers through the local archive without treating those wrappers as
-published channels. Wrapper publication uses registry trusted publishing from
-dedicated release workflow jobs instead of long-lived registry tokens.
+the same archive checksums and confirms generated URLs and checksums match the
+formula content. `make wrapper-smoke` verifies the npm and Python launchers
+through the local archive. Wrapper publication uses registry trusted publishing
+from dedicated release workflow jobs instead of long-lived registry tokens.
 
 The release workflows run the same smoke targets so the action scripts, binary
 archives, Homebrew formula, wrapper launchers, MCPB manifest, and MCP Registry
@@ -155,7 +155,8 @@ make release-verify VERSION=vX.Y.Z
 ~~~
 
 That command compares the local tag target, GitHub Release title and target,
-GitHub tag verification state, required binary assets, and crates.io version.
+GitHub tag verification state, required binary assets, crates.io version, npm
+version, PyPI version, wrapper launch output, and Homebrew formula evidence.
 
 Run `make upstream-golden` before changing rule behavior or fix behavior. It is deterministic and does not require network access. Run `make upstream-golden-live` only when refreshing the upstream oracle or investigating compatibility drift.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -56,12 +56,12 @@ Required sequence:
 - Confirm `CHANGELOG.md` has a `## vX.Y.Z` section.
 - Create and push a GitHub-verified signed annotated tag with `make release-tag VERSION=vX.Y.Z`.
 - Dispatch the intended release command.
-- Verify external state after publication with `make release-verify VERSION=vX.Y.Z`.
+- Verify GitHub Release, crates.io, npm, PyPI, wrapper launch, and Homebrew formula state after publication with `make release-verify VERSION=vX.Y.Z`.
 
 Release command responsibilities:
 
 - `make release-github VERSION=vX.Y.Z` creates or updates the GitHub Release only.
-- `make release VERSION=vX.Y.Z` creates or updates the GitHub Release and publishes to crates.io.
+- `make release VERSION=vX.Y.Z` creates or updates the GitHub Release and publishes to crates.io, npm, and PyPI.
 
 The workflow validates:
 
@@ -111,7 +111,7 @@ because the older `macos-13` image is no longer supported.
 The root `action.yml` is the official GitHub Action channel from `v0.11.0`.
 Release preflight must keep `make action-smoke` passing before publishing a tag.
 
-Tag push flow is also supported. Pushing `vX.Y.Z` runs the same gates and creates or updates the GitHub Release, but it does not publish to crates.io. Use manual dispatch with `publish_crate: true` when crates.io publication is intended.
+Tag push flow is also supported. Pushing `vX.Y.Z` runs the same gates and creates or updates the GitHub Release, but it does not publish to crates.io, npm, or PyPI. Use `make release VERSION=vX.Y.Z` when registry publication is intended.
 
 Manual GitHub Actions dispatch is still available, but the local `make`
 targets are preferred because they create or verify the signed tag and check the
@@ -168,17 +168,17 @@ a tap update before the referenced release assets and checksums exist.
 ## Wrapper Publication
 
 The npm and Python wrappers are thin launchers over GitHub Release binary
-archives. They are not official install channels until all of these are true:
+archives. They are official install channels only when registry state and
+wrapper launch verification pass for the release version.
+
+Keep these conditions true before publishing a wrapper version:
 
 - npm and PyPI maintainer accounts exist for the package owner.
 - The GitHub repository has a `pypi` environment for PyPI publication.
 - npm trusted publishing is configured for `release.yml`.
 - PyPI trusted publishing is configured for `release.yml` with the `pypi` environment.
-- The release workflow is manually dispatched with wrapper publish flags enabled.
+- The release workflow is dispatched with wrapper publish flags enabled.
 - `make wrapper-smoke VERSION=vX.Y.Z` succeeds against the release archive shape.
-
-Current `v0.17.0` release notes and public documentation keep wrapper
-publication deferred when these trusted publisher settings are absent.
 
 Use these trusted publisher settings:
 
@@ -189,6 +189,9 @@ Use these trusted publisher settings:
 
 The PyPI project name must match `wrappers/python/pyproject.toml`. Change the
 wrapper metadata first if the package name is changed before publication.
+After wrapper publication, `make release-verify VERSION=vX.Y.Z` checks the npm
+registry version, PyPI JSON version, `npx` launcher output, and `uvx` launcher
+output.
 
 ## Required Secrets
 
@@ -196,12 +199,6 @@ wrapper metadata first if the package name is changed before publication.
 
 GitHub OIDC Registry authentication does not require a dedicated secret, but the
 Release workflow must keep `id-token: write`.
-
-For the first npm wrapper publication, npm can require a traditional publish
-token because trusted publishing is configured from an existing package. If the
-package does not exist yet, create a short-lived granular token with publish
-permission, store it as `NPM_TOKEN`, publish the first wrapper version, then
-configure npm trusted publishing and revoke the token.
 
 ## Quality Gates and Branch Protection
 
@@ -256,7 +253,7 @@ If workflow job names are changed, update branch protection in the same change. 
 - If it was not published, fix the token or package issue and re-run with the same version.
 - If it was partially published, do not reuse the same version for changed content; bump `Cargo.toml` version.
 - `make release` fails fast when the requested version already exists on crates.io.
-- Use `make release-verify VERSION=vX.Y.Z` to compare the local tag target, GitHub Release title and target, and crates.io version after retry.
+- Use `make release-verify VERSION=vX.Y.Z` to compare the local tag target, GitHub Release title and target, crates.io version, npm version, PyPI version, wrapper launch output, and Homebrew formula evidence after retry.
 
 ### MCP Registry publish failed
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/v0-17-1-distribution-closeout/tasks.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/tasks.md
@@ -3,38 +3,38 @@
 ## Definition of Ready
 
 - [ ] 0.1 npm package `katana-markdown-linter` の trusted publishing 設定を確認する
-- [ ] 0.2 PyPI project `katana-markdown-linter` の trusted publisher と `pypi` environment を確認する
-- [ ] 0.3 `homebrew-katana` tap の local checkout と branch protection を確認する
-- [ ] 0.4 `v0.17.0` の npm / PyPI / GitHub Release / crates.io 公開状態を再確認する
+- [x] 0.2 PyPI project `katana-markdown-linter` の trusted publisher と `pypi` environment を確認する
+- [x] 0.3 `homebrew-katana` tap の local checkout と branch protection を確認する
+- [x] 0.4 `v0.17.0` の npm / PyPI / GitHub Release / crates.io 公開状態を再確認する
 - [ ] 0.5 `NPM_TOKEN` を次回 release の通常手順から外せることを確認する
 
 ## 1. npm / PyPI Wrapper Officialization
 
-- [ ] 1.1 npm wrapper の install command と `npx` 実行例を README / docs に公式導線として反映する
-- [ ] 1.2 PyPI wrapper の install command と `uvx` 実行例を README / docs に公式導線として反映する
-- [ ] 1.3 wrapper が binary launcher であり、独自 lint logic を持たないことを docs に明記する
-- [ ] 1.4 `docs/distribution.md` の npm / pip deferred 表記を公開済み状態へ更新する
+- [x] 1.1 npm wrapper の install command と `npx` 実行例を README / docs に公式導線として反映する
+- [x] 1.2 PyPI wrapper の install command と `uvx` 実行例を README / docs に公式導線として反映する
+- [x] 1.3 wrapper が binary launcher であり、独自 lint logic を持たないことを docs に明記する
+- [x] 1.4 `docs/distribution.md` の npm / pip deferred 表記を公開済み状態へ更新する
 
 ## 2. Trusted Publishing Cleanup
 
-- [ ] 2.1 `.github/workflows/release.yml` の npm publish job から `NPM_TOKEN` / `NODE_AUTH_TOKEN` 依存を削除する
-- [ ] 2.2 npm publish job が trusted publishing 前提で失敗する場合の error message を明確にする
-- [ ] 2.3 PyPI publish job が `pypi` environment と OIDC publish を維持していることを検証する
-- [ ] 2.4 `scripts/release/wrapper-publish-gate.sh` の文言と実際の workflow 条件を一致させる
-- [ ] 2.5 `docs/release-runbook.md` から初回公開用 token 手順を通常手順として扱う記述を外す
+- [x] 2.1 `.github/workflows/release.yml` の npm publish job から `NPM_TOKEN` / `NODE_AUTH_TOKEN` 依存を削除する
+- [x] 2.2 npm publish job が trusted publishing 前提で失敗する場合の error message を明確にする
+- [x] 2.3 PyPI publish job が `pypi` environment と OIDC publish を維持していることを検証する
+- [x] 2.4 `scripts/release/wrapper-publish-gate.sh` の文言と実際の workflow 条件を一致させる
+- [x] 2.5 `docs/release-runbook.md` から初回公開用 token 手順を通常手順として扱う記述を外す
 
 ## 3. Release Verification
 
-- [ ] 3.1 `scripts/release/verify-release-published.sh` に npm registry version check を追加する
-- [ ] 3.2 `scripts/release/verify-release-published.sh` に PyPI JSON version check を追加する
-- [ ] 3.3 `scripts/release/verify-release-published.sh` に `npx` wrapper smoke を追加する
-- [ ] 3.4 `scripts/release/verify-release-published.sh` に `uvx` wrapper smoke を追加する
-- [ ] 3.5 `scripts/release/verify-release-published.sh` に Homebrew formula URL / checksum / test block check を追加する
-- [ ] 3.6 `make release-verify VERSION=v0.17.1` が追加検証を呼ぶことを確認する
+- [x] 3.1 `scripts/release/verify-release-published.sh` に npm registry version check を追加する
+- [x] 3.2 `scripts/release/verify-release-published.sh` に PyPI JSON version check を追加する
+- [x] 3.3 `scripts/release/verify-release-published.sh` に `npx` wrapper smoke を追加する
+- [x] 3.4 `scripts/release/verify-release-published.sh` に `uvx` wrapper smoke を追加する
+- [x] 3.5 `scripts/release/verify-release-published.sh` に Homebrew formula URL / checksum / test block check を追加する
+- [x] 3.6 `make release-verify VERSION=v0.17.1` が追加検証を呼ぶことを確認する
 
 ## 4. Homebrew Tap Update
 
-- [ ] 4.1 `make homebrew-formula VERSION=v0.17.1` で生成される formula を確認する
+- [x] 4.1 `make homebrew-formula VERSION=v0.17.1` で生成される formula を確認する
 - [ ] 4.2 `homebrew-katana` tap に `Formula/kml.rb` 差分を作る
 - [ ] 4.3 tap 側で `brew audit` / `brew test` 相当の確認を行う
 - [ ] 4.4 tap 更新の commit / push / PR 方針を branch protection に合わせて実行する
@@ -42,27 +42,27 @@
 
 ## 5. Documentation and Release Metadata
 
-- [ ] 5.1 README の install section を Cargo / GitHub Release / npm / PyPI / Homebrew の現状に合わせる
-- [ ] 5.2 `docs/release-runbook.md` の wrapper publish と post-release verification を更新する
-- [ ] 5.3 `docs/quality-gates.md` に registry / wrapper / Homebrew verification を追加する
-- [ ] 5.4 `CHANGELOG.md` に `v0.17.1` の配布後始末を追加する
-- [ ] 5.5 version metadata を `0.17.1` に更新する
+- [x] 5.1 README の install section を Cargo / GitHub Release / npm / PyPI / Homebrew の現状に合わせる
+- [x] 5.2 `docs/release-runbook.md` の wrapper publish と post-release verification を更新する
+- [x] 5.3 `docs/quality-gates.md` に registry / wrapper / Homebrew verification を追加する
+- [x] 5.4 `CHANGELOG.md` に `v0.17.1` の配布後始末を追加する
+- [x] 5.5 version metadata を `0.17.1` に更新する
 
 ## 6. Verification
 
-- [ ] 6.1 `make fmt-check`
-- [ ] 6.2 `make lint`
-- [ ] 6.3 `make ast-lint`
-- [ ] 6.4 `cargo test --workspace --locked`
-- [ ] 6.5 `make dogfood`
-- [ ] 6.6 `git diff --check`
-- [ ] 6.7 `make release-check VERSION=v0.17.1`
+- [x] 6.1 `make fmt-check`
+- [x] 6.2 `make lint`
+- [x] 6.3 `make ast-lint`
+- [x] 6.4 `cargo test --workspace --locked`
+- [x] 6.5 `make dogfood`
+- [x] 6.6 `git diff --check`
+- [x] 6.7 `make release-check VERSION=v0.17.1`
 - [ ] 6.8 `make release-task-ledger-check VERSION=v0.17.1`
 
 ## Definition of Done
 
-- [ ] 7.1 npm / PyPI wrapper が README と docs で公式 install channel として扱われている
-- [ ] 7.2 npm publish job が通常 release path で `NPM_TOKEN` を要求しない
-- [ ] 7.3 `make release-verify` が npm / PyPI / wrapper launch / Homebrew formula を確認する
+- [x] 7.1 npm / PyPI wrapper が README と docs で公式 install channel として扱われている
+- [x] 7.2 npm publish job が通常 release path で `NPM_TOKEN` を要求しない
+- [x] 7.3 `make release-verify` が npm / PyPI / wrapper launch / Homebrew formula を確認する
 - [ ] 7.4 Homebrew tap 更新が review 可能な差分として完了している
 - [ ] 7.5 `v0.17.1` release 後の public registry state が verification で確認できる

--- a/scripts/release/homebrew_formula.py
+++ b/scripts/release/homebrew_formula.py
@@ -32,6 +32,7 @@ class HomebrewFormulaTool:
         formula = self.output.read_text(encoding="utf-8")
         required = ["class Kml < Formula", "bin.install \"kml\"", "kml --version"]
         missing = [item for item in required if item not in formula]
+        missing.extend(self._missing_asset_content(formula))
         if missing:
             raise SystemExit(f"Formula is missing required content: {', '.join(missing)}")
         print(f"Formula check passed for {self.output}")
@@ -58,6 +59,14 @@ class HomebrewFormulaTool:
         if not assets:
             raise SystemExit("No Homebrew-compatible binary assets were found")
         return assets
+
+    def _missing_asset_content(self, formula: str) -> list[str]:
+        missing: list[str] = []
+        for asset in self._load_assets():
+            for item in [asset.url(self.repo, self.version), asset.checksum]:
+                if item not in formula:
+                    missing.append(item)
+        return missing
 
     def _render_formula(self, assets: list[FormulaAsset]) -> str:
         by_target = {asset.target: asset for asset in assets}

--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -5,91 +5,194 @@ VERSION_BARE="${1:?version is required}"
 REPO="${2:-${GH_REPO:-HiroyukiFuruno/katana-markdown-linter}}"
 PACKAGE="${3:-katana-markdown-linter}"
 TAG="v${VERSION_BARE}"
+VERIFY_OUTPUT_DIR="${VERIFY_OUTPUT_DIR:-target/release-verify/${TAG}}"
+TMP_ROOT=""
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "gh CLI is required to verify GitHub Release state." >&2
+cleanup() {
+  [[ -z "${TMP_ROOT}" ]] || rm -rf "${TMP_ROOT}"
+}
+
+require_command() {
+  command_name="$1"
+  command -v "${command_name}" >/dev/null 2>&1 && return
+  echo "${command_name} is required to verify ${TAG} publication." >&2
   exit 1
-fi
+}
 
-local_target="$(git rev-parse "${TAG}^{}")"
-release_tag="$(gh release view "${TAG}" --repo "${REPO}" --json tagName --jq '.tagName')"
-release_title="$(gh release view "${TAG}" --repo "${REPO}" --json name --jq '.name')"
-release_target="$(gh release view "${TAG}" --repo "${REPO}" --json targetCommitish --jq '.targetCommitish')"
-release_draft="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft')"
-release_url="$(gh release view "${TAG}" --repo "${REPO}" --json url --jq '.url')"
-
-if [[ "${release_tag}" != "${TAG}" ]]; then
-  echo "GitHub Release tag mismatch: expected ${TAG}, got ${release_tag}" >&2
+assert_equal() {
+  label="$1"
+  expected="$2"
+  actual="$3"
+  [[ "${actual}" == "${expected}" ]] && return
+  echo "${label} mismatch: expected ${expected}, got ${actual:-missing}" >&2
   exit 1
-fi
+}
 
-if [[ "${release_title}" != "${TAG}" ]]; then
-  echo "GitHub Release title mismatch: expected ${TAG}, got ${release_title}" >&2
-  exit 1
-fi
+verify_github_release() {
+  local_target="$(git rev-parse "${TAG}^{}")"
+  release_tag="$(gh release view "${TAG}" --repo "${REPO}" --json tagName --jq '.tagName')"
+  release_title="$(gh release view "${TAG}" --repo "${REPO}" --json name --jq '.name')"
+  release_target="$(gh release view "${TAG}" --repo "${REPO}" --json targetCommitish --jq '.targetCommitish')"
+  release_draft="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft')"
+  release_url="$(gh release view "${TAG}" --repo "${REPO}" --json url --jq '.url')"
 
-if [[ "${release_draft}" != "false" ]]; then
-  echo "${TAG} GitHub Release is still a draft." >&2
-  exit 1
-fi
+  assert_equal "GitHub Release tag" "${TAG}" "${release_tag}"
+  assert_equal "GitHub Release title" "${TAG}" "${release_title}"
+  assert_equal "GitHub Release draft state" "false" "${release_draft}"
 
-if [[ "${release_target}" != "${local_target}" ]]; then
-  echo "${TAG} GitHub Release target differs from the local tag target." >&2
-  echo "release: ${release_target}" >&2
-  echo "local:   ${local_target}" >&2
-  exit 1
-fi
-
-asset_names="$(gh release view "${TAG}" --repo "${REPO}" --json assets --jq '.assets[].name')"
-for target in \
-  x86_64-unknown-linux-gnu \
-  x86_64-apple-darwin \
-  aarch64-apple-darwin \
-  x86_64-pc-windows-msvc; do
-  extension="tar.gz"
-  if [[ "${target}" == x86_64-pc-windows-msvc ]]; then
-    extension="zip"
-  fi
-  archive="kml-${TAG}-${target}.${extension}"
-  if ! grep -Fxq "${archive}" <<< "${asset_names}"; then
-    echo "GitHub Release is missing binary archive: ${archive}" >&2
+  if [[ "${release_target}" != "${local_target}" ]]; then
+    echo "${TAG} GitHub Release target differs from the local tag target." >&2
+    echo "release: ${release_target}" >&2
+    echo "local:   ${local_target}" >&2
     exit 1
   fi
-  if ! grep -Fxq "${archive}.sha256" <<< "${asset_names}"; then
-    echo "GitHub Release is missing binary checksum: ${archive}.sha256" >&2
-    exit 1
-  fi
-done
 
-case "$(uname -s)/$(uname -m)" in
-  Linux/x86_64) smoke_target="x86_64-unknown-linux-gnu" ;;
-  Darwin/x86_64) smoke_target="x86_64-apple-darwin" ;;
-  Darwin/arm64) smoke_target="aarch64-apple-darwin" ;;
-  *) smoke_target="" ;;
-esac
+  asset_names="$(gh release view "${TAG}" --repo "${REPO}" --json assets --jq '.assets[].name')"
+}
 
-if [[ -n "${smoke_target}" ]]; then
-  smoke_extension="tar.gz"
-  smoke_archive="kml-${TAG}-${smoke_target}.${smoke_extension}"
-  smoke_dir="$(mktemp -d)"
-  trap 'rm -rf "${smoke_dir}"' EXIT
-  gh release download "${TAG}" --repo "${REPO}" --dir "${smoke_dir}" --pattern "${smoke_archive}" --pattern "${smoke_archive}.sha256"
+verify_binary_assets() {
+  for target in \
+    x86_64-unknown-linux-gnu \
+    x86_64-apple-darwin \
+    aarch64-apple-darwin \
+    x86_64-pc-windows-msvc; do
+    extension="tar.gz"
+    if [[ "${target}" == x86_64-pc-windows-msvc ]]; then
+      extension="zip"
+    fi
+    archive="kml-${TAG}-${target}.${extension}"
+    if ! grep -Fxq "${archive}" <<< "${asset_names}"; then
+      echo "GitHub Release is missing binary archive: ${archive}" >&2
+      exit 1
+    fi
+    if ! grep -Fxq "${archive}.sha256" <<< "${asset_names}"; then
+      echo "GitHub Release is missing binary checksum: ${archive}.sha256" >&2
+      exit 1
+    fi
+  done
+}
+
+smoke_current_platform_binary() {
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64) smoke_target="x86_64-unknown-linux-gnu" ;;
+    Darwin/x86_64) smoke_target="x86_64-apple-darwin" ;;
+    Darwin/arm64) smoke_target="aarch64-apple-darwin" ;;
+    *) smoke_target="" ;;
+  esac
+
+  [[ -n "${smoke_target}" ]] || return
+
+  smoke_dir="${TMP_ROOT}/binary-smoke"
+  mkdir -p "${smoke_dir}"
+  smoke_archive="kml-${TAG}-${smoke_target}.tar.gz"
+  gh release download "${TAG}" \
+    --repo "${REPO}" \
+    --dir "${smoke_dir}" \
+    --pattern "${smoke_archive}" \
+    --pattern "${smoke_archive}.sha256"
   python3 scripts/release/binary_artifacts.py smoke \
     --version "${TAG}" \
     --target "${smoke_target}" \
     --archive "${smoke_dir}/${smoke_archive}" \
     --checksum "${smoke_dir}/${smoke_archive}.sha256"
-fi
+}
 
-cargo_info="$(cargo info "${PACKAGE}@${VERSION_BARE}" --registry crates-io)"
-crate_version="$(printf '%s\n' "${cargo_info}" | sed -n 's/^version: //p')"
-if [[ "${crate_version}" != "${VERSION_BARE}" ]]; then
-  echo "crates.io version mismatch: expected ${VERSION_BARE}, got ${crate_version:-missing}" >&2
-  exit 1
-fi
+verify_crates_io() {
+  cargo_info="$(cargo info "${PACKAGE}@${VERSION_BARE}" --registry crates-io)"
+  crate_version="$(printf '%s\n' "${cargo_info}" | sed -n 's/^version: //p')"
+  if [[ "${crate_version}" != "${VERSION_BARE}" ]]; then
+    echo "crates.io version mismatch: expected ${VERSION_BARE}, got ${crate_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+verify_npm_registry() {
+  require_command npm
+  npm_registry_version="$(npm view "${PACKAGE}@${VERSION_BARE}" version 2>/dev/null || true)"
+  if [[ "${npm_registry_version}" != "${VERSION_BARE}" ]]; then
+    echo "npm registry version mismatch: expected ${VERSION_BARE}, got ${npm_registry_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+verify_pypi_registry() {
+  pypi_registry_version="$(
+    python3 -c 'import json, sys, urllib.request; package, version = sys.argv[1:3]; url = f"https://pypi.org/pypi/{package}/{version}/json"; print(json.load(urllib.request.urlopen(url, timeout=30))["info"]["version"])' "${PACKAGE}" "${VERSION_BARE}" 2>/dev/null || true
+  )"
+  if [[ "${pypi_registry_version}" != "${VERSION_BARE}" ]]; then
+    echo "PyPI version mismatch: expected ${VERSION_BARE}, got ${pypi_registry_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+smoke_npm_wrapper() {
+  require_command npx
+  npm_wrapper_version="$(npx --yes "${PACKAGE}@${VERSION_BARE}" --version | tail -n 1)"
+  if [[ "${npm_wrapper_version}" != "${VERSION_BARE}" ]]; then
+    echo "npm wrapper version mismatch: expected ${VERSION_BARE}, got ${npm_wrapper_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+smoke_pypi_wrapper() {
+  require_command uvx
+  pypi_wrapper_version="$(uvx --from "${PACKAGE}==${VERSION_BARE}" kml --version | tail -n 1)"
+  if [[ "${pypi_wrapper_version}" != "${VERSION_BARE}" ]]; then
+    echo "PyPI wrapper version mismatch: expected ${VERSION_BARE}, got ${pypi_wrapper_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+verify_homebrew_formula() {
+  formula_dist_dir="${TMP_ROOT}/homebrew-assets"
+  formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml.rb"
+  mkdir -p "${formula_dist_dir}" "$(dirname "${formula_path}")"
+  for target in \
+    x86_64-unknown-linux-gnu \
+    x86_64-apple-darwin \
+    aarch64-apple-darwin; do
+    archive="kml-${TAG}-${target}.tar.gz"
+    gh release download "${TAG}" \
+      --repo "${REPO}" \
+      --dir "${formula_dist_dir}" \
+      --pattern "${archive}" \
+      --pattern "${archive}.sha256"
+  done
+  python3 scripts/release/homebrew_formula.py generate \
+    --version "${TAG}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py check \
+    --version "${TAG}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${formula_path}" >/dev/null
+}
+
+require_command gh
+require_command cargo
+require_command python3
+trap cleanup EXIT
+TMP_ROOT="$(mktemp -d)"
+
+verify_github_release
+verify_binary_assets
+smoke_current_platform_binary
+verify_crates_io
+verify_npm_registry
+verify_pypi_registry
+smoke_npm_wrapper
+smoke_pypi_wrapper
+verify_homebrew_formula
 
 echo "tag_target=${local_target}"
 echo "github_release_title=${release_title}"
 echo "github_release_target=${release_target}"
 echo "github_release_url=${release_url}"
 echo "crates_io_version=${crate_version}"
+echo "npm_registry_version=${npm_registry_version}"
+echo "pypi_registry_version=${pypi_registry_version}"
+echo "npm_wrapper_version=${npm_wrapper_version}"
+echo "pypi_wrapper_version=${pypi_wrapper_version}"
+echo "homebrew_formula_path=${formula_path}"

--- a/scripts/release/wrapper-publish-gate.sh
+++ b/scripts/release/wrapper-publish-gate.sh
@@ -4,21 +4,27 @@ set -euo pipefail
 NPM_ENABLED="${PUBLISH_NPM_WRAPPER:-false}"
 PYPI_ENABLED="${PUBLISH_PYPI_WRAPPER:-false}"
 
-if [[ "$NPM_ENABLED" == "true" ]]; then
+require_trusted_publishing_context() {
+  registry="$1"
   if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
-    echo "npm wrapper publish requires GitHub Actions trusted publishing." >&2
+    echo "${registry} wrapper publish requires GitHub Actions trusted publishing. Local release checks never publish registry packages." >&2
     exit 1
   fi
+  if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+    echo "${registry} wrapper publish requires id-token: write so the registry can exchange a GitHub OIDC token." >&2
+    exit 1
+  fi
+}
+
+if [[ "$NPM_ENABLED" == "true" ]]; then
+  require_trusted_publishing_context "npm"
   echo "npm wrapper publish enabled through trusted publishing."
 else
   echo "npm wrapper publish deferred."
 fi
 
 if [[ "$PYPI_ENABLED" == "true" ]]; then
-  if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
-    echo "PyPI wrapper publish requires GitHub Actions trusted publishing." >&2
-    exit 1
-  fi
+  require_trusted_publishing_context "PyPI"
   echo "PyPI wrapper publish enabled through trusted publishing."
 else
   echo "PyPI wrapper publish deferred."

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.0",
+  "version": "0.17.1",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.0/katana-markdown-linter-0.17.0.mcpb",
-      "version": "0.17.0",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/katana-markdown-linter-0.17.1.mcpb",
+      "version": "0.17.1",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -303,6 +303,8 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         ("Makefile", &makefile, "scripts/release/verify-task-ledger.py"),
         ("Makefile", &makefile, "release-verify:"),
         ("Makefile", &makefile, "scripts/release/verify-release-published.sh"),
+        ("Makefile", &makefile, "publish_npm_wrapper=true"),
+        ("Makefile", &makefile, "publish_pypi_wrapper=true"),
         (".github/workflows/release.yml", &workflow, "run: make lint"),
         (".github/workflows/release.yml", &workflow, "run: make examples"),
         (".github/workflows/release.yml", &workflow, "run: make mcp-build"),
@@ -315,6 +317,16 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (".github/workflows/release.yml", &workflow, "Generate Homebrew formula"),
         (".github/workflows/release.yml", &workflow, "Publish npm wrapper"),
         (".github/workflows/release.yml", &workflow, "node-version: \"24\""),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
+            "Verify npm trusted publishing context",
+        ),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
+            "npm publish --access public --provenance",
+        ),
         (".github/workflows/release.yml", &workflow, "Publish PyPI wrapper"),
         (".github/workflows/release.yml", &workflow, "environment: pypi"),
         (".github/workflows/release.yml", &workflow, "pypa/gh-action-pypi-publish@release/v1"),
@@ -354,11 +366,16 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         ("docs/quality-gates.md", &quality, "already exists on crates.io"),
         ("scripts/release/release-notes.sh", &release_notes, "CHANGELOG.md is missing a non-empty section"),
         ("scripts/release/assert-crate-not-published.sh", &crate_guard, "Bump Cargo.toml before dispatching"),
-        ("scripts/release/verify-release-published.sh", &published_verifier, "GitHub Release title mismatch"),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "assert_equal \"GitHub Release title\""),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_title="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_target="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "GitHub Release is missing binary archive"),
         ("scripts/release/verify-release-published.sh", &published_verifier, "crates_io_version="),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "npm_registry_version="),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "pypi_registry_version="),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "npm_wrapper_version="),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "pypi_wrapper_version="),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "homebrew_formula_path="),
         ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "Verify that the OpenSpec task ledger is release-ready."),
         ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "Release task ledger is not ready"),
         ("scripts/release/verify-task-ledger.py", &task_ledger_verifier, "品質評価スコア table is missing a 合計 row"),
@@ -370,6 +387,20 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         .collect();
 
     assert_no_violations("release-local-ci-parity-and-retry-safety", violations);
+}
+
+#[test]
+fn ast_linter_npm_wrapper_publish_is_tokenless() {
+    let workflow = read_workspace_file(".github/workflows/release.yml");
+    let violations = ["NPM_TOKEN", "NODE_AUTH_TOKEN"]
+        .into_iter()
+        .filter(|forbidden| workflow.contains(forbidden))
+        .map(|forbidden| {
+            format!(".github/workflows/release.yml: remove `{forbidden}` from npm wrapper publish")
+        })
+        .collect();
+
+    assert_no_violations("npm-wrapper-tokenless-publish", violations);
 }
 
 #[test]

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Thin npm launcher for the kml Markdown linter binary.",
   "license": "MIT",
   "repository": {

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.0"
+version = "0.17.1"
 description = "Thin Python launcher for the kml Markdown linter binary."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.0"
+            package_version = "0.17.1"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Prepare v0.17.1 release metadata and wrapper versions
- Complete distribution closeout implementation for npm, PyPI, and Homebrew verification
- Expand release verification gates across registries and wrapper launch paths

## Verification
- make fmt-check
- make lint
- make ast-lint
- cargo test --workspace --locked
- make dogfood
- git diff --check
- make release-check VERSION=v0.17.1
- make mcpb-smoke VERSION=v0.17.1
- make server-json-validate VERSION=v0.17.1

## Notes
- npm trusted publishing could not be confirmed locally because this environment is not authenticated to npm.
- Homebrew tap update tasks remain release-time tasks after public artifacts exist.