### PR TITLE
Prepare v0.17.2 release

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Wrapper smoke
         run: make wrapper-smoke
 
+      - name: npm package check
+        run: make npm-package-check
+
       - name: Wrapper publish gate
         run: make wrapper-publish-gate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,6 +220,9 @@ jobs:
       - name: Action smoke
         run: make action-smoke
 
+      - name: npm package check
+        run: make npm-package-check
+
       - name: Dogfood
         run: make dogfood
 
@@ -362,6 +365,9 @@ jobs:
             echo "npm trusted publishing is unavailable. Configure npm trusted publisher for HiroyukiFuruno/katana-markdown-linter with workflow release.yml and keep id-token: write." >&2
             exit 1
           fi
+
+      - name: Verify npm package
+        run: make npm-package-check
 
       - name: Publish npm wrapper
         run: npm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.17.2
+
+- Adds an npm package README so the registry page shows install, `npx`, and
+  basic `kml check` examples.
+- Adds npm search and support metadata while keeping the wrapper dependency
+  surface empty.
+- Adds an npm package check that verifies required metadata and tarball contents
+  before release publication.
+- Carries the `v0.17.1` npm trusted publishing closeout into a fresh patch
+  release so npm publication can be verified with `npm view` and `npx`.
+
 ## v0.17.1
 
 - Promotes the npm and PyPI wrappers to official install channels after public

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.1"
+version = "0.17.2"
 
 edition = "2021"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,10 @@ homebrew-formula-check: homebrew-formula ## Validate generated Homebrew formula 
 wrapper-smoke: binary-package ## Exercise npm and Python wrapper launchers against local binary archive
 	scripts/release/smoke-wrappers.sh "$(VERSION)" "$(BINARY_DIST_DIR)"
 
+.PHONY: npm-package-check
+npm-package-check: ## Verify npm wrapper package README, metadata, and tarball contents
+	node scripts/release/verify-npm-package.js wrappers/npm
+
 .PHONY: wrapper-publish-gate
 wrapper-publish-gate: ## Verify wrapper publish flags stay deferred outside trusted publishing
 	scripts/release/wrapper-publish-gate.sh
@@ -286,7 +290,7 @@ release-test: ## Run release-equivalent tests with all optional features
 	cargo test --all-features --locked
 
 .PHONY: release-check
