### PR TITLE
Release kml v0.17.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,8 +274,22 @@ jobs:
 
       - name: Generate Homebrew formula
         run: |
-          python3 scripts/release/homebrew_formula.py generate --version "${{ steps.version.outputs.version }}"
-          python3 scripts/release/homebrew_formula.py check --version "${{ steps.version.outputs.version }}"
+          python3 scripts/release/homebrew_formula.py generate \
+            --version "${{ steps.version.outputs.version }}" \
+            --formula-name kml \
+            --output target/homebrew/kml.rb
+          python3 scripts/release/homebrew_formula.py check \
+            --version "${{ steps.version.outputs.version }}" \
+            --formula-name kml \
+            --output target/homebrew/kml.rb
+          python3 scripts/release/homebrew_formula.py generate \
+            --version "${{ steps.version.outputs.version }}" \
+            --formula-name "kml@${{ steps.version.outputs.version_bare }}" \
+            --output "target/homebrew/kml@${{ steps.version.outputs.version_bare }}.rb"
+          python3 scripts/release/homebrew_formula.py check \
+            --version "${{ steps.version.outputs.version }}" \
+            --formula-name "kml@${{ steps.version.outputs.version_bare }}" \
+            --output "target/homebrew/kml@${{ steps.version.outputs.version_bare }}.rb"
 
       - name: Build release notes
         run: scripts/release/release-notes.sh "${{ steps.version.outputs.version_bare }}" > RELEASE_NOTES.md
@@ -310,6 +324,15 @@ jobs:
               --title "$TAG" \
               --notes-file RELEASE_NOTES.md
           fi
+
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_KATANA_GIT_TOKEN: ${{ secrets.HOMEBREW_KATANA_GIT_TOKEN }}
+        run: |
+          python3 scripts/release/update_homebrew_tap.py \
+            --version "${{ steps.version.outputs.version }}" \
+            --current-formula target/homebrew/kml.rb \
+            --versioned-formula "target/homebrew/kml@${{ steps.version.outputs.version_bare }}.rb"
 
       - name: Publish MCP Registry metadata
         if: >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.17.5
+
+- Adds global and command-specific CLI help for `kml help`, `kml --help`,
+  `kml -h`, and `kml <command> --help`.
+- Adds the `kml -v` version alias alongside `kml version`, `kml --version`,
+  and `kml -V`.
+- Updates the release flow so Homebrew tap formulae are published from verified
+  release assets and checked during post-release verification.
+
 ## v0.17.4
 
 - Fixes npm and PyPI wrapper binary caches so cached `kml` binaries are scoped

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.4"
+version = "0.17.5"
 
 edition = "2021"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ MCP_SERVER_JSON ?= $(MCPB_DIST_DIR)/server.json
 BINARY_DIST_DIR ?= target/binary
 BINARY_TARGET ?=
 HOMEBREW_FORMULA ?= target/homebrew/kml.rb
+HOMEBREW_VERSIONED_FORMULA ?= target/homebrew/kml@$(VERSION_BARE).rb
 export RUSTFLAGS=-D warnings
 
 # AI context-aware CLI proxy (mandatory for agents)
@@ -213,11 +214,13 @@ binary-smoke: binary-package ## Exercise the standalone binary archive after ext
 
 .PHONY: homebrew-formula
 homebrew-formula: binary-package ## Render Homebrew formula from binary archive checksums
-	python3 scripts/release/homebrew_formula.py generate --version "$(VERSION)" --dist-dir "$(BINARY_DIST_DIR)" --output "$(HOMEBREW_FORMULA)"
+	python3 scripts/release/homebrew_formula.py generate --version "$(VERSION)" --dist-dir "$(BINARY_DIST_DIR)" --formula-name kml --output "$(HOMEBREW_FORMULA)"
+	python3 scripts/release/homebrew_formula.py generate --version "$(VERSION)" --dist-dir "$(BINARY_DIST_DIR)" --formula-name "kml@$(VERSION_BARE)" --output "$(HOMEBREW_VERSIONED_FORMULA)"
 
 .PHONY: homebrew-formula-check
 homebrew-formula-check: homebrew-formula ## Validate generated Homebrew formula output
-	python3 scripts/release/homebrew_formula.py check --version "$(VERSION)" --output "$(HOMEBREW_FORMULA)"
+	python3 scripts/release/homebrew_formula.py check --version "$(VERSION)" --formula-name kml --output "$(HOMEBREW_FORMULA)"
+	python3 scripts/release/homebrew_formula.py check --version "$(VERSION)" --formula-name "kml@$(VERSION_BARE)" --output "$(HOMEBREW_VERSIONED_FORMULA)"
 
 .PHONY: wrapper-smoke
 wrapper-smoke: binary-package ## Exercise npm and Python wrapper launchers against local binary archive

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.4 check README.md
+npx --yes katana-markdown-linter@0.17.5 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.4 kml check README.md
+uvx --from katana-markdown-linter==0.17.5 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,16 +137,15 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/kml-v0.17.4-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/kml-v0.17.4-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.4-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.4-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.5/kml-v0.17.5-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.5/kml-v0.17.5-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.17.5-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.17.5-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
 
-Homebrew formula generation is part of the release flow. After the tap update is
-published, install with:
+Homebrew formula publication is part of the release flow. Install with:
 
 ~~~bash
 brew install HiroyukiFuruno/katana/kml
