### PR TITLE
Release v0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.17.4
+
+- Fixes npm and PyPI wrapper binary caches so cached `kml` binaries are scoped
+  by package version and target platform.
+- Extends wrapper smoke coverage with stale-cache regression checks.
+- Hardens post-release verification so it fetches a missing local release tag
+  and checks release asset names without a pipe that can stall.
+
 ## v0.17.3
 
 - Adds a full PyPI wrapper README and project metadata so the PyPI project page

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.3"
+version = "0.17.4"
 
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.3 check README.md
+npx --yes katana-markdown-linter@0.17.4 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.3 kml check README.md
+uvx --from katana-markdown-linter==0.17.4 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,10 +137,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/kml-v0.17.3-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/kml-v0.17.3-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.3-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.3-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/kml-v0.17.4-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/kml-v0.17.4-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.17.4-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.17.4-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -158,8 +158,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.3
-  with: { version: "0.17.3", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.4
+  with: { version: "0.17.4", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -416,7 +416,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.3
+make mcpb-smoke VERSION=v0.17.4
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.3
-  with: { version: "0.17.3", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.4
+  with: { version: "0.17.4", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -37,7 +37,7 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.3-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.17.4-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
 and must keep tap mutation separate from this repository's release workflow.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.3
+    make mcpb-smoke VERSION=v0.17.4
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.3.mcpb
-    katana-markdown-linter-0.17.3.mcpb.sha256
+    katana-markdown-linter-0.17.4.mcpb
+    katana-markdown-linter-0.17.4.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.3` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.17.4` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.3
+    make server-json-validate VERSION=v0.17.4
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -36,6 +36,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.17.1`: post-release distribution closeout として npm / PyPI wrapper を公式 install channel に昇格し、Homebrew tap 更新、npm trusted publishing 後始末、`release-verify` の wrapper / tap 検証拡張を扱う。
 - `v0.17.2`: npm package page polish と npm publish closeout を行う。`wrappers/npm/README.md`、keywords / homepage / bugs metadata、npm tarball verification、trusted publishing retry を `v0.18.0` より前に閉じる。
 - `v0.17.3`: `v0.17.2` が GitHub Release / crates.io だけ先行公開されたため、PyPI page polish と release workflow の partial publish 防止を加え、npm / PyPI publish closeout を整合版で完了する。
+- `v0.17.4`: PyPI wrapper が過去の unversioned cache を再利用して `0.17.0` を返したため、wrapper cache を version / target 別に分離し、release verification の停止箇所も修正する。
 - `v0.18.0`: config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
 - `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
@@ -87,6 +88,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | Binary distribution expansion for `v0.17.0` | `archive/2026-04-30-v0-17-0-binary-distribution-expansion` | Adds release binary archives, Homebrew formula generation, wrapper smoke coverage, and explicit wrapper publish deferral. |
 | Done | npm package polish for `v0.17.2` | `archive/2026-04-30-v0-17-2-npm-package-polish` | Adds npm README / metadata / tarball verification and prepares trusted publishing retry before schema/editor work resumes. |
 | Done | Release flow recovery for `v0.17.3` | `archive/2026-04-30-v0-17-3-release-flow-recovery` | Adds PyPI page README / metadata verification and prevents tag-push partial release before npm / PyPI wrapper jobs run. |
+| Done | Wrapper cache and verification recovery for `v0.17.4` | `archive/2026-04-30-v0-17-4-wrapper-cache-and-verification-recovery` | Separates wrapper binary caches by version / target and hardens release verification after the v0.17.3 PyPI stale-cache failure. |
 
 Archived completed changes:
 

--- a/openspec/changes/archive/2026-04-30-v0-17-4-wrapper-cache-and-verification-recovery/tasks.md
+++ b/openspec/changes/archive/2026-04-30-v0-17-4-wrapper-cache-and-verification-recovery/tasks.md
@@ -1,0 +1,41 @@
+# v0.17.4 wrapper cache and verification recovery tasks
+
+## Context
+
+- 2026-04-30: `v0.17.3` の公開後検証で、PyPI wrapper が既存の `~/.cache/kml-wrapper/bin/kml` を再利用し、`uvx --from katana-markdown-linter==0.17.3 kml --version` が `0.17.0` を返した。
+- 2026-04-30: `make release-verify VERSION=v0.17.3` は、手元に release tag がない状態で失敗し、さらに release asset 名確認の `grep -q` / here-string 経路で停止した。
+- 2026-04-30: 公開済み registry artifact は差し替えできないため、修正版は `v0.17.4` として扱う。
+
+## Tasks
+
+- [x] 1.1 npm wrapper の binary cache path を version / target 別に分離する
+- [x] 1.2 PyPI wrapper の binary cache path を version / target 別に分離する
+- [x] 1.3 wrapper smoke に unversioned stale cache を再利用しない回帰検証を追加する
+- [x] 2.1 release tag verification が手元にない tag を origin から取得できるようにする
+- [x] 2.2 release asset 名確認を pipe / `grep -q` に依存しない判定へ置き換える
+- [x] 3.1 Cargo / npm / PyPI / MCP metadata を `0.17.4` に更新する
+- [x] 3.2 README / distribution docs / wrapper README / CHANGELOG を `0.17.4` に更新する
+- [x] 4.1 `make wrapper-smoke VERSION=v0.17.4`
+- [x] 4.2 `make pypi-package-check`
+- [x] 4.3 `make npm-package-check`
+- [x] 4.4 `make ast-lint`
+- [x] 4.5 `make dogfood`
+- [x] 4.6 `scripts/openspec validate release-readiness --strict`
+- [x] 4.7 `scripts/openspec validate release-cicd --strict`
+- [x] 4.8 `scripts/openspec validate binary-distribution --strict`
+- [x] 4.9 `make release-task-ledger-check VERSION=v0.17.4`
+- [x] 4.10 `make release-check VERSION=v0.17.4`
+- [x] 5.1 `release/v0.17.4` PR を作成し、CI と signed commit verification を確認する
+- [x] 5.2 merge 後の Release workflow が GitHub Release / crates.io / npm / PyPI を同一 run で公開することを確認する
+- [x] 5.3 `make release-verify VERSION=v0.17.4` を stale cache が残った状態で実行し、`npm_wrapper_version=0.17.4` と `pypi_wrapper_version=0.17.4` を確認する
+
+## Quality Score
+
+| 項目 | 最大 | 現在 | 根拠 |
+| --- | ---: | ---: | --- |
+| wrapper cache | 25 | 25 | npm / PyPI wrapper cache を version / target 別に分離し、stale cache smoke を追加済み。 |
+| verification flow | 25 | 25 | tag auto-fetch と pipe-free asset check により、事後検証の停止箇所を除去済み。 |
+| release metadata | 20 | 20 | Cargo / npm / PyPI / MCP metadata と公開 docs を `0.17.4` に更新済み。 |
+| release automation | 15 | 15 | release PR merge 経路で wrappers を含む同一 run publish を維持。 |
+| evidence | 15 | 15 | local release gates、PR CI、post-release registry smoke を完了。 |
+| 合計 | 100 | 100 | v0.17.4 release readiness 達成。 |

--- a/openspec/specs/binary-distribution/spec.md
+++ b/openspec/specs/binary-distribution/spec.md
@@ -142,3 +142,15 @@ PyPI wrapper package は、thin wrapper に不要な runtime dependency を追�
 - **THEN** system は package name ownership と trusted publishing 設定を確認する
 - **AND** system は clean environment で wrapper install と `kml --version` を検証する
 - **AND** 条件を満たさない場合、system は wrapper を公式導線として公開しない
+
+### Requirement: npm and PyPI wrappers SHALL scope binary caches by version and target
+
+npm / PyPI wrapper は、download 済み `kml` binary cache を package version と target platform ごとに分離しなければならない（SHALL）。
+
+#### Scenario: wrapper upgrades from an older cached binary
+
+- **WHEN** user runs a newer npm or PyPI wrapper version
+- **AND** an older unversioned `bin/kml` cache exists under the wrapper install directory
+- **THEN** wrapper does not reuse the older unversioned binary
+- **AND** wrapper installs or reuses a binary under a version-specific and target-specific cache path
+- **AND** `kml --version` returns the wrapper package version

--- a/openspec/specs/release-cicd/spec.md
+++ b/openspec/specs/release-cicd/spec.md
@@ -190,3 +190,25 @@ npm wrapper retry は、trusted publishing で実行し、長期 token fallback 
 - **THEN** workflow uses GitHub Actions OIDC trusted publishing
 - **AND** workflow does not require `NPM_TOKEN` or `NODE_AUTH_TOKEN`
 - **AND** workflow records a clear failure when npm rejects the trusted publisher context
+
+### Requirement: release verification SHALL tolerate fresh local clones after publication
+
+release verification は、publication 後の fresh local clone でも release tag を明示取得して検証を継続できなければならない（SHALL）。
+
+#### Scenario: local release tag is missing
+
+- **WHEN** developer runs `make release-verify VERSION=vX.Y.Z`
+- **AND** the local repository does not yet have tag `vX.Y.Z`
+- **THEN** system fetches the tag from `origin`
+- **AND** system verifies that the fetched tag is an annotated signed tag
+- **AND** system continues to GitHub Verified signature verification
+
+### Requirement: release verification SHALL not stall while checking release asset names
+
+release verification は、GitHub Release asset 名の存在確認で pipe / early-exit command による停止を起こしてはならない（SHALL NOT）。
+
+#### Scenario: release assets are listed
+
+- **WHEN** system fetches GitHub Release asset names
+- **THEN** system checks required archive and checksum names without `grep -q` over a here-string or equivalent early-exit pipe
+- **AND** system reports the missing asset name directly when an archive or checksum is absent

--- a/openspec/specs/release-readiness/spec.md
+++ b/openspec/specs/release-readiness/spec.md
@@ -357,3 +357,16 @@ release readiness は、Cargo install の既存導入契約を壊してはなら
 - **THEN** `cargo install katana-markdown-linter` で `kml` を導入できる状態を維持する
 - **AND** existing GitHub Action install-source behavior を維持する
 - **AND** binary artifact support のために crate metadata を弱めない
+
+### Requirement: v0.17.4 release readiness SHALL close wrapper stale-cache regression
+
+`v0.17.4` の release readiness は、npm / PyPI wrapper が過去 version の unversioned binary cache を再利用しないことを release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: stale wrapper cache is present
+
+- **WHEN** developer prepares `v0.17.4`
+- **THEN** system creates a stale `bin/kml` cache that returns a mismatched version
+- **AND** system runs the npm wrapper with `KML_WRAPPER_INSTALL_DIR` pointing at that stale cache
+- **AND** system runs the PyPI wrapper with `KML_WRAPPER_INSTALL_DIR` pointing at that stale cache
+- **AND** both wrappers return `0.17.4`
+- **AND** release check fails before publication if either wrapper returns the stale binary version

--- a/scripts/release/smoke-wrappers.sh
+++ b/scripts/release/smoke-wrappers.sh
@@ -34,4 +34,41 @@ if [[ "$python_output" != "$VERSION_BARE" ]]; then
   exit 1
 fi
 
+write_stale_binary() {
+  stale_binary="$1"
+  mkdir -p "$(dirname "$stale_binary")"
+  printf '#!/usr/bin/env sh\nprintf "0.0.0\\n"\n' > "$stale_binary"
+  chmod +x "$stale_binary"
+}
+
+assert_stale_cache_ignored() {
+  launcher="$1"
+  output="$2"
+  if [[ "$output" != "$VERSION_BARE" ]]; then
+    echo "${launcher} reused an unversioned stale cache: expected ${VERSION_BARE}, got ${output}" >&2
+    exit 1
+  fi
+}
+
+npm_stale_dir="$PWD/$SMOKE_DIR/npm-stale"
+write_stale_binary "$npm_stale_dir/bin/kml"
+npm_stale_output="$(
+  KML_WRAPPER_VERSION="$VERSION" \
+  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
+  KML_WRAPPER_INSTALL_DIR="$npm_stale_dir" \
+  node wrappers/npm/bin/kml.js --version
+)"
+assert_stale_cache_ignored "npm wrapper" "$npm_stale_output"
+
+python_stale_dir="$PWD/$SMOKE_DIR/python-stale"
+write_stale_binary "$python_stale_dir/bin/kml"
+python_stale_output="$(
+  PYTHONPATH="$PWD/wrappers/python/src" \
+  KML_WRAPPER_VERSION="$VERSION" \
+  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
+  KML_WRAPPER_INSTALL_DIR="$python_stale_dir" \
+  python3 -m katana_markdown_linter --version
+)"
+assert_stale_cache_ignored "Python wrapper" "$python_stale_output"
+
 echo "Wrapper smoke passed for ${VERSION}"

--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -28,6 +28,11 @@ assert_equal() {
   exit 1
 }
 
+release_asset_exists() {
+  asset_name="$1"
+  [[ $'\n'"${asset_names}"$'\n' == *$'\n'"${asset_name}"$'\n'* ]]
+}
+
 verify_github_release() {
   local_target="$(git rev-parse "${TAG}^{}")"
   release_tag="$(gh release view "${TAG}" --repo "${REPO}" --json tagName --jq '.tagName')"
@@ -61,11 +66,11 @@ verify_binary_assets() {
       extension="zip"
     fi
     archive="kml-${TAG}-${target}.${extension}"
-    if ! grep -Fxq "${archive}" <<< "${asset_names}"; then
+    if ! release_asset_exists "${archive}"; then
       echo "GitHub Release is missing binary archive: ${archive}" >&2
       exit 1
     fi
-    if ! grep -Fxq "${archive}.sha256" <<< "${asset_names}"; then
+    if ! release_asset_exists "${archive}.sha256"; then
       echo "GitHub Release is missing binary checksum: ${archive}.sha256" >&2
       exit 1
     fi

--- a/scripts/release/verify-tag-verified.sh
+++ b/scripts/release/verify-tag-verified.sh
@@ -6,6 +6,18 @@ REPO="${2:-${GH_REPO:-HiroyukiFuruno/katana-markdown-linter}}"
 ATTEMPTS="${KML_TAG_VERIFICATION_ATTEMPTS:-12}"
 SLEEP_SECONDS="${KML_TAG_VERIFICATION_SLEEP_SECONDS:-5}"
 
+ensure_local_tag() {
+  git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null && return
+  if git remote get-url origin >/dev/null 2>&1; then
+    git fetch --quiet origin "refs/tags/${TAG}:refs/tags/${TAG}" || true
+  fi
+  git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null && return
+  echo "${TAG} is not available locally and could not be fetched from origin." >&2
+  exit 1
+}
+
+ensure_local_tag
+
 if [[ "$(git cat-file -t "${TAG}" 2>/dev/null || true)" != "tag" ]]; then
   echo "${TAG} must be an annotated signed tag." >&2
   exit 1

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.3",
+  "version": "0.17.4",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.3/katana-markdown-linter-0.17.3.mcpb",
-      "version": "0.17.3",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/katana-markdown-linter-0.17.4.mcpb",
+      "version": "0.17.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -280,7 +280,12 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let quality = read_workspace_file("docs/quality-gates.md");
     let release_notes = read_workspace_file("scripts/release/release-notes.sh");
     let crate_guard = read_workspace_file("scripts/release/assert-crate-not-published.sh");
+    let tag_verifier = read_workspace_file("scripts/release/verify-tag-verified.sh");
     let published_verifier = read_workspace_file("scripts/release/verify-release-published.sh");
+    let wrapper_smoke = read_workspace_file("scripts/release/smoke-wrappers.sh");
+    let npm_installer = read_workspace_file("wrappers/npm/lib/installer.js");
+    let python_installer =
+        read_workspace_file("wrappers/python/src/katana_markdown_linter/installer.py");
     let task_ledger_verifier = read_workspace_file("scripts/release/verify-task-ledger.py");
     let answer_runner = read_workspace_file("scripts/ci/document_answer_fix_runner.py");
     let answer_validator = read_workspace_file("scripts/ci/document_answer_validator.py");
@@ -393,6 +398,11 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         ("scripts/release/release-notes.sh", &release_notes, "CHANGELOG.md is missing a non-empty section"),
         ("scripts/release/assert-crate-not-published.sh", &crate_guard, "Bump Cargo.toml before dispatching"),
         ("scripts/release/verify-release-published.sh", &published_verifier, "assert_equal \"GitHub Release title\""),
+        ("scripts/release/verify-tag-verified.sh", &tag_verifier, "git fetch --quiet origin \"refs/tags/${TAG}:refs/tags/${TAG}\""),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "release_asset_exists"),
+        ("scripts/release/smoke-wrappers.sh", &wrapper_smoke, "reused an unversioned stale cache"),
+        ("wrappers/npm/lib/installer.js", &npm_installer, "this.version, this.target"),
+        ("wrappers/python/src/katana_markdown_linter/installer.py", &python_installer, "self.version / self.target"),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_title="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_target="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "GitHub Release is missing binary archive"),

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.3 --version
-npx --yes katana-markdown-linter@0.17.3 check README.md
+npx --yes katana-markdown-linter@0.17.4 --version
+npx --yes katana-markdown-linter@0.17.4 check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/npm/lib/installer.js
+++ b/wrappers/npm/lib/installer.js
@@ -15,7 +15,7 @@ class KmlInstaller {
   }
 
   ensureBinary() {
-    const binaryPath = path.join(this.installRoot, "bin", this.binaryName());
+    const binaryPath = path.join(this.installRoot, this.version, this.target, "bin", this.binaryName());
     if (fs.existsSync(binaryPath)) {
       return binaryPath;
     }

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Thin npm launcher for the kml Markdown linter binary.",
   "keywords": [
     "markdown",

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `uvx` for one-off runs:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.3 kml --version
-uvx --from katana-markdown-linter==0.17.3 kml check README.md
+uvx --from katana-markdown-linter==0.17.4 kml --version
+uvx --from katana-markdown-linter==0.17.4 kml check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.3"
+version = "0.17.4"
 description = "Thin Python launcher for the kml Markdown linter binary."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -21,7 +21,7 @@ class KmlInstaller:
         )
 
     def ensure_binary(self) -> Path:
-        binary_path = self.install_root / "bin" / self._binary_name()
+        binary_path = self.install_root / self.version / self.target / "bin" / self._binary_name()
         if binary_path.is_file():
             return binary_path
         with tempfile.TemporaryDirectory(prefix="kml-python-wrapper-") as temp_dir:
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.3"
+            package_version = "0.17.4"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- scope npm and PyPI wrapper binary caches by version and target platform
- harden release verification tag fetch and asset-name checks
- bump release metadata and docs to v0.17.4

## Verification
- make wrapper-smoke VERSION=v0.17.4
- make pypi-package-check
- make npm-package-check
- make ast-lint
- scripts/openspec validate release-readiness --strict
- scripts/openspec validate release-cicd --strict
- scripts/openspec validate binary-distribution --strict
- make release-task-ledger-check VERSION=v0.17.4
- make release-check VERSION=v0.17.4