### PR TITLE
Prevent release workflow double publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,28 +159,6 @@ jobs:
             scripts/release/verify-version.sh "${{ inputs.version }}"
           fi
 
-      - name: Import GPG signing key
-        if: github.event_name == 'pull_request'
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.RELEASE_GPG_KEY }}
-          passphrase: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
-          git_user_signingkey: true
-          git_tag_gpgsign: true
-          git_config_global: true
-
-      - name: Create signed release tag
-        if: github.event_name == 'pull_request'
-        run: |
-          tag="${{ steps.version.outputs.version }}"
-          scripts/release/assert-tag-safe.sh "$tag"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag ${tag} already exists locally."
-          else
-            git tag -s "$tag" -m "Release $tag"
-            git push origin "refs/tags/${tag}"
-          fi
-
       - name: Verify release tag is GitHub Verified
         env:
           GH_TOKEN: ${{ github.token }}
@@ -297,6 +275,7 @@ jobs:
         run: scripts/release/release-notes.sh "${{ steps.version.outputs.version_bare }}" > RELEASE_NOTES.md
 
       - name: Create or update GitHub Release
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.version }}
@@ -328,6 +307,7 @@ jobs:
           fi
 
       - name: Update Homebrew tap
+        if: github.event_name == 'workflow_dispatch'
         env:
           HOMEBREW_KATANA_GIT_TOKEN: ${{ secrets.HOMEBREW_KATANA_GIT_TOKEN }}
         run: |
@@ -338,21 +318,34 @@ jobs:
 
       - name: Publish MCP Registry metadata
         if: >
-          github.event_name != 'workflow_dispatch' ||
-          inputs.publish_crate == true ||
+          github.event_name == 'workflow_dispatch' &&
           (
-            inputs.publish_npm_wrapper != true &&
-            inputs.publish_pypi_wrapper != true
+            inputs.publish_crate == true ||
+            (
+              inputs.publish_npm_wrapper != true &&
+              inputs.publish_pypi_wrapper != true
+            )
           )
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar -xz -f - mcp-publisher
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish "${{ steps.mcpb.outputs.server_json_path }}"
+          set +e
+          publish_output="$(./mcp-publisher publish "${{ steps.mcpb.outputs.server_json_path }}" 2>&1)"
+          publish_status="$?"
+          set -e
+          printf '%s\n' "$publish_output"
+          if [[ "$publish_status" -ne 0 ]]; then
+            if grep -q "cannot publish duplicate version" <<<"$publish_output"; then
+              echo "MCP Registry metadata is already published for this version; continuing."
+            else
+              exit "$publish_status"
+            fi
+          fi
 
       - name: Publish crate
         if: >
-          github.event_name == 'pull_request' ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish_crate == true)
+          github.event_name == 'workflow_dispatch' &&
+          inputs.publish_crate == true
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
@@ -367,16 +360,8 @@ jobs:
     name: Publish npm wrapper
     needs: release
     if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.event.pull_request.head.ref, 'release/v')
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        inputs.publish_npm_wrapper == true
-      )
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish_npm_wrapper == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -413,16 +398,8 @@ jobs:
     name: Publish PyPI wrapper
     needs: release
     if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.event.pull_request.head.ref, 'release/v')
-      ) ||
-      (
-        github.event_name == 'workflow_dispatch' &&
-        inputs.publish_pypi_wrapper == true
-      )
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish_pypi_wrapper == true
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary
- Keep PR-closed release workflow runs as validation-only
- Restrict GitHub Release, Homebrew, MCP Registry, crates.io, npm, and PyPI publication to workflow_dispatch
- Treat duplicate MCP Registry version responses as already-published success for retry safety

## Verification
- make ast-lint
- make release-verify VERSION=v0.17.6
- git diff --check