### PR TITLE
Prepare v0.17.3 release

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -79,6 +79,9 @@ jobs:
       - name: npm package check
         run: make npm-package-check
 
+      - name: PyPI package check
+        run: make pypi-package-check
+
       - name: Wrapper publish gate
         run: make wrapper-publish-gate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    tags:
-      - "v*"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -223,6 +220,9 @@ jobs:
       - name: npm package check
         run: make npm-package-check
 
+      - name: PyPI package check
+        run: make pypi-package-check
+
       - name: Dogfood
         run: make dogfood
 
@@ -326,7 +326,6 @@ jobs:
 
       - name: Publish crate
         if: >
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
           github.event_name == 'pull_request' ||
           (github.event_name == 'workflow_dispatch' && inputs.publish_crate == true)
         env:
@@ -342,7 +341,17 @@ jobs:
   publish-npm-wrapper:
     name: Publish npm wrapper
     needs: release
-    if: github.event_name == 'workflow_dispatch' && inputs.publish_npm_wrapper
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'release/v')
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish_npm_wrapper == true
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -351,6 +360,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -376,7 +387,17 @@ jobs:
   publish-pypi-wrapper:
     name: Publish PyPI wrapper
     needs: release
-    if: github.event_name == 'workflow_dispatch' && inputs.publish_pypi_wrapper
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'release/v')
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        inputs.publish_pypi_wrapper == true
+      )
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -386,6 +407,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -396,6 +419,9 @@ jobs:
         run: |
           python3 -m pip install --upgrade build
           python3 -m build wrappers/python
+
+      - name: Verify PyPI package
+        run: make pypi-package-check
 
       - name: Publish PyPI wrapper
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.17.3
+
+- Adds a full PyPI wrapper README and project metadata so the PyPI project page
+  shows install, `uvx`, supported platform, and wrapper contract details.
+- Adds `make pypi-package-check` to verify the PyPI README, metadata, source
+  distribution, wheel, and wheel long description before publication.
+- Fixes the Release workflow so merging a `release/vX.Y.Z` pull request
+  publishes GitHub Release, crates.io, npm, and PyPI from the same run.
+- Removes tag-push release execution to prevent partial publication before npm
+  and PyPI wrapper jobs run.
+- Carries the npm README and metadata closeout into a fresh patch version after
+  `v0.17.2` was already published to GitHub Releases and crates.io.
+
 ## v0.17.2
 
 - Adds an npm package README so the registry page shows install, `npx`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.2"
+version = "0.17.3"
 
 edition = "2021"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,10 @@ wrapper-smoke: binary-package ## Exercise npm and Python wrapper launchers again
 npm-package-check: ## Verify npm wrapper package README, metadata, and tarball contents
 	node scripts/release/verify-npm-package.js wrappers/npm
 
+.PHONY: pypi-package-check
+pypi-package-check: ## Verify PyPI wrapper README, metadata, and distributions
+	python3 scripts/release/verify-pypi-package.py wrappers/python
+
 .PHONY: wrapper-publish-gate
 wrapper-publish-gate: ## Verify wrapper publish flags stay deferred outside trusted publishing
 	scripts/release/wrapper-publish-gate.sh
@@ -290,7 +294,7 @@ release-test: ## Run release-equivalent tests with all optional features
 	cargo test --all-features --locked
 
 .PHONY: release-check