@@ -158,8 +157,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.4
-  with: { version: "0.17.4", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.5
+  with: { version: "0.17.5", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -198,7 +197,14 @@ kml rule MD013 --locale ja --output json
 kml config file
 kml config get --output json
 kml config schema
+kml --help
+kml -h
+kml help
+kml check --help
+kml check -h
 kml version
+kml --version
+kml -v
 kml fix --config .markdownlint.json README.md
 kml init-config
 ~~~
@@ -416,7 +422,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.4
+make mcpb-smoke VERSION=v0.17.5
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -8,7 +8,7 @@
 | Standalone binary artifacts | Official from `v0.17.1` | `make binary-smoke`, release asset checksum, `make release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
 | npm wrapper | Official from `v0.17.3` | npm registry version, `npx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
 | PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, package README / metadata check, `make release-verify` | Thin launcher over GitHub Release binary archives |
-| Homebrew formula | Official from `v0.17.1` | `make homebrew-formula-check`, release archive checksum, formula test block, tap review | Tap update is reviewed separately in `homebrew-katana` after release assets exist |
+| Homebrew formula | Official from `v0.17.1` | `make homebrew-formula-check`, release archive checksum, formula test block, actual tap check in `make release-verify` | Release workflow updates latest and versioned formulae in `homebrew-katana` after release assets exist |
 | GitHub Action | Official from `v0.11.0` | `make action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
 | MCPB bundle | Official from `v0.14.0` | `make mcpb-smoke`, `make server-json-validate`, release asset checksum | Local stdio MCP package for `kml-mcp` |
 | MCP Registry metadata | Official from `v0.14.0` | rendered `server.json`, MCPB checksum, registry publish verification | Discovery metadata for the MCPB bundle |
@@ -19,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.4
-  with: { version: "0.17.4", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.5
+  with: { version: "0.17.5", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -37,9 +37,11 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.4-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.17.5-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
-and must keep tap mutation separate from this repository's release workflow.
+and is published to `HiroyukiFuruno/homebrew-katana` by the release workflow
+with `HOMEBREW_KATANA_GIT_TOKEN`. Each release updates the latest `kml`
+formula and adds a versioned `kml@X.Y.Z` formula.
 
 The npm and PyPI packages do not contain independent lint logic. They download
 the matching GitHub Release archive for the package version, verify the archive

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.4
+    make mcpb-smoke VERSION=v0.17.5
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.4.mcpb
-    katana-markdown-linter-0.17.4.mcpb.sha256
+    katana-markdown-linter-0.17.5.mcpb
+    katana-markdown-linter-0.17.5.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.4` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.17.5` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.4
+    make server-json-validate VERSION=v0.17.5
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -30,7 +30,7 @@
 | `make mcpb-smoke` | Build the MCPB bundle and run the bundled `kml-mcp` binary through stdio smoke | Yes for release gates |
 | `make server-json-validate` | Render and validate MCP Registry metadata for the release MCPB artifact | Yes for release gates |
 | `make release-check` | Run local release preflight gates except live upstream clone | Yes |
-| `make release-verify` | Verify published tag, GitHub Release, crates.io, npm, PyPI, wrapper launch, and Homebrew formula state | Yes after publication |
+| `make release-verify` | Verify published tag, GitHub Release, crates.io, npm, PyPI, wrapper launch, and actual Homebrew tap formula state | Yes after publication |
 
 `make lint` is intentionally limited to Clippy. Repository-specific checks belong in `make ast-lint` so Rust style warnings and project invariants can be triaged independently.
 
@@ -163,7 +163,8 @@ make release-verify VERSION=vX.Y.Z
 
 That command compares the local tag target, GitHub Release title and target,
 GitHub tag verification state, required binary assets, crates.io version, npm
-version, PyPI version, wrapper launch output, and Homebrew formula evidence.
+version, PyPI version, wrapper launch output, and Homebrew tap formula
+evidence.
 
 Run `make upstream-golden` before changing rule behavior or fix behavior. It is deterministic and does not require network access. Run `make upstream-golden-live` only when refreshing the upstream oracle or investigating compatibility drift.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -160,21 +160,25 @@ of replacing the published meaning of the same version.
 
 ## Homebrew Tap Update
 
-The release workflow generates `target/homebrew/kml.rb` from the verified
-binary assets. Apply that file to the `homebrew-katana` tap in a separate
-branch after the GitHub Release exists:
+The release workflow generates both `target/homebrew/kml.rb` and
+`target/homebrew/kml@X.Y.Z.rb` from the verified binary assets. After the
+GitHub Release exists, the workflow updates `HiroyukiFuruno/homebrew-katana`
+with `HOMEBREW_KATANA_GIT_TOKEN`.
+
+Configure this repository secret before publishing:
 
 ~~~bash
-cd /Users/hiroyuki_furuno/works/private/homebrew-katana
-git switch -c release/kml-vX.Y.Z
-mkdir -p Formula
-cp /Users/hiroyuki_furuno/works/private/katana-markdown-linter/target/homebrew/kml.rb Formula/kml.rb
-brew audit --strict --online Formula/kml.rb
-brew test Formula/kml.rb
+gh secret set HOMEBREW_KATANA_GIT_TOKEN --body "<token-with-homebrew-katana-write-access>"
 ~~~
 
-Push and review the tap change separately from the core release PR. Do not push
-a tap update before the referenced release assets and checksums exist.
+Do not add a `github.token` fallback. The tap update must fail when the
+dedicated token is missing. `make release-verify VERSION=vX.Y.Z` compares the
+generated formulae with the actual tap files:
+
+- `Formula/kml.rb`
+- `Formula/kml@X.Y.Z.rb`
+
+If either file still points at an older release, verification fails.
 
 ## Wrapper Publication
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -37,6 +37,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.17.2`: npm package page polish と npm publish closeout を行う。`wrappers/npm/README.md`、keywords / homepage / bugs metadata、npm tarball verification、trusted publishing retry を `v0.18.0` より前に閉じる。
 - `v0.17.3`: `v0.17.2` が GitHub Release / crates.io だけ先行公開されたため、PyPI page polish と release workflow の partial publish 防止を加え、npm / PyPI publish closeout を整合版で完了する。
 - `v0.17.4`: PyPI wrapper が過去の unversioned cache を再利用して `0.17.0` を返したため、wrapper cache を version / target 別に分離し、release verification の停止箇所も修正する。
+- `v0.17.5`: CLI help / version alias の入口を修正し、Homebrew tap が古い version のまま残らないように release workflow と post-release verification を修正する。
 - `v0.18.0`: config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
 - `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
@@ -89,6 +90,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | npm package polish for `v0.17.2` | `archive/2026-04-30-v0-17-2-npm-package-polish` | Adds npm README / metadata / tarball verification and prepares trusted publishing retry before schema/editor work resumes. |
 | Done | Release flow recovery for `v0.17.3` | `archive/2026-04-30-v0-17-3-release-flow-recovery` | Adds PyPI page README / metadata verification and prevents tag-push partial release before npm / PyPI wrapper jobs run. |
 | Done | Wrapper cache and verification recovery for `v0.17.4` | `archive/2026-04-30-v0-17-4-wrapper-cache-and-verification-recovery` | Separates wrapper binary caches by version / target and hardens release verification after the v0.17.3 PyPI stale-cache failure. |
+| In Progress | CLI help and Homebrew tap recovery for `v0.17.5` | `v0-17-5-cli-help-and-version-aliases` | Adds CLI help/version aliases and closes the Homebrew tap update gap that left `brew install HiroyukiFuruno/katana/kml` on v0.17.1. |
 
 Archived completed changes:
 

--- a/openspec/changes/v0-17-5-cli-help-and-version-aliases/design.md
+++ b/openspec/changes/v0-17-5-cli-help-and-version-aliases/design.md
@@ -1,0 +1,32 @@
+# v0.17.5 CLI help and version aliases design
+
+## 方針
+
+既存の軽量 parser を維持し、`--help` / `-h` を最優先で検出する。ヘルプ要求時は lint 対象の探索を行わず、標準出力に usage を出して exit code `0` で終了する。
+
+## 設計
+
+- `Command::Help(Option<HelpTopic>)` を追加し、global help と command help を同じ command として扱う。
+- `HelpTopic` は既存 command 名からだけ解決する。未知の command は global help に倒す。
+- `--version` / `-V` / `-v` は `Command::Version` として早期解決する。
+- `kml <command> --help` と `kml <command> -h` は、その command の usage を表示する。
+- 回帰テストは CLI binary を実行し、空の作業ディレクトリでも lint 処理へ進まないことを確認する。
+
+## 互換性
+
+既存の `kml version`、`kml --version`、`kml -V` は維持する。`-v` は新しく version alias として追加する。
+
+## Homebrew tap 更新
+
+`homebrew-katana` の `Formula/kml.rb` は `v0.17.1` のまま止まっていた。release workflow は formula を生成していたが、tap repository へ反映していなかったためである。
+
+`v0.17.5` では、release workflow の GitHub Release 作成後に `HOMEBREW_KATANA_GIT_TOKEN` を使って `homebrew-katana` を更新する。`github.token` への fallback は持たない。
+
+更新対象は次の 2 種類とする。
+
+- `Formula/kml.rb`: 最新版を指す formula
+- `Formula/kml@X.Y.Z.rb`: その version を固定して導入する formula
+
+公開後検証では、生成した formula と実際の tap 上の formula を比較する。これにより、GitHub Release / npm / PyPI は新しいのに Homebrew だけ古い状態を検出する。
+
+`v0.17.1` 以降の過去 version は、npm / PyPI の公開済み version に合わせ、`0.17.1`、`0.17.3`、`0.17.4` を versioned formula として登録する。`0.17.2` は npm / PyPI に存在しないため対象外とする。

--- a/openspec/changes/v0-17-5-cli-help-and-version-aliases/proposal.md
+++ b/openspec/changes/v0-17-5-cli-help-and-version-aliases/proposal.md
@@ -1,0 +1,25 @@
+# v0.17.5 CLI help and version aliases proposal
+
+## 目的
+
+`kml help`、`kml --help`、`kml -h` がヘルプを表示し、`kml -v` も `kml version` と同じように version を表示できる状態にする。
+
+## 背景
+
+`kml help` は入力ファイル `help` として扱われ、`kml --help` はヘルプ表示ではなく通常の検査処理へ流れていた。利用者が CLI の使い方を確認する入口として壊れているため、動作修正として patch release に含める。
+
+## 範囲
+
+- global help: `kml help`、`kml --help`、`kml -h`
+- command help: `kml <command> --help`、`kml <command> -h`
+- version aliases: `kml version`、`kml --version`、`kml -V`、`kml -v`
+- Homebrew tap の current formula と versioned formula の自動更新
+- npm / PyPI に公開済みの `v0.17.1` 以降に合わせた Homebrew versioned formula 登録
+- README / CHANGELOG / release metadata の `0.17.5` 更新
+
+## 範囲外
+
+- 引数 parser の crate 置き換え
+- subcommand ごとの詳細な tutorial 化
+- 既存 lint / fix / fmt の処理仕様変更
+- npm / PyPI に存在しない `v0.17.2` の Homebrew versioned formula 登録

--- a/openspec/changes/v0-17-5-cli-help-and-version-aliases/specs/release-readiness/spec.md
+++ b/openspec/changes/v0-17-5-cli-help-and-version-aliases/specs/release-readiness/spec.md
@@ -1,0 +1,69 @@
+### Requirement: v0.17.5 release readiness SHALL restore CLI help entrypoints
+
+`v0.17.5` の release readiness は、CLI help entrypoint が lint 対象探索に流れないことを release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: global help is requested
+
+- **WHEN** developer prepares `v0.17.5`
+- **THEN** system runs `kml help`
+- **AND** system runs `kml --help`
+- **AND** system runs `kml -h`
+- **AND** each command exits with code `0`
+- **AND** each command prints global usage
+- **AND** system does not run Markdown file discovery for those commands
+
+#### Scenario: command help is requested
+
+- **WHEN** developer prepares `v0.17.5`
+- **THEN** system runs `kml check --help`
+- **AND** system runs `kml check -h`
+- **AND** each command exits with code `0`
+- **AND** each command prints command usage
+
+### Requirement: v0.17.5 release readiness SHALL support version aliases
+
+`v0.17.5` の release readiness は、version 表示の短縮 alias を release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: version alias is requested
+
+- **WHEN** developer prepares `v0.17.5`
+- **THEN** system runs `kml version`
+- **AND** system runs `kml --version`
+- **AND** system runs `kml -V`
+- **AND** system runs `kml -v`
+- **AND** each command exits with code `0`
+- **AND** each command prints `0.17.5`
+
+### Requirement: v0.17.5 release readiness SHALL update Homebrew tap
+
+`v0.17.5` の release readiness は、Homebrew tap が release artifact と同じ version を指すことを release blocker として扱わなければならない（SHALL）。
+
+#### Scenario: release workflow updates Homebrew tap
+
+- **WHEN** developer publishes `v0.17.5`
+- **THEN** release workflow uses `HOMEBREW_KATANA_GIT_TOKEN`
+- **AND** release workflow updates `Formula/kml.rb` in `HiroyukiFuruno/homebrew-katana`
+- **AND** release workflow adds `Formula/kml@0.17.5.rb` in `HiroyukiFuruno/homebrew-katana`
+- **AND** versioned formula `Formula/kml@0.17.5.rb` is `keg_only :versioned_formula`
+- **AND** release workflow does not fall back to `github.token` for the tap update
+
+#### Scenario: post-release verification checks actual tap content
+
+- **WHEN** developer runs `make release-verify VERSION=v0.17.5`
+- **THEN** system renders the expected Homebrew formula from GitHub Release assets
+- **AND** system reads `Formula/kml.rb` from `HiroyukiFuruno/homebrew-katana`
+- **AND** system reads `Formula/kml@0.17.5.rb` from `HiroyukiFuruno/homebrew-katana`
+- **AND** verification fails if either tap file differs from the generated formula
+
+### Requirement: v0.17.5 release readiness SHALL backfill Homebrew versioned formulae
+
+`v0.17.5` の release readiness は、npm / PyPI に合わせて `v0.17.1` 以降の公開済み Homebrew formula を登録しなければならない（SHALL）。
+
+#### Scenario: historical Homebrew formulae are backfilled
+
+- **WHEN** developer prepares `v0.17.5`
+- **THEN** `homebrew-katana` contains `Formula/kml@0.17.1.rb`
+- **AND** `homebrew-katana` contains `Formula/kml@0.17.3.rb`
+- **AND** `homebrew-katana` contains `Formula/kml@0.17.4.rb`
+- **AND** each versioned formula is `keg_only :versioned_formula`
+- **AND** `homebrew-katana` does not add `Formula/kml@0.17.2.rb`

--- a/openspec/changes/v0-17-5-cli-help-and-version-aliases/tasks.md
+++ b/openspec/changes/v0-17-5-cli-help-and-version-aliases/tasks.md
@@ -1,0 +1,49 @@
+# v0.17.5 CLI help and version aliases tasks
+
+## Context
+
+- 2026-05-01: `kml help` が入力ファイルとして扱われ、`help: filesystem error` で失敗することを確認した。
+- 2026-05-01: `kml --help` がヘルプ表示ではなく通常の check 処理へ流れることを確認した。
+- 2026-05-01: CLI の入口動作に関わるため、修正版は `v0.17.5` patch release とする。
+- 2026-05-01: GitHub Release / crates.io / npm / PyPI の最新公開 version は `0.17.4` であり、`v0.17.5` は未使用である。
+- 2026-05-01: `homebrew-katana` の `Formula/kml.rb` は `v0.17.1` のままで、`v0.17.3` / `v0.17.4` の formula が登録されていないことを確認した。
+- 2026-05-01: npm は `0.17.0` / `0.17.3` / `0.17.4`、PyPI は `0.17.0` / `0.17.1` / `0.17.3` / `0.17.4` を公開済みであることを確認した。
+- 2026-05-01: Homebrew の過去 version 登録は、npm / PyPI に合わせて `v0.17.1` 以降の `0.17.1` / `0.17.3` / `0.17.4` を対象とし、npm / PyPI に存在しない `0.17.2` は対象外とする。
+- 2026-05-01: Homebrew tap 更新 token は `HOMEBREW_KATANA_GIT_TOKEN` に固定する。
+
+## Tasks
+
+- [x] 1.1 `kml help`、`kml --help`、`kml -h` を global help として扱う
+- [x] 1.2 `kml <command> --help`、`kml <command> -h` を command help として扱う
+- [x] 1.3 `kml -v` を `kml version` と同じ version alias として扱う
+- [x] 1.4 help / version alias の回帰テストを追加する
+- [x] 2.1 Homebrew formula generator が `kml.rb` と `kml@X.Y.Z.rb` を生成できるようにする
+- [x] 2.2 release workflow が `HOMEBREW_KATANA_GIT_TOKEN` で `homebrew-katana` の current / versioned formula を更新するようにする
+- [x] 2.3 `release-verify` が実際の `homebrew-katana` tap formula と生成 formula の差分を検出するようにする
+- [x] 2.4 `homebrew-katana` に `kml@0.17.1` / `kml@0.17.3` / `kml@0.17.4` を登録する
+- [x] 2.5 versioned formula を `keg_only :versioned_formula` として生成する
+- [x] 3.1 Cargo / npm / PyPI / MCP metadata を `0.17.5` に更新する
+- [x] 3.2 README / distribution docs / wrapper README / CHANGELOG を `0.17.5` に更新する
+- [x] 4.1 `cargo test --test cli_core_contract --locked`
+- [x] 4.2 `cargo test cli::args::tests::parses_cli_parity_commands_and_options --locked`
+- [x] 4.3 `make homebrew-formula-check VERSION=v0.17.5`
+- [x] 4.4 `make ast-lint`
+- [x] 4.5 `make dogfood`
+- [x] 4.6 `scripts/openspec validate release-readiness --strict`
+- [ ] 4.7 `make release-task-ledger-check VERSION=v0.17.5`
+- [x] 4.8 `make release-check VERSION=v0.17.5`
+- [ ] 5.1 `release/v0.17.5` PR を作成し、CI と signed commit verification を確認する
+- [ ] 5.2 merge 後に `make release VERSION=v0.17.5` を実行する
+- [ ] 5.3 `make release-verify VERSION=v0.17.5` で GitHub Release / crates.io / npm / PyPI / wrapper launch / Homebrew tap を確認する
+
+## Quality Score
+
+| 項目 | 最大 | 現在 | 根拠 |
+| --- | ---: | ---: | --- |
+| help behavior | 30 | 30 | global help と command help を実装し、CLI binary 回帰テストを追加済み。 |
+| version alias | 20 | 20 | `version` / `--version` / `-V` / `-v` を同じ出力として検証済み。 |
+| Homebrew tap | 20 | 20 | workflow / verification / 過去 versioned formula 登録を実装済み。 |
+| release metadata | 15 | 15 | Cargo / wrappers / MCP / README / docs / CHANGELOG を `0.17.5` へ更新済み。 |
+| verification | 10 | 9 | CLI tests、Homebrew formula check、ast-lint、dogfood、OpenSpec validation、release-check が成功。 |
+| release execution | 5 | 0 | PR / merge / publish / post-release verification 待ち。 |
+| 合計 | 100 | 94 | task ledger check と公開処理が未完了。 |

--- a/scripts/release/homebrew_formula.py
+++ b/scripts/release/homebrew_formula.py
@@ -17,6 +17,10 @@ class FormulaAsset:
 class HomebrewFormulaTool:
     def __init__(self, args: argparse.Namespace) -> None:
         self.version = self._normalize_version(args.version)
+        self.version_bare = self.version.removeprefix("v")
+        self.formula_name = args.formula_name
+        self.versioned_formula = "@" in self.formula_name
+        self.class_name = self._formula_class_name(args.formula_name)
         self.repo = args.repo
         self.dist_dir = Path(args.dist_dir)
         self.output = Path(args.output)
@@ -30,7 +34,14 @@ class HomebrewFormulaTool:
 
     def check(self) -> None:
         formula = self.output.read_text(encoding="utf-8")
-        required = ["class Kml < Formula", "bin.install \"kml\"", "kml --version"]
+        required = [
+            f"class {self.class_name} < Formula",
+            f"version \"{self.version_bare}\"",
+            "bin.install \"kml\"",
+            "kml --version",
+        ]
+        if self.versioned_formula:
+            required.append("keg_only :versioned_formula")
         missing = [item for item in required if item not in formula]
         missing.extend(self._missing_asset_content(formula))
         if missing:
@@ -71,12 +82,15 @@ class HomebrewFormulaTool:
     def _render_formula(self, assets: list[FormulaAsset]) -> str:
         by_target = {asset.target: asset for asset in assets}
         lines = [
-            "class Kml < Formula",
+            f"class {self.class_name} < Formula",
             "  desc \"Markdownlint-compatible Markdown linter library and CLI\"",
             "  homepage \"https://github.com/HiroyukiFuruno/katana-markdown-linter\"",
+            f"  version \"{self.version_bare}\"",
             "  license \"MIT\"",
             "",
         ]
+        if self.versioned_formula:
+            lines.extend(["  keg_only :versioned_formula", ""])
         mac_assets = [
             by_target.get("aarch64-apple-darwin"),
             by_target.get("x86_64-apple-darwin"),
@@ -131,11 +145,19 @@ class HomebrewFormulaTool:
     def _normalize_version(self, version: str) -> str:
         return version if version.startswith("v") else f"v{version}"
 
+    def _formula_class_name(self, name: str) -> str:
+        base, _, suffix = name.partition("@")
+        class_name = "".join(part.capitalize() for part in base.split("-"))
+        if suffix:
+            class_name += f"AT{''.join(char for char in suffix if char.isalnum())}"
+        return class_name
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("command", choices=("generate", "check"))
     parser.add_argument("--version", required=True)
+    parser.add_argument("--formula-name", default="kml")
     parser.add_argument("--repo", default="HiroyukiFuruno/katana-markdown-linter")
     parser.add_argument("--dist-dir", default="target/binary")
     parser.add_argument("--output", default="target/homebrew/kml.rb")

--- a/scripts/release/update_homebrew_tap.py
+++ b/scripts/release/update_homebrew_tap.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TapFile:
+    path: str
+    source: Path
+    message: str
+
+
+class HomebrewTapUpdater:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.version = self._normalize_version(args.version)
+        self.version_bare = self.version.removeprefix("v")
+        self.repo = args.repo
+        self.branch = args.branch
+        self.token = os.environ.get(args.token_env, "")
+        self.current_formula = Path(args.current_formula)
+        self.versioned_formula = Path(args.versioned_formula)
+        self.formula_dir = args.formula_dir.rstrip("/")
+        if not self.token:
+            raise SystemExit(f"{args.token_env} is required to update {self.repo}.")
+
+    def update(self) -> None:
+        for tap_file in self._tap_files():
+            self._put_file(tap_file)
+
+    def _tap_files(self) -> list[TapFile]:
+        versioned_name = f"kml@{self.version_bare}.rb"
+        return [
+            TapFile(
+                path=f"{self.formula_dir}/kml.rb",
+                source=self.current_formula,
+                message=f"chore: update kml to {self.version_bare}",
+            ),
+            TapFile(
+                path=f"{self.formula_dir}/{versioned_name}",
+                source=self.versioned_formula,
+                message=f"chore: add {versioned_name}",
+            ),
+        ]
+
+    def _put_file(self, tap_file: TapFile) -> None:
+        content = tap_file.source.read_text(encoding="utf-8")
+        payload = {
+            "branch": self.branch,
+            "message": tap_file.message,
+            "content": base64.b64encode(content.encode()).decode(),
+        }
+        current_sha = self._current_sha(tap_file.path)
+        if current_sha:
+            payload["sha"] = current_sha
+        response = self._request("PUT", self._contents_url(tap_file.path), payload)
+        html_url = response.get("content", {}).get("html_url", tap_file.path)
+        print(f"Updated {html_url}")
+
+    def _current_sha(self, path: str) -> str:
+        try:
+            response = self._request("GET", f"{self._contents_url(path)}?ref={self.branch}")
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                return ""
+            raise
+        return str(response.get("sha", ""))
+
+    def _request(self, method: str, url: str, payload: dict | None = None) -> dict:
+        data = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(url, data=data, method=method)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("Authorization", f"Bearer {self.token}")
+        request.add_header("User-Agent", "katana-markdown-linter-release")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+
+    def _contents_url(self, path: str) -> str:
+        return f"https://api.github.com/repos/{self.repo}/contents/{path}"
+
+    def _normalize_version(self, version: str) -> str:
+        return version if version.startswith("v") else f"v{version}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--repo", default="HiroyukiFuruno/homebrew-katana")
+    parser.add_argument("--branch", default="master")
+    parser.add_argument("--formula-dir", default="Formula")
+    parser.add_argument("--current-formula", required=True)
+    parser.add_argument("--versioned-formula", required=True)
+    parser.add_argument("--token-env", default="HOMEBREW_KATANA_GIT_TOKEN")
+    HomebrewTapUpdater(parser.parse_args()).update()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -6,6 +6,8 @@ REPO="${2:-${GH_REPO:-HiroyukiFuruno/katana-markdown-linter}}"
 PACKAGE="${3:-katana-markdown-linter}"
 TAG="v${VERSION_BARE}"
 VERIFY_OUTPUT_DIR="${VERIFY_OUTPUT_DIR:-target/release-verify/${TAG}}"
+HOMEBREW_TAP_REPO="${HOMEBREW_TAP_REPO:-HiroyukiFuruno/homebrew-katana}"
+HOMEBREW_TAP_BRANCH="${HOMEBREW_TAP_BRANCH:-master}"
 TMP_ROOT=""
 
 cleanup() {
@@ -151,6 +153,7 @@ smoke_pypi_wrapper() {
 verify_homebrew_formula() {
   formula_dist_dir="${TMP_ROOT}/homebrew-assets"
   formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml.rb"
+  versioned_formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml@${VERSION_BARE}.rb"
   mkdir -p "${formula_dist_dir}" "$(dirname "${formula_path}")"
   for target in \
     x86_64-unknown-linux-gnu \
@@ -165,14 +168,53 @@ verify_homebrew_formula() {
   done
   python3 scripts/release/homebrew_formula.py generate \
     --version "${TAG}" \
+    --formula-name kml \
     --repo "${REPO}" \
     --dist-dir "${formula_dist_dir}" \
     --output "${formula_path}" >/dev/null
   python3 scripts/release/homebrew_formula.py check \
     --version "${TAG}" \
+    --formula-name kml \
     --repo "${REPO}" \
     --dist-dir "${formula_dist_dir}" \
     --output "${formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py generate \
+    --version "${TAG}" \
+    --formula-name "kml@${VERSION_BARE}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${versioned_formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py check \
+    --version "${TAG}" \
+    --formula-name "kml@${VERSION_BARE}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${versioned_formula_path}" >/dev/null
+  verify_homebrew_tap_formula "Formula/kml.rb" "${formula_path}"
+  verify_homebrew_tap_formula "Formula/kml@${VERSION_BARE}.rb" "${versioned_formula_path}"
+}
+
+verify_homebrew_tap_formula() {
+  tap_path="$1"
+  expected_path="$2"
+  actual_path="${TMP_ROOT}/$(basename "${tap_path}")"
+  raw_url="https://raw.githubusercontent.com/${HOMEBREW_TAP_REPO}/${HOMEBREW_TAP_BRANCH}/${tap_path}"
+  python3 - "${raw_url}" "${actual_path}" <<'PY'
+import sys
+import urllib.request
+
+url, output = sys.argv[1:3]
+with urllib.request.urlopen(url, timeout=30) as response:
+    content = response.read()
+with open(output, "wb") as file:
+    file.write(content)
+PY
+  if ! cmp -s "${expected_path}" "${actual_path}"; then
+    echo "Homebrew tap formula mismatch: ${tap_path} does not match ${TAG}." >&2
+    echo "tap:      ${raw_url}" >&2
+    echo "expected: ${expected_path}" >&2
+    exit 1
+  fi
 }
 
 require_command gh
@@ -201,3 +243,4 @@ echo "pypi_registry_version=${pypi_registry_version}"
 echo "npm_wrapper_version=${npm_wrapper_version}"
 echo "pypi_wrapper_version=${pypi_wrapper_version}"
 echo "homebrew_formula_path=${formula_path}"
+echo "homebrew_versioned_formula_path=${versioned_formula_path}"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.4",
+  "version": "0.17.5",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.4/katana-markdown-linter-0.17.4.mcpb",
-      "version": "0.17.4",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.5/katana-markdown-linter-0.17.5.mcpb",
+      "version": "0.17.5",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -11,11 +11,40 @@ pub enum Command {
     Check,
     Fix,
     Fmt,
+    Help(Option<HelpTopic>),
     InitConfig,
     Lsp,
     Rule(Option<String>),
     Config(ConfigCommand),
     Version,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpTopic {
+    Check,
+    Config,
+    Fix,
+    Fmt,
+    InitConfig,
+    Lsp,
+    Rule,
+    Version,
+}
+
+impl HelpTopic {
+    fn from_command(value: &str) -> Option<Self> {
+        match value {
+            "check" => Some(Self::Check),
+            "config" => Some(Self::Config),
+            "fix" => Some(Self::Fix),
+            "fmt" => Some(Self::Fmt),
+            "init" | "init-config" => Some(Self::InitConfig),
+            "lsp" => Some(Self::Lsp),
+            "rule" => Some(Self::Rule),
+            "version" => Some(Self::Version),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,6 +104,20 @@ impl Default for Cli {
 }
 
 pub fn parse_args(args: Vec<String>) -> Cli {
+    if requests_help(&args) {
+        return Cli {
+            command: Command::Help(help_topic(&args)),
+            ..Cli::default()
+        };
+    }
+
+    if requests_version(&args) {
+        return Cli {
+            command: Command::Version,
+            ..Cli::default()
+        };
+    }
+
     let mut command = Command::Check;
     let mut config = None;
     let mut format = OutputFormat::Text;
@@ -102,7 +145,7 @@ pub fn parse_args(args: Vec<String>) -> Cli {
             "fix" => command = Command::Fix,
             "fmt" => command = Command::Fmt,
             "lsp" => command = Command::Lsp,
-            "version" | "--version" | "-V" => command = Command::Version,
+            "version" | "--version" | "-V" | "-v" => command = Command::Version,
             "rule" => {
                 let rule_id = iter
                     .next_if(|value| !value.starts_with('-'))
@@ -202,6 +245,30 @@ pub fn parse_args(args: Vec<String>) -> Cli {
     }
 }
 
+fn requests_help(args: &[String]) -> bool {
+    matches!(args.first().map(String::as_str), Some("help"))
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+}
+
+fn help_topic(args: &[String]) -> Option<HelpTopic> {
+    if matches!(args.first().map(String::as_str), Some("help")) {
+        return args.get(1).and_then(|value| HelpTopic::from_command(value));
+    }
+
+    args.iter()
+        .find(|value| !value.starts_with('-'))
+        .and_then(|value| HelpTopic::from_command(value))
+}
+
+fn requests_version(args: &[String]) -> bool {
+    matches!(args.first().map(String::as_str), Some("version"))
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--version" | "-V" | "-v"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,6 +343,26 @@ mod tests {
         assert_eq!(parse_args(vec!["fmt".to_string()]).command, Command::Fmt);
         assert_eq!(parse_args(vec!["lsp".to_string()]).command, Command::Lsp);
         assert_eq!(
+            parse_args(vec!["help".to_string()]).command,
+            Command::Help(None)
+        );
+        assert_eq!(
+            parse_args(vec!["--help".to_string()]).command,
+            Command::Help(None)
+        );
+        assert_eq!(
+            parse_args(vec!["-h".to_string()]).command,
+            Command::Help(None)
+        );
+        assert_eq!(
+            parse_args(vec!["check".to_string(), "--help".to_string()]).command,
+            Command::Help(Some(HelpTopic::Check))
+        );
+        assert_eq!(
+            parse_args(vec!["help".to_string(), "fmt".to_string()]).command,
+            Command::Help(Some(HelpTopic::Fmt))
+        );
+        assert_eq!(
             parse_args(vec!["rule".to_string(), "MD013".to_string()]).command,
             Command::Rule(Some("MD013".to_string()))
         );
@@ -300,6 +387,7 @@ mod tests {
             parse_args(vec!["version".to_string()]).command,
             Command::Version
         );
+        assert_eq!(parse_args(vec!["-v".to_string()]).command, Command::Version);
     }
 
     #[test]

--- a/src/cli/workflow/help.rs
+++ b/src/cli/workflow/help.rs
@@ -1,0 +1,192 @@
+use crate::cli::args::HelpTopic;
+
+const GLOBAL_HELP: &str = "\
+katana-markdown-linter (kml)
+
+Usage: kml <command> [options] [paths...]
+
+Commands:
+  check [paths...]          Report Markdown lint diagnostics.
+  fix [paths...]            Apply safe lint fixes.
+  fmt [paths...]            Normalize Markdown layout formatting.
+  rule [RULE_ID]            List rules or show one rule.
+  config get|file|schema    Print resolved config, config path, or JSON schema.
+  init-config               Create a default .markdownlint.json file.
+  lsp                       Run the language server over stdio.
+  version                   Print the kml version.
+  help                      Show this help.
+
+Options:
+  --help, -h                Show this help.
+  --version, -V, -v         Print the kml version.
+  --config <path>           Use a specific markdownlint config file.
+  --file <path>             Add one explicit input file.
+  --output json             Emit JSON output.
+  --format json             Alias for --output json.
+  --locale <locale>, -l     Use localized rule text.
+  --stdin                   Read Markdown from standard input.
+  --fix                     Apply safe fixes during check.
+  --unsafe --yes            Allow unsafe fixes for the fix command.
+  --include <glob>          Include paths matching a glob.
+  --exclude <glob>          Exclude paths matching a glob.
+  --no-ignore               Ignore .gitignore filtering.
+  --include-ignored         Include ignored paths.
+  --include-reserved        Include reserved directories such as node_modules.
+  --force-exclude           Apply exclude globs to explicit inputs.
+  --statistics              Print summary statistics.
+  --quiet                   Suppress text output where supported.
+  --verbose                 Print extra details where supported.
+  --diff                    Print diffs for applied fixes.
+";
+
+const CHECK_HELP: &str = "\
+Usage: kml check [options] [paths...]
+
+Report Markdown lint diagnostics.
+
+Options:
+  --fix                     Apply safe fixes before reporting.
+  --config <path>           Use a specific markdownlint config file.
+  --file <path>             Add one explicit input file.
+  --output json             Emit JSON output.
+  --format json             Alias for --output json.
+  --locale <locale>, -l     Use localized rule text.
+  --stdin                   Read Markdown from standard input.
+  --include <glob>          Include paths matching a glob.
+  --exclude <glob>          Exclude paths matching a glob.
+  --no-ignore               Ignore .gitignore filtering.
+  --include-ignored         Include ignored paths.
+  --include-reserved        Include reserved directories such as node_modules.
+  --force-exclude           Apply exclude globs to explicit inputs.
+  --statistics              Print summary statistics.
+  --quiet                   Suppress text output.
+  --verbose                 Print extra details.
+  --help, -h                Show this help.
+";
+
+const FIX_HELP: &str = "\
+Usage: kml fix [options] [paths...]
+
+Apply safe lint fixes.
+
+Options:
+  --unsafe --yes            Allow unsafe fixes.
+  --config <path>           Use a specific markdownlint config file.
+  --file <path>             Add one explicit input file.
+  --output json             Emit JSON output.
+  --format json             Alias for --output json.
+  --locale <locale>, -l     Use localized rule text.
+  --stdin                   Read Markdown from standard input.
+  --include <glob>          Include paths matching a glob.
+  --exclude <glob>          Exclude paths matching a glob.
+  --no-ignore               Ignore .gitignore filtering.
+  --include-ignored         Include ignored paths.
+  --include-reserved        Include reserved directories such as node_modules.
+  --force-exclude           Apply exclude globs to explicit inputs.
+  --statistics              Print summary statistics.
+  --quiet                   Suppress text output.
+  --verbose                 Print extra details.
+  --diff                    Print diffs for applied fixes.
+  --help, -h                Show this help.
+";
+
+const FMT_HELP: &str = "\
+Usage: kml fmt [options] [paths...]
+
+Normalize Markdown layout formatting.
+
+Options:
+  --config <path>           Use a specific markdownlint config file.
+  --file <path>             Add one explicit input file.
+  --output json             Emit JSON output.
+  --format json             Alias for --output json.
+  --locale <locale>, -l     Use localized rule text.
+  --stdin                   Read Markdown from standard input.
+  --include <glob>          Include paths matching a glob.
+  --exclude <glob>          Exclude paths matching a glob.
+  --no-ignore               Ignore .gitignore filtering.
+  --include-ignored         Include ignored paths.
+  --include-reserved        Include reserved directories such as node_modules.
+  --force-exclude           Apply exclude globs to explicit inputs.
+  --statistics              Print summary statistics.
+  --quiet                   Suppress text output.
+  --verbose                 Print extra details.
+  --diff                    Print diffs for applied formatting.
+  --help, -h                Show this help.
+";
+
+const RULE_HELP: &str = "\
+Usage: kml rule [RULE_ID] [options]
+
+List rules or show one rule.
+
+Options:
+  --output json             Emit JSON output.
+  --format json             Alias for --output json.
+  --locale <locale>, -l     Use localized rule text.
+  --help, -h                Show this help.
+";
+
+const CONFIG_HELP: &str = "\
+Usage: kml config get|file|schema [options]
+
+Print resolved config, config path, or JSON schema.
+
+Options:
+  --config <path>           Use a specific markdownlint config file.
+  --output json             Emit JSON output where supported.
+  --format json             Alias for --output json.
+  --help, -h                Show this help.
+";
+
+const INIT_CONFIG_HELP: &str = "\
+Usage: kml init-config [options]
+
+Create a default .markdownlint.json file.
+
+Options:
+  --config <path>           Create the config file at this path.
+  --help, -h                Show this help.
+";
+
+const LSP_HELP: &str = "\
+Usage: kml lsp
+
+Run the language server over stdio.
+
+Options:
+  --help, -h                Show this help.
+";
+
+const VERSION_HELP: &str = "\
+Usage: kml version
+
+Print the kml version.
+
+Aliases:
+  kml --version
+  kml -V
+  kml -v
+
+Options:
+  --help, -h                Show this help.
+";
+
+pub(crate) fn run_help(topic: Option<HelpTopic>) -> i32 {
+    println!("{}", help_text(topic));
+    0
+}
+
+fn help_text(topic: Option<HelpTopic>) -> &'static str {
+    match topic {
+        Some(HelpTopic::Check) => CHECK_HELP,
+        Some(HelpTopic::Config) => CONFIG_HELP,
+        Some(HelpTopic::Fix) => FIX_HELP,
+        Some(HelpTopic::Fmt) => FMT_HELP,
+        Some(HelpTopic::InitConfig) => INIT_CONFIG_HELP,
+        Some(HelpTopic::Lsp) => LSP_HELP,
+        Some(HelpTopic::Rule) => RULE_HELP,
+        Some(HelpTopic::Version) => VERSION_HELP,
+        None => GLOBAL_HELP,
+    }
+}

--- a/src/cli/workflow/mod.rs
+++ b/src/cli/workflow/mod.rs
@@ -2,6 +2,7 @@ mod check;
 mod common;
 mod config_cmd;
 mod fmt;
+mod help;
 
 use super::args::{Cli, Command};
 use crate::i18n::Locale;
@@ -37,6 +38,7 @@ pub fn run(cli: Cli) -> Result<i32, String> {
             Ok(exit)
         }
         Command::Fmt => fmt::run_fmt(&cli, locale),
+        Command::Help(topic) => Ok(help::run_help(topic)),
         Command::Lsp => {
             crate::lsp::run_stdio()?;
             Ok(0)

--- a/tests/ast_linter/workflow_portability_guard.rs
+++ b/tests/ast_linter/workflow_portability_guard.rs
@@ -12,6 +12,9 @@ struct WorkflowPortabilityGuard {
     attributes: String,
     preflight: String,
     release: String,
+    homebrew_formula: String,
+    homebrew_tap_updater: String,
+    release_verifier: String,
 }
 
 impl WorkflowPortabilityGuard {
@@ -21,6 +24,9 @@ impl WorkflowPortabilityGuard {
             attributes: read_workspace_file(".gitattributes"),
             preflight: read_workspace_file(".github/workflows/release-preflight.yml"),
             release: read_workspace_file(".github/workflows/release.yml"),
+            homebrew_formula: read_workspace_file("scripts/release/homebrew_formula.py"),
+            homebrew_tap_updater: read_workspace_file("scripts/release/update_homebrew_tap.py"),
+            release_verifier: read_workspace_file("scripts/release/verify-release-published.sh"),
         }
     }
 
@@ -30,6 +36,7 @@ impl WorkflowPortabilityGuard {
         self.require_cross_platform_commands(&mut violations);
         self.require_windows_line_ending_guard(&mut violations);
         self.require_unified_rust_cache(&mut violations);
+        self.require_homebrew_tap_update(&mut violations);
         violations
     }
 
@@ -105,6 +112,58 @@ impl WorkflowPortabilityGuard {
             require_contains(violations, path, content, "uses: Swatinem/rust-cache@v2");
             require_contains(violations, path, content, "shared-key:");
             require_contains(violations, path, content, shared_key);
+        }
+    }
+
+    fn require_homebrew_tap_update(&self, violations: &mut Vec<String>) {
+        for required in [
+            "HOMEBREW_KATANA_GIT_TOKEN: ${{ secrets.HOMEBREW_KATANA_GIT_TOKEN }}",
+            "scripts/release/update_homebrew_tap.py",
+            "target/homebrew/kml@${{ steps.version.outputs.version_bare }}.rb",
+        ] {
+            require_contains(
+                violations,
+                ".github/workflows/release.yml",
+                &self.release,
+                required,
+            );
+        }
+        for required in [
+            "versioned_formula = \"@\" in self.formula_name",
+            "keg_only :versioned_formula",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/homebrew_formula.py",
+                &self.homebrew_formula,
+                required,
+            );
+        }
+        for required in [
+            "HOMEBREW_KATANA_GIT_TOKEN",
+            "HiroyukiFuruno/homebrew-katana",
+            "path=f\"{self.formula_dir}/kml.rb\"",
+            "versioned_name = f\"kml@{self.version_bare}.rb\"",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/update_homebrew_tap.py",
+                &self.homebrew_tap_updater,
+                required,
+            );
+        }
+        for required in [
+            "HOMEBREW_TAP_REPO",
+            "raw.githubusercontent.com",
+            "Formula/kml@${VERSION_BARE}.rb",
+            "Homebrew tap formula mismatch",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/verify-release-published.sh",
+                &self.release_verifier,
+                required,
+            );
         }
     }
 }

--- a/tests/cli_core_contract.rs
+++ b/tests/cli_core_contract.rs
@@ -157,6 +157,77 @@ fn config_schema_outputs_json_schema_for_editor_completion() {
 }
 
 #[test]
+fn help_commands_print_usage_without_linting_workspace() {
+    for argument in ["--help", "-h", "help"] {
+        let dir = TestDir::new("help-command");
+        let output = run_kml_in([argument], None, dir.path());
+
+        assert!(
+            output.status.success(),
+            "{argument} should exit successfully\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_contains(&stdout, "Usage: kml <command> [options] [paths...]");
+        assert_contains(&stdout, "Commands:");
+        assert_contains(&stdout, "check");
+        assert_contains(&stdout, "version");
+    }
+}
+
+#[test]
+fn command_help_flags_print_command_usage() {
+    for command_name in [
+        "check",
+        "fix",
+        "fmt",
+        "rule",
+        "config",
+        "init-config",
+        "lsp",
+        "version",
+    ] {
+        for help_flag in ["--help", "-h"] {
+            let dir = TestDir::new("command-help");
+            let output = run_kml_in([command_name, help_flag], None, dir.path());
+
+            assert!(
+                output.status.success(),
+                "{command_name} {help_flag} should exit successfully\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert_contains(&stdout, &format!("Usage: kml {command_name}"));
+        }
+    }
+}
+
+#[test]
+fn version_aliases_print_package_version() {
+    for argument in ["version", "--version", "-V", "-v"] {
+        let dir = TestDir::new("version-command");
+        let output = run_kml_in([argument], None, dir.path());
+
+        assert!(
+            output.status.success(),
+            "{argument} should exit successfully\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout.trim(), env!("CARGO_PKG_VERSION"));
+    }
+}
+
+#[test]
 fn config_validation_reports_schema_property_errors() {
     let dir = TestDir::new("config-schema-validation");
     let file = dir.path().join("bad.md");
@@ -191,8 +262,18 @@ fn config_validation_reports_schema_property_errors() {
 }
 
 fn run_kml<const N: usize>(args: [&str; N], stdin: Option<&str>) -> std::process::Output {
+    let current_dir = std::env::current_dir().expect("current dir should be available");
+    run_kml_in(args, stdin, &current_dir)
+}
+
+fn run_kml_in<const N: usize>(
+    args: [&str; N],
+    stdin: Option<&str>,
+    current_dir: &Path,
+) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_kml"));
     command.args(args);
+    command.current_dir(current_dir);
     if stdin.is_some() {
         command.stdin(Stdio::piped());
     }
@@ -223,6 +304,13 @@ fn stdout_json(output: &std::process::Output) -> Value {
 
 fn file_text(path: &Path) -> String {
     path.display().to_string()
+}
+
+fn assert_contains(text: &str, expected: &str) {
+    assert!(
+        text.contains(expected),
+        "expected output to contain {expected:?}\noutput:\n{text}"
+    );
 }
 
 struct TestDir {

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.4 --version
-npx --yes katana-markdown-linter@0.17.4 check README.md
+npx --yes katana-markdown-linter@0.17.5 --version
+npx --yes katana-markdown-linter@0.17.5 check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "Thin npm launcher for the kml Markdown linter binary.",
   "keywords": [
     "markdown",

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `uvx` for one-off runs:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.4 kml --version
-uvx --from katana-markdown-linter==0.17.4 kml check README.md
+uvx --from katana-markdown-linter==0.17.5 kml --version
+uvx --from katana-markdown-linter==0.17.5 kml check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.4"
+version = "0.17.5"
 description = "Thin Python launcher for the kml Markdown linter binary."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.4"
+__version__ = "0.17.5"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.4"
+            package_version = "0.17.5"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add global and command help entrypoints for kml
- add -v as a version alias and refresh 0.17.5 release metadata
- update Homebrew release automation to publish current and versioned formulae

## Verification
- cargo test --test cli_core_contract --locked
- cargo test cli::args::tests::parses_cli_parity_commands_and_options --locked
- make homebrew-formula-check VERSION=v0.17.5
- make ast-lint
- make dogfood
- scripts/openspec validate release-readiness --strict
- make release-check VERSION=v0.17.5