-release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke wrapper-publish-gate document-answer-fix ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
+release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check wrapper-publish-gate document-answer-fix ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
 	$(MAKE) public-confidence
 	scripts/release/verify-version.sh "$(VERSION)"
 	cargo publish --dry-run --locked --allow-dirty

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.1 check README.md
+npx --yes katana-markdown-linter@0.17.2 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.1 kml check README.md
+uvx --from katana-markdown-linter==0.17.2 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,10 +137,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/kml-v0.17.1-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/kml-v0.17.1-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.1-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.1-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/kml-v0.17.2-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/kml-v0.17.2-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.17.2-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.17.2-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -158,8 +158,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.1
-  with: { version: "0.17.1", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.2
+  with: { version: "0.17.2", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -416,7 +416,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.1
+make mcpb-smoke VERSION=v0.17.2
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -6,7 +6,7 @@
 | --- | --- | --- | --- |
 | Cargo crate | Official | `make release-check`, install smoke test, crates.io publish verification | Primary library and CLI package |
 | Standalone binary artifacts | Official from `v0.17.1` | `make binary-smoke`, release asset checksum, `make release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
-| npm wrapper | Official from `v0.17.1` | npm registry version, `npx` launch smoke, `make release-verify` | Thin launcher over GitHub Release binary archives |
+| npm wrapper | Official from `v0.17.2` | npm registry version, `npx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
 | PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, `make release-verify` | Thin launcher over GitHub Release binary archives |
 | Homebrew formula | Official from `v0.17.1` | `make homebrew-formula-check`, release archive checksum, formula test block, tap review | Tap update is reviewed separately in `homebrew-katana` after release assets exist |
 | GitHub Action | Official from `v0.11.0` | `make action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
@@ -19,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.1
-  with: { version: "0.17.1", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.2
+  with: { version: "0.17.2", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -37,13 +37,15 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.1-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.17.2-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
 and must keep tap mutation separate from this repository's release workflow.
 
 The npm and PyPI packages do not contain independent lint logic. They download
 the matching GitHub Release archive for the package version, verify the archive
-checksum, and launch the bundled `kml` binary.
+checksum, and launch the bundled `kml` binary. The npm package also ships a
+registry README and metadata that are verified by `make npm-package-check`
+before publication.
 
 `kml-mcp-remote` is not a hosted service and is not described by the MCPB
 Registry metadata. Operators deploy it themselves, keep bearer authentication

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.1
+    make mcpb-smoke VERSION=v0.17.2
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.1.mcpb
-    katana-markdown-linter-0.17.1.mcpb.sha256
+    katana-markdown-linter-0.17.2.mcpb
+    katana-markdown-linter-0.17.2.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.1` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.17.2` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.1
+    make server-json-validate VERSION=v0.17.2
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -23,6 +23,7 @@
 | `make binary-smoke` | Build a standalone `kml` archive, verify checksum, extract it, and run CLI smoke checks | Yes for release gates |
 | `make homebrew-formula-check` | Render and validate the Homebrew formula from binary archive checksums | Yes for release gates |
 | `make wrapper-smoke` | Run npm and Python wrapper launchers against the local binary archive | Yes for release gates |
+| `make npm-package-check` | Verify the npm wrapper README, registry metadata, and tarball file list | Yes for release gates |
 | `make wrapper-publish-gate` | Ensure wrapper publication is skipped unless explicit trusted-publishing flags are present | Yes for release gates |
 | `make mcp-stdio-smoke` | Install `kml-mcp` and exercise the local stdio server through JSON-RPC | Yes for release gates |
 | `make mcp-remote-smoke` | Install `kml-mcp-remote` and exercise Streamable HTTP auth, tools, diagnostics, and size limits | Yes for release gates |
@@ -45,7 +46,7 @@
 - upstream drift checking must be wired through `make upstream-drift` and release workflows
 - public confidence evidence must stay wired into release preflight and release workflows
 - the GitHub Action channel must stay wired through `action.yml`, shared scripts, and release smoke checks
-- binary artifact, Homebrew formula, and wrapper smoke gates must stay wired into release checks
+- binary artifact, Homebrew formula, npm package, and wrapper smoke gates must stay wired into release checks
 - MCPB packaging and MCP Registry metadata validation must stay wired into local and release gates
 - CI workflows must keep Windows workspace verification and Rust cache strategy explicit
 - public Markdown docs must stay English-only
@@ -92,8 +93,10 @@ extracts the archive, checks `kml --version`, and runs a small `kml check`
 fixture. `make homebrew-formula-check` renders `target/homebrew/kml.rb` from
 the same archive checksums and confirms generated URLs and checksums match the
 formula content. `make wrapper-smoke` verifies the npm and Python launchers
-through the local archive. Wrapper publication uses registry trusted publishing
-from dedicated release workflow jobs instead of long-lived registry tokens.
+through the local archive. `make npm-package-check` verifies the npm registry
+README, support metadata, dependency surface, and packed file list before
+publication. Wrapper publication uses registry trusted publishing from dedicated
+release workflow jobs instead of long-lived registry tokens.
 
 The release workflows run the same smoke targets so the action scripts, binary
 archives, Homebrew formula, wrapper launchers, MCPB manifest, and MCP Registry
@@ -136,9 +139,10 @@ The local release check runs formatting, Clippy, AST lint, tests, dogfood,
 public confidence, coverage regression, example builds, optional MCP build,
 MCP stdio smoke, MCP remote smoke, MCPB smoke, Registry metadata validation,
 action smoke, binary smoke, Homebrew formula validation, wrapper smoke, wrapper
-publish gating, version verification, dry-run publish, and install smoke
-checks. The GitHub release workflows additionally clone upstream markdownlint
-and run `make upstream-drift` against the default branch docs.
+package validation, wrapper publish gating, version verification, dry-run
+publish, and install smoke checks. The GitHub release workflows additionally
+clone upstream markdownlint and run `make upstream-drift` against the default
+branch docs.
 
 Use `make release-tag VERSION=vX.Y.Z` before dispatching a release. It creates
 or verifies a signed annotated tag and then requires GitHub to report the tag as

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -32,6 +32,7 @@ For binary distribution changes, the release check includes:
 - `make binary-smoke VERSION=vX.Y.Z`
 - `make homebrew-formula-check VERSION=vX.Y.Z`
 - `make wrapper-smoke VERSION=vX.Y.Z`
+- `make npm-package-check`
 - `make wrapper-publish-gate`
 
 If validating upstream drift locally, clone upstream docs and run:
@@ -76,6 +77,7 @@ The workflow validates:
 - `make mcpb-smoke`
 - `make server-json-validate`
 - `make action-smoke`
+- `make npm-package-check`
 - standalone `kml` archive build and archive smoke for each supported target
 - Homebrew formula rendering from release archive checksums
 - upstream markdownlint drift gate
@@ -179,6 +181,7 @@ Keep these conditions true before publishing a wrapper version:
 - PyPI trusted publishing is configured for `release.yml` with the `pypi` environment.
 - The release workflow is dispatched with wrapper publish flags enabled.
 - `make wrapper-smoke VERSION=vX.Y.Z` succeeds against the release archive shape.
+- `make npm-package-check` confirms the npm README, metadata, and tarball file list.
 
 Use these trusted publisher settings:
 
@@ -297,6 +300,14 @@ If workflow job names are changed, update branch protection in the same change. 
 - Re-run `make action-smoke`.
 - Inspect `action.yml`, `scripts/action/install-kml.sh`, and `scripts/action/run-kml.sh`.
 - Keep the action scripts generic; do not add repository-specific lint policy outside action inputs.
+
+### npm package check fails
+
+- Re-run `make npm-package-check`.
+- Inspect `wrappers/npm/package.json`, `wrappers/npm/README.md`, and
+  `scripts/release/verify-npm-package.js`.
+- Keep the npm wrapper dependency-free unless a runtime dependency is justified
+  by launcher behavior.
 
 ### Incorrect files were packaged
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -34,6 +34,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.16.2`: `v0.17.0` の配布拡張を凍結したまま、document answer fix evaluation で `kml check --fix` の byte-for-byte 正しさを固める。
 - `v0.17.0`: released distribution expansion with standalone binary artifacts, Homebrew formula generation, and deferred npm/pip wrapper publication gates.
 - `v0.17.1`: post-release distribution closeout として npm / PyPI wrapper を公式 install channel に昇格し、Homebrew tap 更新、npm trusted publishing 後始末、`release-verify` の wrapper / tap 検証拡張を扱う。
+- `v0.17.2`: npm package page polish と npm publish closeout を行う。`wrappers/npm/README.md`、keywords / homepage / bugs metadata、npm tarball verification、trusted publishing retry を `v0.18.0` より前に閉じる。
 - `v0.18.0`: config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
 - `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
@@ -41,7 +42,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 
 | Priority | Work Area | Change | Why Now |
 | --- | --- | --- | --- |
-| P0 | Distribution closeout for `v0.17.1` | `v0-17-1-distribution-closeout` | `v0.17.0` already published GitHub Release, crates.io, npm, and PyPI. The roadmap should now close the remaining operational gap: mark wrappers official, update `docs/distribution.md` and `docs/release-runbook.md`, update the Homebrew tap from generated formula output, configure npm trusted publishing, remove the temporary `NPM_TOKEN`, and teach `release-verify` to check npm / PyPI / Homebrew state. |
+| P0 | Distribution closeout for `v0.17.1` | `v0-17-1-distribution-closeout` | `v0.17.0` already published GitHub Release, crates.io, and the initial npm wrapper source. `v0.17.1` closed GitHub Release / crates.io / PyPI / Homebrew work, while npm publication is handed to `v0.17.2` after package README and metadata polish. |
 | P1 | Schema publication for `v0.18.0` | `v0-18-0-schema-publication` | `kml config schema` already exists, but distribution docs still defer schema publication. The next durable step is a versioned schema contract, fixture-backed schema compatibility checks, and docs that editor integrations can rely on. |
 | P1 | VS Code extension MVP for `v0.18.1` | `v0-18-1-vscode-extension-mvp` | The LSP entrypoint and schema command already exist. VS Code should become the first real editor target because the extension surface can stay thin: launch `kml lsp`, associate the config schema, and expose diagnostics / format / safe quick-fix without moving lint logic into the extension. |
 | P2 | Zed extension MVP for `v0.18.2` | `v0-18-2-zed-extension-mvp` | Zed is the second target. Keep it behind VS Code so the shared `kml lsp` contract is already stable, then validate only the Zed-specific extension boundary and installation flow. |
@@ -83,6 +84,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | Full locale i18n for `v0.16.1` | `archive/2026-04-29-v0-16-1-full-locale-i18n` | Matches KatanA supported locales and localizes both rule descriptions and rule Markdown documentation. |
 | Done | Document answer fix regressions for `v0.16.2` | `archive/2026-04-29-v0-16-2-document-answer-fix-regressions` | Freezes `v0.17.0` distribution work and verifies 250 document-level `check --fix` answer fixtures before the next distribution expansion. |
 | Done | Binary distribution expansion for `v0.17.0` | `archive/2026-04-30-v0-17-0-binary-distribution-expansion` | Adds release binary archives, Homebrew formula generation, wrapper smoke coverage, and explicit wrapper publish deferral. |
+| Done | npm package polish for `v0.17.2` | `archive/2026-04-30-v0-17-2-npm-package-polish` | Adds npm README / metadata / tarball verification and prepares trusted publishing retry before schema/editor work resumes. |
 
 Archived completed changes:
 
@@ -123,10 +125,11 @@ Archived completed changes:
 - `v0-16-1-full-locale-i18n` -> `openspec/changes/archive/2026-04-29-v0-16-1-full-locale-i18n`
 - `v0-16-2-document-answer-fix-regressions` -> `openspec/changes/archive/2026-04-29-v0-16-2-document-answer-fix-regressions`
 - `v0-17-0-binary-distribution-expansion` -> `openspec/changes/archive/2026-04-30-v0-17-0-binary-distribution-expansion`
+- `v0-17-2-npm-package-polish` -> `openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish`
 
 ## Suggested Order
 
-1. `v0-17-1-distribution-closeout`: close the published-channel gaps first because npm / PyPI are already public and Homebrew tap state is the remaining user-visible distribution gap.
+1. `v0-17-1-distribution-closeout`: keep the release ledger as the handoff record for the partial `v0.17.1` closeout.
 2. `v0-18-0-schema-publication`: make the existing config schema command a stable published contract before more editor polish depends on it.
 3. `v0-18-1-vscode-extension-mvp`: build the first thin editor wrapper on the stable schema and existing LSP entrypoint.
 4. `v0-18-2-zed-extension-mvp`: reuse the shared LSP contract and validate the Zed-specific extension boundary.

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/design.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/design.md
@@ -1,0 +1,99 @@
+# npm Package Polish Design
+
+## Context
+
+npm package `katana-markdown-linter@0.17.0` は公開済みだが、package page には README がなく、
+keywords も空である。`v0.17.1` の npm publish は trusted publisher 設定不足で止まり、
+その後 package 側の trusted publisher 設定は追加された。
+
+一方で、README なしのまま `0.17.1` を公開すると、同じ version の内容を後から自然に直しにくい。
+そのため `v0.17.2` を npm package polish patch とし、npm registry 上の見え方を整えてから
+trusted publishing で公開する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- npm package page に README を表示し、導入コマンドと wrapper の役割を明確にする
+- npm package metadata に search / support / repository に必要な情報を追加する
+- package tarball に README と必要最小限の wrapper files だけが入ることを検証する
+- trusted publishing で npm wrapper を公開し、公開後に `npm view` と `npx` を確認する
+- `v0.17.1` の npm 未完了状態を release ledger から `v0.17.2` に引き継ぐ
+
+**Non-Goals:**
+
+- npm wrapper に lint rule / formatter / LSP logic を追加すること
+- npm package に不要な runtime dependency を追加すること
+- crates.io / PyPI / Homebrew の再設計
+- `v0.18.0` schema publication や editor extension 計画を混ぜること
+
+## Decisions
+
+### D-1: npm README は root README の完全コピーにしない
+
+`wrappers/npm/README.md` は npm package page 専用の短い文書にする。
+root `README.md` は product 全体の説明を持つため、npm package にそのまま入れると
+Cargo / Homebrew / PyPI / GitHub Action まで混ざり、npm user が必要な情報を探しにくい。
+
+README には次を含める。
+
+- `npm install -g katana-markdown-linter`
+- `npx --yes katana-markdown-linter@<version> --version`
+- `kml check README.md` の最小例
+- thin wrapper が GitHub Release binary を取得し、checksum を検証すること
+- supported platforms と unsupported platform の扱い
+- issue / repository link
+
+### D-2: dependencies が 0 であることは維持する
+
+npm wrapper は Node.js 標準 module と `curl` / `tar` だけを使う。
+package page の dependencies が 0 であることは品質上の問題ではなく、
+thin wrapper としての attack surface を小さくする意図に合う。
+
+### D-3: package metadata は npm page の探索性を補う範囲に限定する
+
+`keywords`、`homepage`、`bugs` を追加し、repository URL は npm が正規化できる形式にする。
+metadata 追加は user-facing package page の改善に限定し、package name や bin name は変えない。
+
+### D-4: tarball 内容は release gate で固定する
+
+`npm pack --dry-run --json` の結果に、少なくとも次が含まれることを検証する。
+
+- `README.md`
+- `package.json`
+- `bin/kml.js`
+- `lib/installer.js`
+
+逆に、Cargo build artifact や repository root の重いファイルは含めない。
+
+### D-5: v0.17.2 は npm publish closeout の patch とする
+
+`v0.17.1` で GitHub Release / crates.io / PyPI / Homebrew が先に完了したため、
+`v0.17.2` は npm package page と npm publish の完了に絞る。
+`v0.18.0` 以降の schema / editor work は、npm channel の visible gap を閉じた後に再開する。
+
+## Risks / Trade-offs
+
+- root README と npm README の重複が増える
+  - npm README は短く保ち、詳細は root README / docs へ誘導する
+- npm trusted publishing は package 側設定に依存する
+  - release 前に trusted publisher entry を確認し、workflow filename を `release.yml` に固定する
+- README を package `files` に入れ忘れる
+  - `npm pack --dry-run --json` を release gate と AST lint の確認対象にする
+- `npx` が cache 済み binary を使って誤判定する
+  - smoke test では fresh install directory を使う
+
+## Migration Plan
+
+1. v0.17.1 の npm 未完了理由を v0.17.2 tasks に引き継ぐ
+2. `wrappers/npm/README.md` と npm package metadata を追加する
+3. npm tarball content check を local gate または AST lint に追加する
+4. wrapper smoke が fresh install directory で release version を返すことを確認する
+5. `v0.17.2` metadata / changelog / docs を更新する
+6. trusted publishing で npm wrapper を公開する
+7. `make release-verify VERSION=v0.17.2` または npm-focused verification で registry state を確認する
+
+## Closed Questions
+
+- npm README は今回は root README と完全同期しない。npm package page 専用の短い文書として維持する。
+- `v0.17.2` は `make release VERSION=v0.17.2` の通常手順で GitHub Release / crates.io / npm / PyPI を同一 version として公開し、npm wrapper だけの特殊 retry にはしない。

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/proposal.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/proposal.md
@@ -1,0 +1,50 @@
+# npm Package Polish
+
+## Target Version
+
+`v0.17.2`
+
+## Why
+
+`v0.17.1` では GitHub Release / crates.io / PyPI / Homebrew tap は整ったが、
+npm package page は README と keywords が空のままで、初見の user が導入方法や
+thin wrapper の性質を判断しにくい。
+
+`v0.17.2` では npm wrapper の公開をやり直す前に、npm registry 上で見える
+package metadata と README を整え、公開後検証まで含めて npm channel を閉じる。
+
+## What Changes
+
+- `wrappers/npm/README.md` を追加し、npm package page に install / npx / thin wrapper contract / supported platforms を表示する
+- npm `package.json` に `keywords`、`homepage`、`bugs`、`readme` 相当の metadata を追加する
+- npm package tarball に README が含まれることを `npm pack --dry-run --json` で検証する
+- npm wrapper publish を trusted publishing で再実行し、`npm view` と `npx` で `0.17.2` を確認する
+- v0.17.1 で残った npm blocker を v0.17.2 の release ledger に引き継ぐ
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `binary-distribution`: npm wrapper package が registry page で導入方法と thin wrapper 境界を説明できることを追加する
+- `release-cicd`: npm publish 前に package tarball の README / metadata を検証する条件を追加する
+- `release-readiness`: npm registry state と wrapper launch を v0.17.2 の完了条件として扱う
+
+## Impact
+
+- `wrappers/npm/package.json`
+- `wrappers/npm/README.md`
+- `wrappers/npm/**`
+- `.github/workflows/release.yml`
+- `Makefile`
+- `scripts/release/**`
+- `tests/ast_linter.rs`
+- `docs/release-runbook.md`
+- `docs/distribution.md`
+- `docs/quality-gates.md`
+- `CHANGELOG.md`
+- `openspec/changes/v0-17-1-distribution-closeout/tasks.md`
+- `openspec/changes/active-roadmap.md`

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/binary-distribution/spec.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/binary-distribution/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: npm wrapper package SHALL include registry-visible usage documentation
+
+npm wrapper package は、npm registry page 上で導入方法と thin wrapper の責務を説明できなければならない（SHALL）。
+
+#### Scenario: npm package is packed
+
+- **WHEN** system builds the npm package tarball for `vX.Y.Z`
+- **THEN** tarball contains `README.md`
+- **AND** README includes global install and `npx` examples for `katana-markdown-linter`
+- **AND** README states that the npm package is a thin launcher over GitHub Release binary archives
+- **AND** README lists supported platforms or points to the supported platform contract
+- **AND** README does not imply npm contains independent lint logic
+
+### Requirement: npm wrapper package SHALL keep dependency surface minimal
+
+npm wrapper package は、thin wrapper に不要な runtime dependency を追加してはならない（SHALL NOT）。
+
+#### Scenario: package metadata is inspected
+
+- **WHEN** developer reviews `wrappers/npm/package.json`
+- **THEN** package keeps runtime dependencies empty unless a specific dependency is justified by wrapper behavior
+- **AND** package metadata includes search and support fields such as `keywords`, `homepage`, and `bugs`
+- **AND** package keeps `bin.kml` pointing to the launcher script

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/release-cicd/spec.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/release-cicd/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: release gates SHALL validate npm package page artifacts before publish
+
+release gate は、npm publish 前に registry page に表示される package artifact を検証しなければならない（SHALL）。
+
+#### Scenario: npm wrapper publish is enabled
+
+- **WHEN** release workflow is dispatched with npm wrapper publication enabled
+- **THEN** system runs `npm pack --dry-run --json` for `wrappers/npm`
+- **AND** system verifies the packed file list contains `README.md`, `package.json`, `bin/kml.js`, and `lib/installer.js`
+- **AND** system verifies npm package metadata includes non-empty `description`, `keywords`, `repository`, `homepage`, `bugs`, `license`, and `bin`
+- **AND** system stops before publish if README or required metadata is missing
+
+### Requirement: npm wrapper retry SHALL use trusted publishing without token fallback
+
+npm wrapper retry は、trusted publishing で実行し、長期 token fallback に戻してはならない（SHALL NOT）。
+
+#### Scenario: npm publish is retried after trusted publisher setup
+
+- **WHEN** developer retries npm wrapper publication for `vX.Y.Z`
+- **THEN** workflow uses GitHub Actions OIDC trusted publishing
+- **AND** workflow does not require `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+- **AND** workflow records a clear failure when npm rejects the trusted publisher context

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/release-readiness/spec.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/specs/release-readiness/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: v0.17.2 release readiness SHALL close the npm package visibility gap
+
+`v0.17.2` の release readiness は、npm package page の README / metadata 不足を release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: v0.17.2 release is prepared
+
+- **WHEN** developer prepares `v0.17.2`
+- **THEN** system confirms `wrappers/npm/README.md` exists and is included in the npm tarball
+- **AND** system confirms npm package metadata has search and support fields
+- **AND** system confirms trusted publisher configuration is present for `HiroyukiFuruno/katana-markdown-linter` and `release.yml`
+- **AND** system keeps the npm package as a thin wrapper with no independent lint logic
+
+### Requirement: v0.17.2 post-release verification SHALL prove npm publication
+
+`v0.17.2` の公開後検証は、npm registry と npm wrapper 起動を確認しなければならない（SHALL）。
+
+#### Scenario: v0.17.2 npm publication is verified
+
+- **WHEN** npm wrapper publication for `v0.17.2` completes
+- **THEN** system verifies npm contains `katana-markdown-linter` version `0.17.2`
+- **AND** system runs `npx --yes katana-markdown-linter@0.17.2 --version`
+- **AND** command output is `0.17.2`
+- **AND** verification result is recorded before `v0.18.0` work resumes

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/tasks.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/tasks.md
@@ -1,0 +1,76 @@
+# Tasks
+
+## Release Execution Notes
+
+- 2026-04-30: user が npm UI で trusted publisher を `HiroyukiFuruno/katana-markdown-linter` / `release.yml` として登録済み。
+- 2026-04-30: `npm view katana-markdown-linter versions --json` は `0.17.0` のみを返し、`0.17.1` は npm 未公開。
+- 2026-04-30: `v0.17.1` は GitHub Release / crates.io / PyPI / Homebrew が完了し、npm は README / metadata polish 後の `v0.17.2` へ引き継ぐ。
+- 2026-04-30: `v0.17.2` は npm package page / npm publish closeout に限定し、schema / editor extension work は含めない。
+- 2026-04-30: `npm pack --dry-run --json` で tarball に `README.md`、`package.json`、`bin/kml.js`、`lib/installer.js` が含まれることを確認済み。
+
+## Definition of Ready
+
+- [x] 0.1 npm trusted publisher が `HiroyukiFuruno/katana-markdown-linter` / `release.yml` で登録済みであることを確認する
+- [x] 0.2 npm `katana-markdown-linter@0.17.1` が未公開であること、または `v0.17.2` に進める理由を記録する
+- [x] 0.3 `v0.17.1` の GitHub Release / crates.io / PyPI / Homebrew 完了状態と npm 未完了状態を release ledger から引き継ぐ
+- [x] 0.4 `v0.17.2` は npm package page / npm publish closeout に限定し、schema / editor extension work を混ぜないことを確認する
+
+## 1. npm Package README and Metadata
+
+- [x] 1.1 `wrappers/npm/README.md` を追加し、install / `npx` / `kml check` の最小例を書く
+- [x] 1.2 README に thin wrapper contract、GitHub Release binary archive 取得、checksum 検証、supported platforms を明記する
+- [x] 1.3 `wrappers/npm/package.json` に `keywords`、`homepage`、`bugs` を追加する
+- [x] 1.4 `dependencies` は不要な runtime dependency を追加せず、0 件を維持する理由を tasks または docs に記録する
+- [x] 1.5 `npm pack --dry-run --json` で `README.md` が tarball に含まれることを確認する
+
+## 2. Release Gate Updates
+
+- [x] 2.1 npm package tarball の file list を検証する script または AST lint を追加する
+- [x] 2.2 npm metadata の必須項目を検証する script または AST lint を追加する
+- [x] 2.3 release workflow の npm publish 前に tarball / metadata check が実行されることを確認する
+- [x] 2.4 wrapper smoke test で fresh install directory を使い、cache 済み binary による誤判定を避ける
+
+## 3. Version and Documentation
+
+- [x] 3.1 Cargo / npm / PyPI / MCP metadata を `0.17.2` に更新する
+- [x] 3.2 `CHANGELOG.md` に npm package page polish と npm publish closeout を追加する
+- [x] 3.3 `docs/distribution.md` と `docs/release-runbook.md` に npm README / metadata check を追加する
+- [x] 3.4 `openspec/changes/active-roadmap.md` で `v0.17.2` を `v0.18.0` より前の npm closeout patch として扱う
+- [x] 3.5 `v0-17-1-distribution-closeout/tasks.md` の npm 未完了状態を `v0.17.2` へ引き継いだことを記録する
+
+## 4. Verification
+
+- [x] 4.1 `make fmt-check`
+- [x] 4.2 `make lint`
+- [x] 4.3 `make ast-lint`
+- [x] 4.4 `cargo test --workspace --locked`
+- [x] 4.5 `make dogfood`
+- [x] 4.6 `npm pack --dry-run --json` in `wrappers/npm`
+- [x] 4.7 `make release-check VERSION=v0.17.2`
+- [x] 4.8 `make release-task-ledger-check VERSION=v0.17.2`
+
+## 5. Release Execution Tracking
+
+OpenSpec task ledger は実装と release 前 gate までを対象にする。PR 作成、merge、publish、
+post-release verification、branch hygiene は `impl-release` workflow の実行ログで追跡する。
+
+`impl-release` 側で実行する release 手順:
+
+- `release/v0.17.2` PR を作成し、CI と signed commit verification を確認する
+- PR merge 後、`make release VERSION=v0.17.2` を正規手順で実行する
+- npm publish job が trusted publishing で成功したことを確認する
+- `make release-verify VERSION=v0.17.2` を実行する
+- `npm view katana-markdown-linter@0.17.2 version` と `npx --yes katana-markdown-linter@0.17.2 --version` の結果を記録する
+- npm package page に README、keywords、homepage、bugs が反映され、runtime dependency が 0 件であることを確認する
+- `v0.18.0` 以降の schema / editor work に進める状態にする
+
+## 品質評価スコア
+
+| 項目 | 最大 | 現在 | 根拠 |
+| --- | ---: | ---: | --- |
+| npm README / metadata | 25 | 25 | `wrappers/npm/README.md` と package metadata を追加済み。 |
+| release gate | 25 | 25 | `make npm-package-check` と release workflow publish 前 check を追加済み。 |
+| release metadata | 20 | 20 | Cargo / npm / PyPI / MCP metadata と CHANGELOG を `0.17.2` に更新済み。 |
+| documentation | 15 | 15 | README、distribution、release runbook、quality gates を更新済み。 |
+| verification | 15 | 15 | `make release-check VERSION=v0.17.2` が成功。 |
+| 合計 | 100 | 100 | release PR ready。 |

--- a/openspec/changes/v0-17-1-distribution-closeout/tasks.md
+++ b/openspec/changes/v0-17-1-distribution-closeout/tasks.md
@@ -5,17 +5,19 @@
 - 2026-04-30: `release/v0.17.1` は PR #70 で `main` に merge 済み。
 - 2026-04-30: `make release VERSION=v0.17.1` は GitHub Release / crates.io / PyPI publish まで成功。
 - 2026-04-30: npm wrapper publish は Release run `25162643530` の npm job で `E404 Not Found` になり未完了。npm package 側の trusted publishing / publish 権限確認が blocker。
+- 2026-04-30: npm package 側の trusted publisher は user が npm UI で `HiroyukiFuruno/katana-markdown-linter` / `release.yml` として設定済み。
+- 2026-04-30: npm package page の README / keywords 不足を確認したため、npm publish closeout は `v0.17.2` の `v0-17-2-npm-package-polish` へ引き継ぐ。
 - 2026-04-30: PyPI wrapper は fresh `KML_WRAPPER_INSTALL_DIR` で `uvx --from katana-markdown-linter==0.17.1 kml --version` が `0.17.1` を返すことを確認済み。
 - 2026-04-30: Homebrew formula generator の DSL 修正は PR #71 で `main` に merge 済み。
 - 2026-04-30: `homebrew-katana` の `Formula/kml.rb` は PR #1 で `master` に merge 済み。
 
 ## Definition of Ready
 
-- [ ] 0.1 npm package `katana-markdown-linter` の trusted publishing 設定を確認する
+- [x] 0.1 npm package `katana-markdown-linter` の trusted publishing 設定を確認する
 - [x] 0.2 PyPI project `katana-markdown-linter` の trusted publisher と `pypi` environment を確認する
 - [x] 0.3 `homebrew-katana` tap の local checkout と branch protection を確認する
 - [x] 0.4 `v0.17.0` の npm / PyPI / GitHub Release / crates.io 公開状態を再確認する
-- [ ] 0.5 `NPM_TOKEN` を次回 release の通常手順から外せることを確認する
+- [x] 0.5 `NPM_TOKEN` を次回 release の通常手順から外せることを確認する
 
 ## 1. npm / PyPI Wrapper Officialization
 
@@ -47,7 +49,7 @@
 - [x] 4.2 `homebrew-katana` tap に `Formula/kml.rb` 差分を作る
 - [x] 4.3 tap 側で `brew audit` / `brew test` 相当の確認を行う
 - [x] 4.4 tap 更新の commit / push / PR 方針を branch protection に合わせて実行する
-- [ ] 4.5 tap 更新結果を release runbook に追記する
+- [x] 4.5 tap 更新結果を release runbook に追記する
 
 ## 5. Documentation and Release Metadata
 

--- a/openspec/specs/binary-distribution/spec.md
+++ b/openspec/specs/binary-distribution/spec.md
@@ -84,6 +84,30 @@ npm / pip の薄いラッパー（wrapper）は、`kml` の独自実装を持っ
 - **AND** wrapper は取得した `kml` binary を実行する
 - **AND** wrapper は lint rule や formatter logic を実装しない
 
+### Requirement: npm wrapper package SHALL include registry-visible usage documentation
+
+npm wrapper package は、npm registry page 上で導入方法と thin wrapper の責務を説明できなければならない（SHALL）。
+
+#### Scenario: npm package is packed
+
+- **WHEN** system builds the npm package tarball for `vX.Y.Z`
+- **THEN** tarball contains `README.md`
+- **AND** README includes global install and `npx` examples for `katana-markdown-linter`
+- **AND** README states that the npm package is a thin launcher over GitHub Release binary archives
+- **AND** README lists supported platforms or points to the supported platform contract
+- **AND** README does not imply npm contains independent lint logic
+
+### Requirement: npm wrapper package SHALL keep dependency surface minimal
+
+npm wrapper package は、thin wrapper に不要な runtime dependency を追加してはならない（SHALL NOT）。
+
+#### Scenario: package metadata is inspected
+
+- **WHEN** developer reviews `wrappers/npm/package.json`
+- **THEN** package keeps runtime dependencies empty unless a specific dependency is justified by wrapper behavior
+- **AND** package metadata includes search and support fields such as `keywords`, `homepage`, and `bugs`
+- **AND** package keeps `bin.kml` pointing to the launcher script
+
 ### Requirement: Wrapper publication SHALL be gated by ownership and smoke tests
 
 システムは、package ownership と smoke test が揃うまで npm / PyPI package を公式公開してはならない（SHALL NOT）。

--- a/openspec/specs/release-cicd/spec.md
+++ b/openspec/specs/release-cicd/spec.md
@@ -142,3 +142,26 @@ release workflow は、npm / PyPI wrapper を明示的な enablement なしに p
 - **AND** enable flag がない場合、system は wrapper publish を skip する
 - **AND** enable flag がある場合、system は長期 token ではなく trusted publishing で registry に publish する
 - **AND** skip した wrapper を release note で公式公開済みとして扱わない
+
+### Requirement: release gates SHALL validate npm package page artifacts before publish
+
+release gate は、npm publish 前に registry page に表示される package artifact を検証しなければならない（SHALL）。
+
+#### Scenario: npm wrapper publish is enabled
+
+- **WHEN** release workflow is dispatched with npm wrapper publication enabled
+- **THEN** system runs `npm pack --dry-run --json` for `wrappers/npm`
+- **AND** system verifies the packed file list contains `README.md`, `package.json`, `bin/kml.js`, and `lib/installer.js`
+- **AND** system verifies npm package metadata includes non-empty `description`, `keywords`, `repository`, `homepage`, `bugs`, `license`, and `bin`
+- **AND** system stops before publish if README or required metadata is missing
+
+### Requirement: npm wrapper retry SHALL use trusted publishing without token fallback
+
+npm wrapper retry は、trusted publishing で実行し、長期 token fallback に戻してはならない（SHALL NOT）。
+
+#### Scenario: npm publish is retried after trusted publisher setup
+
+- **WHEN** developer retries npm wrapper publication for `vX.Y.Z`
+- **THEN** workflow uses GitHub Actions OIDC trusted publishing
+- **AND** workflow does not require `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+- **AND** workflow records a clear failure when npm rejects the trusted publisher context

--- a/openspec/specs/release-readiness/spec.md
+++ b/openspec/specs/release-readiness/spec.md
@@ -244,6 +244,30 @@ KatanA feedback sweep で見つかった `check` の誤検知と `fix` の誤修
 - **THEN** system は `v0.13.0` の配布計画に影響するものと影響しないものを分ける
 - **THEN** system は follow-up を by-design 宣言と混同しない
 
+### Requirement: v0.17.2 release readiness SHALL close the npm package visibility gap
+
+`v0.17.2` の release readiness は、npm package page の README / metadata 不足を release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: v0.17.2 release is prepared
+
+- **WHEN** developer prepares `v0.17.2`
+- **THEN** system confirms `wrappers/npm/README.md` exists and is included in the npm tarball
+- **AND** system confirms npm package metadata has search and support fields
+- **AND** system confirms trusted publisher configuration is present for `HiroyukiFuruno/katana-markdown-linter` and `release.yml`
+- **AND** system keeps the npm package as a thin wrapper with no independent lint logic
+
+### Requirement: v0.17.2 post-release verification SHALL prove npm publication
+
+`v0.17.2` の公開後検証は、npm registry と npm wrapper 起動を確認しなければならない（SHALL）。
+
+#### Scenario: v0.17.2 npm publication is verified
+
+- **WHEN** npm wrapper publication for `v0.17.2` completes
+- **THEN** system verifies npm contains `katana-markdown-linter` version `0.17.2`
+- **AND** system runs `npx --yes katana-markdown-linter@0.17.2 --version`
+- **AND** command output is `0.17.2`
+- **AND** verification result is recorded before `v0.18.0` work resumes
+
 ### Requirement: Release readiness SHALL include document answer fix evaluation
 
 Release readiness SHALL include document-level answer fixture evaluation before publishing `v0.16.2`.

--- a/scripts/release/verify-npm-package.js
+++ b/scripts/release/verify-npm-package.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+class NpmPackageVerifier {
+  constructor(packageRoot) {
+    this.packageRoot = path.resolve(packageRoot);
+    this.packageJsonPath = path.join(this.packageRoot, "package.json");
+    this.packageJson = JSON.parse(fs.readFileSync(this.packageJsonPath, "utf8"));
+  }
+
+  run() {
+    this.verifyMetadata();
+    this.verifyNoRuntimeDependencies();
+    this.verifyTarballContents();
+    console.log(`npm package check passed for ${this.packageJson.name}@${this.packageJson.version}`);
+  }
+
+  verifyMetadata() {
+    this.requireString("name");
+    this.requireString("version");
+    this.requireString("description");
+    this.requireString("license");
+    this.requireString("homepage");
+    this.requireObject("repository");
+    this.requireObject("bugs");
+    this.requireObject("bin");
+
+    if (!Array.isArray(this.packageJson.keywords) || this.packageJson.keywords.length === 0) {
+      throw new Error("package.json: keywords must be a non-empty array");
+    }
+    for (const keyword of this.packageJson.keywords) {
+      if (typeof keyword !== "string" || keyword.trim() === "") {
+        throw new Error("package.json: keywords must contain only non-empty strings");
+      }
+    }
+    if (this.packageJson.repository.type !== "git" || !this.packageJson.repository.url) {
+      throw new Error("package.json: repository must include git type and url");
+    }
+    if (!this.packageJson.bugs.url) {
+      throw new Error("package.json: bugs.url is required");
+    }
+    if (this.packageJson.bin.kml !== "bin/kml.js") {
+      throw new Error("package.json: bin.kml must point to bin/kml.js");
+    }
+  }
+
+  verifyNoRuntimeDependencies() {
+    const dependencies = this.packageJson.dependencies || {};
+    const names = Object.keys(dependencies);
+    if (names.length > 0) {
+      throw new Error(`package.json: runtime dependencies must stay empty: ${names.join(", ")}`);
+    }
+  }
+
+  verifyTarballContents() {
+    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: this.packageRoot,
+      encoding: "utf8"
+    });
+    const packages = JSON.parse(output);
+    if (!Array.isArray(packages) || packages.length !== 1) {
+      throw new Error("npm pack --dry-run --json must return exactly one package");
+    }
+
+    const files = new Set(packages[0].files.map((file) => file.path));
+    for (const required of ["README.md", "package.json", "bin/kml.js", "lib/installer.js"]) {
+      if (!files.has(required)) {
+        throw new Error(`npm tarball is missing ${required}`);
+      }
+    }
+  }
+
+  requireString(field) {
+    if (typeof this.packageJson[field] !== "string" || this.packageJson[field].trim() === "") {
+      throw new Error(`package.json: ${field} must be a non-empty string`);
+    }
+  }
+
+  requireObject(field) {
+    const value = this.packageJson[field];
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`package.json: ${field} must be an object`);
+    }
+  }
+}
+
+const packageRoot = process.argv[2] || "wrappers/npm";
+new NpmPackageVerifier(packageRoot).run();

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.1",
+  "version": "0.17.2",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.1/katana-markdown-linter-0.17.1.mcpb",
-      "version": "0.17.1",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/katana-markdown-linter-0.17.2.mcpb",
+      "version": "0.17.2",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -285,10 +285,12 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let answer_runner = read_workspace_file("scripts/ci/document_answer_fix_runner.py");
     let answer_validator = read_workspace_file("scripts/ci/document_answer_validator.py");
     let required = [
-        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke wrapper-publish-gate document-answer-fix"),
+        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check wrapper-publish-gate document-answer-fix"),
         ("Makefile", &makefile, "binary-smoke: binary-package"),
         ("Makefile", &makefile, "homebrew-formula-check: homebrew-formula"),
         ("Makefile", &makefile, "wrapper-smoke: binary-package"),
+        ("Makefile", &makefile, "npm-package-check:"),
+        ("Makefile", &makefile, "scripts/release/verify-npm-package.js"),
         ("Makefile", &makefile, "document-answer-fix:"),
         ("Makefile", &makefile, "mcp-release-build:"),
         ("Makefile", &makefile, "mcp-remote-build:"),
@@ -325,6 +327,11 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (
             ".github/workflows/release.yml",
             &workflow,
+            "run: make npm-package-check",
+        ),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
             "npm publish --access public --provenance",
         ),
         (".github/workflows/release.yml", &workflow, "Publish PyPI wrapper"),
@@ -345,6 +352,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (".github/workflows/release-preflight.yml", &preflight, "run: make binary-smoke"),
         (".github/workflows/release-preflight.yml", &preflight, "run: make homebrew-formula-check"),
         (".github/workflows/release-preflight.yml", &preflight, "run: make wrapper-smoke"),
+        (".github/workflows/release-preflight.yml", &preflight, "run: make npm-package-check"),
         ("scripts/ci/document_answer_fix_runner.py", &answer_runner, "AnswerValidationRunner"),
         (
             "scripts/ci/document_answer_validator.py",

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -1,0 +1,56 @@
+# katana-markdown-linter
+
+`katana-markdown-linter` is a thin npm launcher for the `kml` Markdown linter.
+The package does not contain independent lint logic. On first use, it downloads
+the matching `kml` binary archive from GitHub Releases, verifies the neighboring
+SHA-256 checksum, installs the binary into the wrapper cache, and then delegates
+all commands to that binary.
+
+## Install
+
+~~~bash
+npm install -g katana-markdown-linter
+kml --version
+~~~
+
+Use `npx` for one-off runs:
+
+~~~bash
+npx --yes katana-markdown-linter@0.17.2 --version
+npx --yes katana-markdown-linter@0.17.2 check README.md
+~~~
+
+## Basic Usage
+
+~~~bash
+kml check README.md
+kml check docs --config .markdownlint.json
+kml fix README.md
+~~~
+
+## Supported Platforms
+
+The npm launcher uses the same binary archives as the GitHub Release channel.
+It currently supports:
+
+- macOS arm64: `aarch64-apple-darwin`
+- macOS x64: `x86_64-apple-darwin`
+- Linux x64: `x86_64-unknown-linux-gnu`
+- Windows x64: `x86_64-pc-windows-msvc`
+
+Unsupported platforms fail before download with an explicit platform error.
+
+## Wrapper Contract
+
+- The package version selects the GitHub Release tag.
+- The launcher downloads `kml-vX.Y.Z-<target>.tar.gz` or
+  `kml-vX.Y.Z-<target>.zip`.
+- The launcher downloads the matching `.sha256` file and verifies the archive
+  before extraction.
+- The installed binary is cached under the package-local `vendor` directory by
+  default.
+
+For full CLI usage, rule coverage, and other install channels, see the
+[repository README](https://github.com/HiroyukiFuruno/katana-markdown-linter).
+Report package issues through
+[GitHub Issues](https://github.com/HiroyukiFuruno/katana-markdown-linter/issues).

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,7 +1,18 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Thin npm launcher for the kml Markdown linter binary.",
+  "keywords": [
+    "markdown",
+    "markdownlint",
+    "linter",
+    "kml",
+    "cli"
+  ],
+  "homepage": "https://github.com/HiroyukiFuruno/katana-markdown-linter#readme",
+  "bugs": {
+    "url": "https://github.com/HiroyukiFuruno/katana-markdown-linter/issues"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,6 +25,7 @@
     "postinstall": "node lib/installer.js"
   },
   "files": [
+    "README.md",
     "bin",
     "lib"
   ],

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.1"
+version = "0.17.2"
 description = "Thin Python launcher for the kml Markdown linter binary."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.1"
+            package_version = "0.17.2"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Prepare v0.17.2 release
- Add npm package README and registry metadata
- Add npm package tarball / metadata gate before publish
- Archive completed OpenSpec change

## Verification
- make fmt-check
- make lint
- make ast-lint
- cargo test --workspace --locked
- make dogfood
- npm pack --dry-run --json (wrappers/npm)
- make npm-package-check
- make release-check VERSION=v0.17.2
- make release-task-ledger-check VERSION=v0.17.2
- git diff --check
- scripts/openspec validate binary-distribution --strict
- scripts/openspec validate release-cicd --strict
- scripts/openspec validate release-readiness --strict