-release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check wrapper-publish-gate document-answer-fix ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
+release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check pypi-package-check wrapper-publish-gate document-answer-fix ## Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
 	$(MAKE) public-confidence
 	scripts/release/verify-version.sh "$(VERSION)"
 	cargo publish --dry-run --locked --allow-dirty

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.2 check README.md
+npx --yes katana-markdown-linter@0.17.3 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.2 kml check README.md
+uvx --from katana-markdown-linter==0.17.3 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,10 +137,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/kml-v0.17.2-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/kml-v0.17.2-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.2-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.2-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/kml-v0.17.3-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/kml-v0.17.3-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.17.3-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.17.3-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -158,8 +158,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.2
-  with: { version: "0.17.2", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.3
+  with: { version: "0.17.3", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -416,7 +416,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.2
+make mcpb-smoke VERSION=v0.17.3
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -6,8 +6,8 @@
 | --- | --- | --- | --- |
 | Cargo crate | Official | `make release-check`, install smoke test, crates.io publish verification | Primary library and CLI package |
 | Standalone binary artifacts | Official from `v0.17.1` | `make binary-smoke`, release asset checksum, `make release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
-| npm wrapper | Official from `v0.17.2` | npm registry version, `npx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
-| PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, `make release-verify` | Thin launcher over GitHub Release binary archives |
+| npm wrapper | Official from `v0.17.3` | npm registry version, `npx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
+| PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
 | Homebrew formula | Official from `v0.17.1` | `make homebrew-formula-check`, release archive checksum, formula test block, tap review | Tap update is reviewed separately in `homebrew-katana` after release assets exist |
 | GitHub Action | Official from `v0.11.0` | `make action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
 | MCPB bundle | Official from `v0.14.0` | `make mcpb-smoke`, `make server-json-validate`, release asset checksum | Local stdio MCP package for `kml-mcp` |
@@ -19,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.2
-  with: { version: "0.17.2", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.3
+  with: { version: "0.17.3", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -37,15 +37,15 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.2-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.17.3-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
 and must keep tap mutation separate from this repository's release workflow.
 
 The npm and PyPI packages do not contain independent lint logic. They download
 the matching GitHub Release archive for the package version, verify the archive
-checksum, and launch the bundled `kml` binary. The npm package also ships a
-registry README and metadata that are verified by `make npm-package-check`
-before publication.
+checksum, and launch the bundled `kml` binary. Both wrapper packages ship
+registry README and metadata that are verified by `make npm-package-check` and
+`make pypi-package-check` before publication.
 
 `kml-mcp-remote` is not a hosted service and is not described by the MCPB
 Registry metadata. Operators deploy it themselves, keep bearer authentication

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.2
+    make mcpb-smoke VERSION=v0.17.3
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.2.mcpb
-    katana-markdown-linter-0.17.2.mcpb.sha256
+    katana-markdown-linter-0.17.3.mcpb
+    katana-markdown-linter-0.17.3.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.2` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.17.3` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.2
+    make server-json-validate VERSION=v0.17.3
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -95,8 +95,11 @@ the same archive checksums and confirms generated URLs and checksums match the
 formula content. `make wrapper-smoke` verifies the npm and Python launchers
 through the local archive. `make npm-package-check` verifies the npm registry
 README, support metadata, dependency surface, and packed file list before
-publication. Wrapper publication uses registry trusted publishing from dedicated
-release workflow jobs instead of long-lived registry tokens.
+publication. `make pypi-package-check` verifies the PyPI wrapper README,
+support metadata, dependency surface, source distribution, wheel, and wheel
+metadata before publication. Wrapper publication uses registry trusted
+publishing from dedicated release workflow jobs instead of long-lived registry
+tokens.
 
 The release workflows run the same smoke targets so the action scripts, binary
 archives, Homebrew formula, wrapper launchers, MCPB manifest, and MCP Registry

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -33,6 +33,7 @@ For binary distribution changes, the release check includes:
 - `make homebrew-formula-check VERSION=vX.Y.Z`
 - `make wrapper-smoke VERSION=vX.Y.Z`
 - `make npm-package-check`
+- `make pypi-package-check`
 - `make wrapper-publish-gate`
 
 If validating upstream drift locally, clone upstream docs and run:
@@ -55,14 +56,19 @@ Required sequence:
 
 - Confirm `Cargo.toml` `package.version` is the intended version.
 - Confirm `CHANGELOG.md` has a `## vX.Y.Z` section.
-- Create and push a GitHub-verified signed annotated tag with `make release-tag VERSION=vX.Y.Z`.
-- Dispatch the intended release command.
+- Merge a release PR from `release/vX.Y.Z`, or dispatch the intended local release command.
 - Verify GitHub Release, crates.io, npm, PyPI, wrapper launch, and Homebrew formula state after publication with `make release-verify VERSION=vX.Y.Z`.
 
 Release command responsibilities:
 
 - `make release-github VERSION=vX.Y.Z` creates or updates the GitHub Release only.
 - `make release VERSION=vX.Y.Z` creates or updates the GitHub Release and publishes to crates.io, npm, and PyPI.
+
+Release PR merge responsibilities:
+
+- A merged `release/vX.Y.Z` pull request creates the signed release tag.
+- The same workflow run creates or updates the GitHub Release.
+- The same workflow run publishes crates.io, npm, and PyPI so wrapper packages do not lag behind the crate.
 
 The workflow validates:
 
@@ -78,6 +84,7 @@ The workflow validates:
 - `make server-json-validate`
 - `make action-smoke`
 - `make npm-package-check`
+- `make pypi-package-check`
 - standalone `kml` archive build and archive smoke for each supported target
 - Homebrew formula rendering from release archive checksums
 - upstream markdownlint drift gate
@@ -113,7 +120,9 @@ because the older `macos-13` image is no longer supported.
 The root `action.yml` is the official GitHub Action channel from `v0.11.0`.
 Release preflight must keep `make action-smoke` passing before publishing a tag.
 
-Tag push flow is also supported. Pushing `vX.Y.Z` runs the same gates and creates or updates the GitHub Release, but it does not publish to crates.io, npm, or PyPI. Use `make release VERSION=vX.Y.Z` when registry publication is intended.
+Tag push does not drive release publication. Use a `release/vX.Y.Z` pull
+request for automatic release, or use `make release-github VERSION=vX.Y.Z` /
+`make release VERSION=vX.Y.Z` for manual dispatch.
 
 Manual GitHub Actions dispatch is still available, but the local `make`
 targets are preferred because they create or verify the signed tag and check the
@@ -179,9 +188,10 @@ Keep these conditions true before publishing a wrapper version:
 - The GitHub repository has a `pypi` environment for PyPI publication.
 - npm trusted publishing is configured for `release.yml`.
 - PyPI trusted publishing is configured for `release.yml` with the `pypi` environment.
-- The release workflow is dispatched with wrapper publish flags enabled.
+- The release workflow is either triggered by a merged `release/vX.Y.Z` pull request or dispatched with wrapper publish flags enabled.
 - `make wrapper-smoke VERSION=vX.Y.Z` succeeds against the release archive shape.
 - `make npm-package-check` confirms the npm README, metadata, and tarball file list.
+- `make pypi-package-check` confirms the PyPI README, metadata, source distribution, wheel, and wheel metadata.
 
 Use these trusted publisher settings:
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -35,6 +35,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.17.0`: released distribution expansion with standalone binary artifacts, Homebrew formula generation, and deferred npm/pip wrapper publication gates.
 - `v0.17.1`: post-release distribution closeout として npm / PyPI wrapper を公式 install channel に昇格し、Homebrew tap 更新、npm trusted publishing 後始末、`release-verify` の wrapper / tap 検証拡張を扱う。
 - `v0.17.2`: npm package page polish と npm publish closeout を行う。`wrappers/npm/README.md`、keywords / homepage / bugs metadata、npm tarball verification、trusted publishing retry を `v0.18.0` より前に閉じる。
+- `v0.17.3`: `v0.17.2` が GitHub Release / crates.io だけ先行公開されたため、PyPI page polish と release workflow の partial publish 防止を加え、npm / PyPI publish closeout を整合版で完了する。
 - `v0.18.0`: config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
 - `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
@@ -42,7 +43,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 
 | Priority | Work Area | Change | Why Now |
 | --- | --- | --- | --- |
-| P0 | Distribution closeout for `v0.17.1` | `v0-17-1-distribution-closeout` | `v0.17.0` already published GitHub Release, crates.io, and the initial npm wrapper source. `v0.17.1` closed GitHub Release / crates.io / PyPI / Homebrew work, while npm publication is handed to `v0.17.2` after package README and metadata polish. |
+| P0 | Distribution closeout for `v0.17.1` | `v0-17-1-distribution-closeout` | `v0.17.0` already published GitHub Release, crates.io, and the initial npm wrapper source. `v0.17.1` closed GitHub Release / crates.io / PyPI / Homebrew work, while npm publication is handed to `v0.17.3` after package README, PyPI README, metadata polish, and workflow hardening. |
 | P1 | Schema publication for `v0.18.0` | `v0-18-0-schema-publication` | `kml config schema` already exists, but distribution docs still defer schema publication. The next durable step is a versioned schema contract, fixture-backed schema compatibility checks, and docs that editor integrations can rely on. |
 | P1 | VS Code extension MVP for `v0.18.1` | `v0-18-1-vscode-extension-mvp` | The LSP entrypoint and schema command already exist. VS Code should become the first real editor target because the extension surface can stay thin: launch `kml lsp`, associate the config schema, and expose diagnostics / format / safe quick-fix without moving lint logic into the extension. |
 | P2 | Zed extension MVP for `v0.18.2` | `v0-18-2-zed-extension-mvp` | Zed is the second target. Keep it behind VS Code so the shared `kml lsp` contract is already stable, then validate only the Zed-specific extension boundary and installation flow. |
@@ -85,6 +86,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | Document answer fix regressions for `v0.16.2` | `archive/2026-04-29-v0-16-2-document-answer-fix-regressions` | Freezes `v0.17.0` distribution work and verifies 250 document-level `check --fix` answer fixtures before the next distribution expansion. |
 | Done | Binary distribution expansion for `v0.17.0` | `archive/2026-04-30-v0-17-0-binary-distribution-expansion` | Adds release binary archives, Homebrew formula generation, wrapper smoke coverage, and explicit wrapper publish deferral. |
 | Done | npm package polish for `v0.17.2` | `archive/2026-04-30-v0-17-2-npm-package-polish` | Adds npm README / metadata / tarball verification and prepares trusted publishing retry before schema/editor work resumes. |
+| Done | Release flow recovery for `v0.17.3` | `archive/2026-04-30-v0-17-3-release-flow-recovery` | Adds PyPI page README / metadata verification and prevents tag-push partial release before npm / PyPI wrapper jobs run. |
 
 Archived completed changes:
 

--- a/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/tasks.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-2-npm-package-polish/tasks.md
@@ -7,6 +7,8 @@
 - 2026-04-30: `v0.17.1` は GitHub Release / crates.io / PyPI / Homebrew が完了し、npm は README / metadata polish 後の `v0.17.2` へ引き継ぐ。
 - 2026-04-30: `v0.17.2` は npm package page / npm publish closeout に限定し、schema / editor extension work は含めない。
 - 2026-04-30: `npm pack --dry-run --json` で tarball に `README.md`、`package.json`、`bin/kml.js`、`lib/installer.js` が含まれることを確認済み。
+- 2026-04-30: user feedback により PyPI project description も release blocker に昇格。`wrappers/python/README.md` と `make pypi-package-check` を追加する。
+- 2026-04-30: PR merge trigger の Release workflow が crates.io だけ先行公開し得る分岐を確認。`release/vX.Y.Z` merge では crates.io / npm / PyPI を同一 run で公開し、tag push trigger は release publication から外す。
 
 ## Definition of Ready
 
@@ -29,6 +31,9 @@
 - [x] 2.2 npm metadata の必須項目を検証する script または AST lint を追加する
 - [x] 2.3 release workflow の npm publish 前に tarball / metadata check が実行されることを確認する
 - [x] 2.4 wrapper smoke test で fresh install directory を使い、cache 済み binary による誤判定を避ける
+- [x] 2.5 PyPI package の README / metadata / sdist / wheel metadata check を release gate に追加する
+- [x] 2.6 `release/vX.Y.Z` PR merge で crates.io / npm / PyPI が同じ Release run から publish されるよう workflow を修正する
+- [x] 2.7 tag push trigger を release publication path から外し、manual dispatch との二重実行を避ける
 
 ## 3. Version and Documentation
 
@@ -37,6 +42,7 @@
 - [x] 3.3 `docs/distribution.md` と `docs/release-runbook.md` に npm README / metadata check を追加する
 - [x] 3.4 `openspec/changes/active-roadmap.md` で `v0.17.2` を `v0.18.0` より前の npm closeout patch として扱う
 - [x] 3.5 `v0-17-1-distribution-closeout/tasks.md` の npm 未完了状態を `v0.17.2` へ引き継いだことを記録する
+- [x] 3.6 `docs/distribution.md`、`docs/release-runbook.md`、`docs/quality-gates.md` に PyPI package page check と release PR 自動公開 flow を追加する
 
 ## 4. Verification
 
@@ -59,6 +65,7 @@ post-release verification、branch hygiene は `impl-release` workflow の実行
 - `release/v0.17.2` PR を作成し、CI と signed commit verification を確認する
 - PR merge 後、`make release VERSION=v0.17.2` を正規手順で実行する
 - npm publish job が trusted publishing で成功したことを確認する
+- PyPI project page に README、keywords、project URLs、runtime dependency 0 件が反映されることを確認する
 - `make release-verify VERSION=v0.17.2` を実行する
 - `npm view katana-markdown-linter@0.17.2 version` と `npx --yes katana-markdown-linter@0.17.2 --version` の結果を記録する
 - npm package page に README、keywords、homepage、bugs が反映され、runtime dependency が 0 件であることを確認する

--- a/openspec/changes/archive/2026-04-30-v0-17-3-release-flow-recovery/tasks.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-3-release-flow-recovery/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+## Release Execution Notes
+
+- 2026-04-30: `v0.17.2` は tag push trigger の Release run `25166227395` により GitHub Release / crates.io だけ先行公開された。
+- 2026-04-30: npm `katana-markdown-linter@0.17.2` と PyPI `katana-markdown-linter==0.17.2` は未公開であることを確認した。
+- 2026-04-30: 公開済み crates.io version は差し替えできないため、整合版は `v0.17.3` とする。
+- 2026-04-30: `v0.17.3` は npm README / metadata closeout に加えて、PyPI project page polish と release workflow の partial publish 防止を含める。
+
+## 1. PyPI Package Page
+
+- [x] 1.1 `wrappers/python/README.md` に install / `uvx` / `kml check` の例を書く
+- [x] 1.2 README に thin wrapper contract、GitHub Release binary archive 取得、checksum 検証、supported platforms を明記する
+- [x] 1.3 `wrappers/python/pyproject.toml` に `keywords`、classifiers、project URLs を追加する
+- [x] 1.4 runtime dependency は 0 件を維持する
+
+## 2. Release Gate Updates
+
+- [x] 2.1 `make pypi-package-check` を追加し、README / metadata / sdist / wheel / wheel metadata を検証する
+- [x] 2.2 release-preflight と release workflow に `make pypi-package-check` を追加する
+- [x] 2.3 `release/vX.Y.Z` PR merge で crates.io / npm / PyPI が同じ Release run から publish されるよう workflow を修正する
+- [x] 2.4 tag push trigger を release publication path から外し、manual dispatch との二重実行を避ける
+
+## 3. Version and Documentation
+
+- [x] 3.1 Cargo / npm / PyPI / MCP metadata を `0.17.3` に更新する
+- [x] 3.2 `CHANGELOG.md` に PyPI page polish と release flow recovery を追加する
+- [x] 3.3 `docs/distribution.md`、`docs/release-runbook.md`、`docs/quality-gates.md` に PyPI package check と release PR 自動公開 flow を追加する
+- [x] 3.4 `openspec/changes/active-roadmap.md` で `v0.17.3` を `v0.18.0` より前の整合版 release として扱う
+
+## 4. Verification
+
+- [x] 4.1 `make pypi-package-check`
+- [x] 4.2 `make npm-package-check`
+- [x] 4.3 `make ast-lint`
+- [x] 4.4 `make dogfood`
+- [x] 4.5 `scripts/openspec validate release-cicd --strict`
+- [x] 4.6 `scripts/openspec validate release-readiness --strict`
+- [x] 4.7 `scripts/openspec validate binary-distribution --strict`
+- [x] 4.8 `make release-check VERSION=v0.17.3`
+- [x] 4.9 `make release-task-ledger-check VERSION=v0.17.3`
+
+## 5. Release Execution Tracking
+
+OpenSpec task ledger は実装と release 前 gate までを対象にする。PR 作成、merge、publish、
+post-release verification、branch hygiene は `impl-release` workflow の実行ログで追跡する。
+
+`impl-release` 側で実行する release 手順:
+
+- `release/v0.17.3` PR を作成し、CI と signed commit verification を確認する
+- PR merge 後の Release workflow が GitHub Release / crates.io / npm / PyPI を同一 run で publish することを確認する
+- `make release-verify VERSION=v0.17.3` を実行する
+- `npm view katana-markdown-linter@0.17.3 version` と `npx --yes katana-markdown-linter@0.17.3 --version` の結果を記録する
+- PyPI project page に README、keywords、project URLs、runtime dependency 0 件が反映されることを確認する
+- `v0.18.0` 以降の schema / editor work に進める状態にする
+
+## 品質評価スコア
+
+| 項目 | 最大 | 現在 | 根拠 |
+| --- | ---: | ---: | --- |
+| PyPI README / metadata | 25 | 25 | `wrappers/python/README.md` と package metadata を追加済み。 |
+| release flow | 25 | 25 | tag push trigger を外し、release PR merge で crates.io / npm / PyPI を同一 run に統一済み。 |
+| release metadata | 20 | 20 | Cargo / npm / PyPI / MCP metadata と CHANGELOG を `0.17.3` に更新済み。 |
+| documentation | 15 | 15 | README、distribution、release runbook、quality gates、OpenSpec specs を更新済み。 |
+| verification | 15 | 15 | `make release-check VERSION=v0.17.3` が成功。 |
+| 合計 | 100 | 100 | release PR ready。 |

--- a/openspec/specs/binary-distribution/spec.md
+++ b/openspec/specs/binary-distribution/spec.md
@@ -108,6 +108,30 @@ npm wrapper package は、thin wrapper に不要な runtime dependency を追加
 - **AND** package metadata includes search and support fields such as `keywords`, `homepage`, and `bugs`
 - **AND** package keeps `bin.kml` pointing to the launcher script
 
+### Requirement: PyPI wrapper package SHALL include registry-visible usage documentation
+
+PyPI wrapper package は、PyPI project page 上で導入方法と thin wrapper の責務を説明できなければならない（SHALL）。
+
+#### Scenario: PyPI package is built
+
+- **WHEN** system builds the PyPI source distribution and wheel for `vX.Y.Z`
+- **THEN** project metadata points `readme` at `README.md`
+- **AND** README includes install and `uvx` examples for `katana-markdown-linter`
+- **AND** README states that the PyPI package is a thin launcher over GitHub Release binary archives
+- **AND** README lists supported platforms or points to the supported platform contract
+- **AND** README does not imply Python contains independent lint logic
+
+### Requirement: PyPI wrapper package SHALL keep dependency surface minimal
+
+PyPI wrapper package は、thin wrapper に不要な runtime dependency を追加してはならない（SHALL NOT）。
+
+#### Scenario: project metadata is inspected
+
+- **WHEN** developer reviews `wrappers/python/pyproject.toml`
+- **THEN** package keeps runtime dependencies empty unless a specific dependency is justified by wrapper behavior
+- **AND** package metadata includes search and support fields such as `keywords` and project URLs
+- **AND** package keeps the `kml` console script pointing to the launcher module
+
 ### Requirement: Wrapper publication SHALL be gated by ownership and smoke tests
 
 システムは、package ownership と smoke test が揃うまで npm / PyPI package を公式公開してはならない（SHALL NOT）。

--- a/openspec/specs/release-cicd/spec.md
+++ b/openspec/specs/release-cicd/spec.md
@@ -35,13 +35,13 @@
 - **THEN** system は GitHub Release を作成または更新する
 - **THEN** system は `.crate` package と checksum を添付する
 
-### Requirement: release workflow SHALL publish to crates.io only when explicitly enabled
+### Requirement: release workflow SHALL publish to crates.io only when a release path enables publication
 
-システムは、crates.io publish を明示的に有効化した場合にのみ実行しなければならない（SHALL）。
+システムは、crates.io publish を release PR merge または明示的な manual dispatch が有効化した場合にのみ実行しなければならない（SHALL）。
 
 #### Scenario: crate を publish する
 
-- **WHEN** release workflow が publish enabled で実行される
+- **WHEN** release workflow が `release/vX.Y.Z` の merge、または publish enabled の manual dispatch で実行される
 - **THEN** system は `CARGO_REGISTRY_TOKEN` が存在することを確認する
 - **THEN** system は `cargo publish` を実行する
 - **THEN** system は token がない場合に明示的なエラーで停止する
@@ -131,16 +131,28 @@ release verification は、tag、GitHub Release、crates.io に加えて binary 
 - **AND** system は各 archive の checksum file が存在することを確認する
 - **AND** system は少なくとも current platform の archive を取得して `kml --version` を検証する
 
-### Requirement: release workflow SHALL not publish wrappers without explicit enablement
+### Requirement: release workflow SHALL publish official registries together from release PR merge
 
-release workflow は、npm / PyPI wrapper を明示的な enablement なしに publish してはならない（SHALL NOT）。
+release workflow は、`release/vX.Y.Z` pull request が merge されたとき、GitHub Release、crates.io、npm、PyPI を同じ release run で公開しなければならない（SHALL）。
+
+#### Scenario: release PR is merged
+
+- **WHEN** `release/vX.Y.Z` pull request is merged into `main`
+- **THEN** system creates or verifies the signed `vX.Y.Z` tag
+- **AND** system creates or updates the GitHub Release
+- **AND** system publishes crates.io, npm, and PyPI after release gates pass
+- **AND** system does not require a second manual workflow run for wrappers
+
+### Requirement: release workflow SHALL not publish wrappers without release-path enablement
+
+release workflow は、npm / PyPI wrapper を release PR merge または明示的な enablement なしに publish してはならない（SHALL NOT）。
 
 #### Scenario: wrapper trusted publishing is absent
 
 - **WHEN** release workflow が wrapper publish step に到達する
-- **THEN** system は publish enable flag と trusted publishing job を確認する
-- **AND** enable flag がない場合、system は wrapper publish を skip する
-- **AND** enable flag がある場合、system は長期 token ではなく trusted publishing で registry に publish する
+- **THEN** system は release PR merge または publish enable flag と trusted publishing job を確認する
+- **AND** release PR merge でも enable flag 付き manual dispatch でもない場合、system は wrapper publish を skip する
+- **AND** wrapper publication が有効な場合、system は長期 token ではなく trusted publishing で registry に publish する
 - **AND** skip した wrapper を release note で公式公開済みとして扱わない
 
 ### Requirement: release gates SHALL validate npm package page artifacts before publish
@@ -153,6 +165,19 @@ release gate は、npm publish 前に registry page に表示される package a
 - **THEN** system runs `npm pack --dry-run --json` for `wrappers/npm`
 - **AND** system verifies the packed file list contains `README.md`, `package.json`, `bin/kml.js`, and `lib/installer.js`
 - **AND** system verifies npm package metadata includes non-empty `description`, `keywords`, `repository`, `homepage`, `bugs`, `license`, and `bin`
+- **AND** system stops before publish if README or required metadata is missing
+
+### Requirement: release gates SHALL validate PyPI package page artifacts before publish
+
+release gate は、PyPI publish 前に project page に表示される package artifact を検証しなければならない（SHALL）。
+
+#### Scenario: PyPI wrapper publish is enabled
+
+- **WHEN** release workflow is dispatched with PyPI wrapper publication enabled or triggered by a merged `release/vX.Y.Z` pull request
+- **THEN** system builds the Python source distribution and wheel for `wrappers/python`
+- **AND** system verifies `README.md` is the configured project readme
+- **AND** system verifies the wheel metadata contains the Markdown long description
+- **AND** system verifies PyPI package metadata includes non-empty `description`, `keywords`, project URLs, `license`, and supported classifiers
 - **AND** system stops before publish if README or required metadata is missing
 
 ### Requirement: npm wrapper retry SHALL use trusted publishing without token fallback

--- a/openspec/specs/release-readiness/spec.md
+++ b/openspec/specs/release-readiness/spec.md
@@ -244,28 +244,40 @@ KatanA feedback sweep で見つかった `check` の誤検知と `fix` の誤修
 - **THEN** system は `v0.13.0` の配布計画に影響するものと影響しないものを分ける
 - **THEN** system は follow-up を by-design 宣言と混同しない
 
-### Requirement: v0.17.2 release readiness SHALL close the npm package visibility gap
+### Requirement: v0.17.3 release readiness SHALL close the npm package visibility gap
 
-`v0.17.2` の release readiness は、npm package page の README / metadata 不足を release blocker として扱わなければならない（SHALL）。
+`v0.17.3` の release readiness は、npm package page の README / metadata 不足を release blocker として扱わなければならない（SHALL）。
 
-#### Scenario: v0.17.2 release is prepared
+#### Scenario: v0.17.3 release is prepared
 
-- **WHEN** developer prepares `v0.17.2`
+- **WHEN** developer prepares `v0.17.3`
 - **THEN** system confirms `wrappers/npm/README.md` exists and is included in the npm tarball
 - **AND** system confirms npm package metadata has search and support fields
 - **AND** system confirms trusted publisher configuration is present for `HiroyukiFuruno/katana-markdown-linter` and `release.yml`
 - **AND** system keeps the npm package as a thin wrapper with no independent lint logic
 
-### Requirement: v0.17.2 post-release verification SHALL prove npm publication
+### Requirement: v0.17.3 release readiness SHALL close the PyPI package visibility gap
 
-`v0.17.2` の公開後検証は、npm registry と npm wrapper 起動を確認しなければならない（SHALL）。
+`v0.17.3` の release readiness は、PyPI project page の README / metadata 不足を release blocker として扱わなければならない（SHALL）。
 
-#### Scenario: v0.17.2 npm publication is verified
+#### Scenario: v0.17.3 release is prepared
 
-- **WHEN** npm wrapper publication for `v0.17.2` completes
-- **THEN** system verifies npm contains `katana-markdown-linter` version `0.17.2`
-- **AND** system runs `npx --yes katana-markdown-linter@0.17.2 --version`
-- **AND** command output is `0.17.2`
+- **WHEN** developer prepares `v0.17.3`
+- **THEN** system confirms `wrappers/python/README.md` explains install, usage, supported platforms, and wrapper contract
+- **AND** system confirms PyPI metadata has search and support fields
+- **AND** system confirms the built wheel metadata contains the Markdown long description
+- **AND** system keeps the PyPI package as a thin wrapper with no independent lint logic
+
+### Requirement: v0.17.3 post-release verification SHALL prove npm publication
+
+`v0.17.3` の公開後検証は、npm registry と npm wrapper 起動を確認しなければならない（SHALL）。
+
+#### Scenario: v0.17.3 npm publication is verified
+
+- **WHEN** npm wrapper publication for `v0.17.3` completes
+- **THEN** system verifies npm contains `katana-markdown-linter` version `0.17.3`
+- **AND** system runs `npx --yes katana-markdown-linter@0.17.3 --version`
+- **AND** command output is `0.17.3`
 - **AND** verification result is recorded before `v0.18.0` work resumes
 
 ### Requirement: Release readiness SHALL include document answer fix evaluation

--- a/scripts/release/verify-pypi-package.py
+++ b/scripts/release/verify-pypi-package.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import venv
+import zipfile
+from pathlib import Path
+
+
+class PyPIPackageVerifier:
+    def __init__(self, package_root: Path) -> None:
+        self.package_root = package_root.resolve()
+        self.pyproject_path = self.package_root / "pyproject.toml"
+        self.readme_path = self.package_root / "README.md"
+        self.target_root = Path("target/pypi-package-check").resolve()
+        self.venv_root = self.target_root / "venv"
+        self.dist_root = self.target_root / "dist"
+        self.pyproject = self.load_pyproject()
+        self.project = self.pyproject["project"]
+
+    def run(self) -> None:
+        try:
+            self.verify_metadata()
+            self.verify_readme()
+            self.build_distributions()
+            self.verify_distributions()
+        finally:
+            self.clean_source_build_artifacts()
+        print(
+            "PyPI package check passed for "
+            f"{self.project['name']}@{self.project['version']}"
+        )
+
+    def load_pyproject(self) -> dict[str, object]:
+        with self.pyproject_path.open("rb") as pyproject_file:
+            return tomllib.load(pyproject_file)
+
+    def verify_metadata(self) -> None:
+        for field in ["name", "version", "description", "readme", "requires-python", "license"]:
+            self.require_non_empty_string(self.project, field)
+
+        if self.project["readme"] != "README.md":
+            raise AssertionError("pyproject.toml: readme must point to README.md")
+
+        dependencies = self.project.get("dependencies", [])
+        if dependencies:
+            raise AssertionError("pyproject.toml: runtime dependencies must stay empty")
+
+        for field in ["keywords", "classifiers"]:
+            values = self.project.get(field)
+            if not isinstance(values, list) or not values:
+                raise AssertionError(f"pyproject.toml: {field} must be a non-empty list")
+
+        urls = self.project.get("urls")
+        if not isinstance(urls, dict):
+            raise AssertionError("pyproject.toml: project.urls is required")
+        for field in ["Homepage", "Repository", "Issues", "Changelog"]:
+            self.require_non_empty_string(urls, field)
+
+    def verify_readme(self) -> None:
+        readme = self.readme_path.read_text(encoding="utf-8")
+        required_fragments = [
+            "downloads the matching `kml` binary archive from GitHub Releases",
+            "SHA-256 checksum",
+            "## Install",
+            "## Supported Platforms",
+            "## Wrapper Contract",
+            "uvx --from katana-markdown-linter==",
+        ]
+        for fragment in required_fragments:
+            if fragment not in readme:
+                raise AssertionError(f"wrappers/python/README.md is missing `{fragment}`")
+
+    def build_distributions(self) -> None:
+        python = self.ensure_build_environment()
+        if self.dist_root.exists():
+            shutil.rmtree(self.dist_root)
+        self.dist_root.mkdir(parents=True)
+        subprocess.run(
+            [
+                str(python),
+                "-m",
+                "build",
+                "--sdist",
+                "--wheel",
+                "--outdir",
+                str(self.dist_root),
+                str(self.package_root),
+            ],
+            check=True,
+        )
+
+    def ensure_build_environment(self) -> Path:
+        python = self.venv_python()
+        if not python.exists():
+            self.venv_root.parent.mkdir(parents=True, exist_ok=True)
+            venv.EnvBuilder(with_pip=True).create(self.venv_root)
+            python = self.venv_python()
+
+        subprocess.run(
+            [str(python), "-m", "pip", "install", "--upgrade", "build"],
+            check=True,
+        )
+        return python
+
+    def verify_distributions(self) -> None:
+        sdists = sorted(self.dist_root.glob("*.tar.gz"))
+        wheels = sorted(self.dist_root.glob("*.whl"))
+        if len(sdists) != 1 or len(wheels) != 1:
+            raise AssertionError("PyPI build must produce exactly one sdist and one wheel")
+
+        sdist_names = self.read_sdist_names(sdists[0])
+        wheel_names = self.read_wheel_names(wheels[0])
+        for required in ["README.md", "pyproject.toml"]:
+            if not any(name.endswith(f"/{required}") for name in sdist_names):
+                raise AssertionError(f"sdist is missing {required}")
+
+        metadata_name = next(
+            (name for name in wheel_names if name.endswith(".dist-info/METADATA")),
+            None,
+        )
+        if metadata_name is None:
+            raise AssertionError("wheel is missing METADATA")
+        self.verify_wheel_metadata(wheels[0], metadata_name)
+
+    def verify_wheel_metadata(self, wheel_path: Path, metadata_name: str) -> None:
+        with zipfile.ZipFile(wheel_path) as wheel:
+            metadata = wheel.read(metadata_name).decode("utf-8")
+        required_fragments = [
+            "Description-Content-Type: text/markdown",
+            "Project-URL: Homepage, https://github.com/HiroyukiFuruno/katana-markdown-linter",
+            "downloads the matching `kml` binary archive from GitHub Releases",
+            "## Supported Platforms",
+        ]
+        for fragment in required_fragments:
+            if fragment not in metadata:
+                raise AssertionError(f"wheel METADATA is missing `{fragment}`")
+
+    def clean_source_build_artifacts(self) -> None:
+        for path in [
+            self.package_root / "build",
+            self.package_root / "src" / "katana_markdown_linter.egg-info",
+        ]:
+            if path.exists():
+                shutil.rmtree(path)
+
+    def read_sdist_names(self, sdist_path: Path) -> set[str]:
+        with tarfile.open(sdist_path, "r:gz") as sdist:
+            return set(sdist.getnames())
+
+    def read_wheel_names(self, wheel_path: Path) -> set[str]:
+        with zipfile.ZipFile(wheel_path) as wheel:
+            return set(wheel.namelist())
+
+    def venv_python(self) -> Path:
+        posix_python = self.venv_root / "bin" / "python"
+        if posix_python.exists():
+            return posix_python
+        return self.venv_root / "Scripts" / "python.exe"
+
+    def require_non_empty_string(self, metadata: object, field: str) -> None:
+        if not isinstance(metadata, dict):
+            raise AssertionError("metadata must be a table")
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise AssertionError(f"pyproject.toml: {field} must be a non-empty string")
+
+
+class ArgumentParser:
+    def parse(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("package_root", nargs="?", default="wrappers/python")
+        return parser.parse_args()
+
+
+def main() -> int:
+    args = ArgumentParser().parse()
+    PyPIPackageVerifier(Path(args.package_root)).run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.2",
+  "version": "0.17.3",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.2/katana-markdown-linter-0.17.2.mcpb",
-      "version": "0.17.2",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/katana-markdown-linter-0.17.3.mcpb",
+      "version": "0.17.3",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -285,12 +285,14 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let answer_runner = read_workspace_file("scripts/ci/document_answer_fix_runner.py");
     let answer_validator = read_workspace_file("scripts/ci/document_answer_validator.py");
     let required = [
-        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check wrapper-publish-gate document-answer-fix"),
+        ("Makefile", &makefile, "release-check: fmt-check lint ast-lint release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check pypi-package-check wrapper-publish-gate document-answer-fix"),
         ("Makefile", &makefile, "binary-smoke: binary-package"),
         ("Makefile", &makefile, "homebrew-formula-check: homebrew-formula"),
         ("Makefile", &makefile, "wrapper-smoke: binary-package"),
         ("Makefile", &makefile, "npm-package-check:"),
         ("Makefile", &makefile, "scripts/release/verify-npm-package.js"),
+        ("Makefile", &makefile, "pypi-package-check:"),
+        ("Makefile", &makefile, "scripts/release/verify-pypi-package.py"),
         ("Makefile", &makefile, "document-answer-fix:"),
         ("Makefile", &makefile, "mcp-release-build:"),
         ("Makefile", &makefile, "mcp-remote-build:"),
@@ -332,6 +334,21 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (
             ".github/workflows/release.yml",
             &workflow,
+            "run: make pypi-package-check",
+        ),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
+            "inputs.publish_npm_wrapper == true",
+        ),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
+            "inputs.publish_pypi_wrapper == true",
+        ),
+        (
+            ".github/workflows/release.yml",
+            &workflow,
             "npm publish --access public --provenance",
         ),
         (".github/workflows/release.yml", &workflow, "Publish PyPI wrapper"),
@@ -353,6 +370,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (".github/workflows/release-preflight.yml", &preflight, "run: make homebrew-formula-check"),
         (".github/workflows/release-preflight.yml", &preflight, "run: make wrapper-smoke"),
         (".github/workflows/release-preflight.yml", &preflight, "run: make npm-package-check"),
+        (".github/workflows/release-preflight.yml", &preflight, "run: make pypi-package-check"),
         ("scripts/ci/document_answer_fix_runner.py", &answer_runner, "AnswerValidationRunner"),
         (
             "scripts/ci/document_answer_validator.py",

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.2 --version
-npx --yes katana-markdown-linter@0.17.2 check README.md
+npx --yes katana-markdown-linter@0.17.3 --version
+npx --yes katana-markdown-linter@0.17.3 check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Thin npm launcher for the kml Markdown linter binary.",
   "keywords": [
     "markdown",

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -1,4 +1,56 @@
 # katana-markdown-linter Python wrapper
 
-This package is a thin launcher for the official `kml` binary artifact. It does
-not implement Markdown linting logic in Python.
+`katana-markdown-linter` is a thin Python launcher for the `kml` Markdown
+linter. The package does not contain independent lint logic. On first use, it
+downloads the matching `kml` binary archive from GitHub Releases, verifies the
+neighboring SHA-256 checksum, installs the binary into the wrapper cache, and
+then delegates all commands to that binary.
+
+## Install
+
+~~~bash
+pipx install katana-markdown-linter
+kml --version
+~~~
+
+Use `uvx` for one-off runs:
+
+~~~bash
+uvx --from katana-markdown-linter==0.17.3 kml --version
+uvx --from katana-markdown-linter==0.17.3 kml check README.md
+~~~
+
+## Basic Usage
+
+~~~bash
+kml check README.md
+kml check docs --config .markdownlint.json
+kml fix README.md
+~~~
+
+## Supported Platforms
+
+The Python launcher uses the same binary archives as the GitHub Release
+channel. It currently supports:
+
+- macOS arm64: `aarch64-apple-darwin`
+- macOS x64: `x86_64-apple-darwin`
+- Linux x64: `x86_64-unknown-linux-gnu`
+- Windows x64: `x86_64-pc-windows-msvc`
+
+Unsupported platforms fail before download with an explicit platform error.
+
+## Wrapper Contract
+
+- The package version selects the GitHub Release tag.
+- The launcher downloads `kml-vX.Y.Z-<target>.tar.gz` or
+  `kml-vX.Y.Z-<target>.zip`.
+- The launcher downloads the matching `.sha256` file and verifies the archive
+  before extraction.
+- The installed binary is cached under the package-local `vendor` directory by
+  default.
+
+For full CLI usage, rule coverage, and other install channels, see the
+[repository README](https://github.com/HiroyukiFuruno/katana-markdown-linter).
+Report package issues through
+[GitHub Issues](https://github.com/HiroyukiFuruno/katana-markdown-linter/issues).

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,11 +4,32 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.2"
+version = "0.17.3"
 description = "Thin Python launcher for the kml Markdown linter binary."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
+keywords = ["markdown", "markdownlint", "linter", "cli", "kml"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Quality Assurance",
+  "Topic :: Text Processing :: Markup :: Markdown",
+]
+
+[project.urls]
+Homepage = "https://github.com/HiroyukiFuruno/katana-markdown-linter"
+Repository = "https://github.com/HiroyukiFuruno/katana-markdown-linter"
+Issues = "https://github.com/HiroyukiFuruno/katana-markdown-linter/issues"
+Changelog = "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/CHANGELOG.md"
 
 [project.scripts]
 kml = "katana_markdown_linter.cli:main"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.2"
+            package_version = "0.17.3"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- bump release metadata to v0.17.3 after v0.17.2 was partially published by the tag-push release path
- add PyPI README, metadata, and package verification before publication
- harden the Release workflow so release PR merge publishes crates.io, npm, and PyPI together and tag pushes no longer trigger partial release

## Verification
- make release-check VERSION=v0.17.3
- make release-task-ledger-check VERSION=v0.17.3
- make pypi-package-check
- make npm-package-check
- scripts/openspec validate release-cicd --strict
- scripts/openspec validate release-readiness --strict
- scripts/openspec validate binary-distribution --strict