### PR TITLE
Release v0.18.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.18.7
+
+- Clarifies that unsafe fixes can be used with both `kml fix` and
+  `kml check --fix` through explicit `--unsafe --yes` opt-in.
+- Adds `kml check --fix --unsafe --yes` to the README CLI examples.
+- Adds CLI contract coverage proving `check --fix --unsafe --yes` applies an
+  unsafe `MD036` fix while keeping JSON command identity as `check`.
+- Updates `kml check --help` so the unsafe fix opt-in is discoverable from the
+  command-specific help.
+
 ## v0.17.6
 
 - Treats bare `kml` as global help, keeping `kml help`, `kml --help`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.17.6"
+version = "0.18.7"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.17.6"
+version = "0.18.7"
 
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.6 check README.md
+npx --yes katana-markdown-linter@0.18.7 check README.md
 ~~~
 
 ### PyPI
@@ -128,7 +128,7 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.6 kml check README.md
+uvx --from katana-markdown-linter==0.18.7 kml check README.md
 ~~~
 
 ### GitHub Releases
@@ -137,10 +137,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.6/kml-v0.17.6-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.6/kml-v0.17.6-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.17.6-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.17.6-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.7/kml-v0.18.7-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.7/kml-v0.18.7-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.18.7-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.18.7-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -157,8 +157,8 @@ Use the repository action to run `kml` in CI without writing install steps:
 
 ~~~yaml
 - uses: actions/checkout@v5
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.6
-  with: { version: "0.17.6", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.18.7
+  with: { version: "0.18.7", command: check, paths: "README.md\ndocs", config: .markdownlint.json }
 ~~~
 
 Pin the action tag and `version` together for reproducible runs. The action
@@ -179,6 +179,7 @@ kml fix
 kml fmt
 kml check --fix
 kml fix --unsafe --yes README.md
+kml check --fix --unsafe --yes README.md
 kml check README.md
 kml check --file README.md
 kml check --output json "docs/**/*.md"
@@ -226,8 +227,9 @@ indentation/list-marker spacing. It does not reflow paragraphs, change heading
 or emphasis style, change URL/table style, remove trailing spaces, or apply
 unsafe fixes by default.
 
-Unsafe fixes require explicit opt-in. Interactive use prompts with `[Y/n]`;
-non-interactive use must pass `--unsafe --yes`.
+Unsafe fixes require explicit opt-in for `fix` and `check --fix`.
+Interactive use prompts with `[Y/n]`; non-interactive use must pass
+`--unsafe --yes`.
 
 `--output json` is the preferred JSON output flag. `--format json` remains a compatibility alias.
 Fix-mode JSON includes per-file `fix_details` so applied rules can be compared
@@ -434,7 +436,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-make mcpb-smoke VERSION=v0.17.6
+make mcpb-smoke VERSION=v0.18.7
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,8 +19,8 @@ use the release tag directly:
 
 ~~~yaml
 - uses: actions/checkout@v6
-- uses: HiroyukiFuruno/katana-markdown-linter@v0.17.6
-  with: { version: "0.17.6", command: check, paths: "README.md\ndocs" }
+- uses: HiroyukiFuruno/katana-markdown-linter@v0.18.7
+  with: { version: "0.18.7", command: check, paths: "README.md\ndocs" }
 ~~~
 
 Pin both the action tag and the crate `version` input. The action installs the
@@ -37,7 +37,7 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.6-aarch64-apple-darwin.tar.gz` and always ship a neighboring
+`kml-v0.18.7-aarch64-apple-darwin.tar.gz` and always ship a neighboring
 `.sha256` file. The Homebrew formula is generated from the same release assets
 and is published to `HiroyukiFuruno/homebrew-katana` by the release workflow
 with `HOMEBREW_KATANA_GIT_TOKEN`. Each release updates the latest `kml`

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -22,7 +22,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    make mcpb-smoke VERSION=v0.17.6
+    make mcpb-smoke VERSION=v0.18.7
 
 ## Run
 
@@ -152,17 +152,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.6.mcpb
-    katana-markdown-linter-0.17.6.mcpb.sha256
+    katana-markdown-linter-0.18.7.mcpb
+    katana-markdown-linter-0.18.7.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`make mcp-server-json VERSION=v0.17.6` renders `target/mcpb/server.json` with
+`make mcp-server-json VERSION=v0.18.7` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    make server-json-validate VERSION=v0.17.6
+    make server-json-validate VERSION=v0.18.7
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.17.6",
+  "version": "0.18.7",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -42,6 +42,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.18.1`: VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
 - `v0.18.3`: editor extension hardening を進める。VS Code / Zed の install docs、smoke tests、release verification、将来の Neovim docs-only sample をまとめて整える。
+- `v0.18.7`: `check --fix --unsafe --yes` の既存挙動を CLI help と README で発見できるようにし、unsafe fix opt-in の契約を回帰テストで固定する。
 
 | Priority | Work Area | Change | Why Now |
 | --- | --- | --- | --- |
@@ -50,6 +51,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | P1 | VS Code extension MVP for `v0.18.1` | `v0-18-1-vscode-extension-mvp` | The LSP entrypoint and schema command already exist. VS Code should become the first real editor target because the extension surface can stay thin: launch `kml lsp`, associate the config schema, and expose diagnostics / format / safe quick-fix without moving lint logic into the extension. |
 | P2 | Zed extension MVP for `v0.18.2` | `v0-18-2-zed-extension-mvp` | Zed is the second target. Keep it behind VS Code so the shared `kml lsp` contract is already stable, then validate only the Zed-specific extension boundary and installation flow. |
 | P2 | Editor extension hardening for `v0.18.3` | `v0-18-3-editor-extension-hardening` | After both target editors have MVPs, harden install docs, smoke tests, release verification, marketplace packaging, and optional docs-only Neovim configuration without expanding the core engine. |
+| P0 | CLI unsafe fix help for `v0.18.7` | `v0-18-7-cli-unsafe-fix-help` | `check --fix --unsafe --yes` already works but was not discoverable from `kml check --help`; release this help contract fix before further schema/editor work. |
 | P2 | Release verification hardening | TBD: `release-verification-hardening` | `v0.17.0` exposed that external registry verification is broader than GitHub Release + crates.io. Add npm, PyPI, wrapper launch, and tap formula checks to the post-release verification path before the next distribution release. |
 | Done | Golden and edge coverage for `v0.4.0` | `golden-edge-coverage-expansion` | Completed for `v0.4.0`; dashboard now derives golden status from the locked baseline and records edge coverage. |
 | Done | Safe check/fix expansion for `v0.4.0` | `safe-fix-strategy-expansion` | Completed for `v0.4.0`; `MD005` and `MD030` safe subsets are locked, while `MD060` remains diagnostic/manual-required because official metadata marks it non-fixable. |

--- a/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/design.md
+++ b/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/design.md
@@ -1,0 +1,32 @@
+# v0.18.7 CLI unsafe fix help design
+
+## 方針
+
+既存の修正実行経路は維持し、CLI help とテスト契約だけを補強する。
+
+`check --fix` は `fix_mode=true` で `run_check_like` を通り、`resolve_unsafe_fix_policy` と `apply_fixes_until_stable` を共有している。
+そのため `--unsafe --yes` の処理を新設せず、既存経路が `check --fix` でも使えることをテストで固定する。
+
+## CLI help
+
+`kml check --help` の options に `--unsafe --yes` を追加する。
+global help は `fix command` 限定の表現をやめ、`fix or check --fix` として説明する。
+
+日本語 help も同じ内容に更新する。
+
+## 回帰テスト
+
+`MD036` は unsafe fix を持つ既存ルールなので、`**Important**` を `# Important` に変換する fixture で確認する。
+
+確認する契約:
+
+- `kml check --fix --unsafe --yes --output json` が成功する
+- file content が unsafe fix 後の内容になる
+- JSON の `command` は `check` のまま
+- `fix_details` に `MD036` が記録される
+- `kml check --help` に `--unsafe --yes` が表示される
+
+## リリース判断
+
+これは既存機能の入口説明と契約テストの欠落修正であり、挙動追加ではない。
+ただし CLI の安全性に関わる help 契約のため、`v0.18.7` の通常リリースとして扱う。

--- a/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/proposal.md
+++ b/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/proposal.md
@@ -1,0 +1,27 @@
+# v0.18.7 CLI unsafe fix help proposal
+
+## 目的
+
+`kml check --fix --unsafe --yes` が利用できることを CLI help と README から分かるようにする。
+
+## 背景
+
+`fix` と `check --fix` は同じ修正処理を共有しており、unsafe fix も `--unsafe --yes` で明示的に許可できる。
+しかし `kml check --help` には `--unsafe --yes` が表示されず、README の例も `kml fix --unsafe --yes` に偏っていた。
+
+この状態では利用者が `check --fix` では unsafe fix を使えないと誤解するため、CLI 契約と公開ドキュメントを揃える。
+
+## 範囲
+
+- `kml check --help` に `--unsafe --yes` を表示する
+- global help の説明を `fix` と `check --fix` の両方に合わせる
+- `check --fix --unsafe --yes` が unsafe fix を適用する CLI 回帰テストを追加する
+- README の CLI usage に `check --fix --unsafe --yes` の例を追加する
+- `0.18.7` の release metadata と release notes を更新する
+
+## 範囲外
+
+- unsafe fix の対象ルール追加
+- confirmation prompt の仕様変更
+- `fix` と `check --fix` の挙動差分追加
+- `v0.18.0` 以降の schema / editor extension change の実装

--- a/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/specs/release-readiness/spec.md
+++ b/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/specs/release-readiness/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: v0.18.7 release readiness SHALL document unsafe fix opt-in for check --fix
+
+`v0.18.7` の release readiness は、`check --fix` でも unsafe fix の明示 opt-in が使えることを CLI help と公開 README で説明しなければならない（SHALL）。
+
+#### Scenario: command help documents unsafe fix opt-in
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** system runs `kml check --help`
+- **AND** command exits with code `0`
+- **AND** command help includes `--unsafe --yes`
+- **AND** command help explains that unsafe fixes are allowed only when used with `--fix`
+
+#### Scenario: check fix applies unsafe fixes with explicit approval
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** system runs `kml check --fix --unsafe --yes` against an unsafe-fixable `MD036` fixture
+- **AND** command exits with code `0`
+- **AND** command applies the unsafe fix
+- **AND** JSON output keeps `command` as `check`
+- **AND** JSON output records the applied `MD036` fix detail
+
+#### Scenario: public CLI usage documents both fix entrypoints
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** README includes `kml fix --unsafe --yes`
+- **AND** README includes `kml check --fix --unsafe --yes`
+- **AND** README explains that unsafe fixes require explicit opt-in for both `fix` and `check --fix`

--- a/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/tasks.md
+++ b/openspec/changes/archive/2026-05-01-v0-18-7-cli-unsafe-fix-help/tasks.md
@@ -1,0 +1,41 @@
+# v0.18.7 CLI unsafe fix help tasks
+
+## Context
+
+- 2026-05-01: `kml fix --unsafe --yes` は README と `kml fix --help` に表示されていた。
+- 2026-05-01: `kml check --fix --unsafe --yes` は実装上は動作するが、`kml check --help` に表示されないことを確認した。
+- 2026-05-01: `MD036` の unsafe fix で `check --fix --unsafe --yes` が実際に適用されることを手元で確認した。
+- 2026-05-01: CLI の安全性に関わる opt-in 導線のため、`v0.18.7` の release blocker として扱う。
+
+## Tasks
+
+- [x] 1.1 `kml check --help` に `--unsafe --yes` を追加する
+- [x] 1.2 global help の `--unsafe --yes` 説明を `fix` と `check --fix` の両方に合わせる
+- [x] 1.3 日本語 help も同じ内容に更新する
+- [x] 1.4 `check --fix --unsafe --yes` が unsafe fix を適用する CLI 回帰テストを追加する
+- [x] 1.5 `kml check --help` に unsafe fix opt-in が表示される CLI 回帰テストを追加する
+- [x] 1.6 README の CLI usage に `kml check --fix --unsafe --yes README.md` を追加する
+- [x] 2.1 Cargo / npm / PyPI / MCP metadata を `0.18.7` に更新する
+- [x] 2.2 README / docs / CHANGELOG を `0.18.7` に更新する
+- [x] 3.1 `cargo test --test cli_core_contract unsafe`
+- [x] 3.2 `cargo test --test cli_core_contract`
+- [x] 3.3 `make fmt-check`
+- [x] 3.4 `make ast-lint`
+- [x] 3.5 `make dogfood`
+- [x] 3.6 `make lint`
+- [x] 3.7 `cargo test --workspace --locked`
+- [x] 3.8 `git diff --check`
+- [x] 3.9 `make release-check VERSION=v0.18.7`
+- [x] 3.10 `make release-task-ledger-check VERSION=v0.18.7`
+
+## Quality Score
+
+| 項目 | 最大 | 現在 | 根拠 |
+| --- | ---: | ---: | --- |
+| CLI help | 25 | 25 | `check --help` と global help に unsafe fix opt-in を表示した。 |
+| unsafe fix contract | 25 | 25 | `check --fix --unsafe --yes` が `MD036` の unsafe fix を適用する回帰テストを追加した。 |
+| documentation | 15 | 15 | README の CLI usage と unsafe fix 説明を `fix` / `check --fix` 両対応に更新した。 |
+| release metadata | 15 | 15 | Cargo / wrappers / MCP / README / docs / CHANGELOG を `0.18.7` へ更新した。 |
+| verification | 15 | 15 | 狭い CLI 契約、fmt-check、ast-lint、dogfood、lint、workspace test、diff check、release-check が成功。 |
+| ledger | 5 | 5 | `make release-task-ledger-check VERSION=v0.18.7` の対象形式へ更新済み。 |
+| 合計 | 100 | 100 | release 前 gate 完了。 |

--- a/openspec/specs/release-readiness/spec.md
+++ b/openspec/specs/release-readiness/spec.md
@@ -539,3 +539,31 @@ release readiness は、Cargo install の既存導入契約を壊してはなら
 - **AND** `homebrew-katana` contains `Formula/kml@0.17.4.rb`
 - **AND** each versioned formula is `keg_only :versioned_formula`
 - **AND** `homebrew-katana` does not add `Formula/kml@0.17.2.rb`
+
+### Requirement: v0.18.7 release readiness SHALL document unsafe fix opt-in for check --fix
+
+`v0.18.7` の release readiness は、`check --fix` でも unsafe fix の明示 opt-in が使えることを CLI help と公開 README で説明しなければならない（SHALL）。
+
+#### Scenario: command help documents unsafe fix opt-in
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** system runs `kml check --help`
+- **AND** command exits with code `0`
+- **AND** command help includes `--unsafe --yes`
+- **AND** command help explains that unsafe fixes are allowed only when used with `--fix`
+
+#### Scenario: check fix applies unsafe fixes with explicit approval
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** system runs `kml check --fix --unsafe --yes` against an unsafe-fixable `MD036` fixture
+- **AND** command exits with code `0`
+- **AND** command applies the unsafe fix
+- **AND** JSON output keeps `command` as `check`
+- **AND** JSON output records the applied `MD036` fix detail
+
+#### Scenario: public CLI usage documents both fix entrypoints
+
+- **WHEN** developer prepares `v0.18.7`
+- **THEN** README includes `kml fix --unsafe --yes`
+- **AND** README includes `kml check --fix --unsafe --yes`
+- **AND** README explains that unsafe fixes require explicit opt-in for both `fix` and `check --fix`

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.17.6",
+  "version": "0.18.7",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.17.6/katana-markdown-linter-0.17.6.mcpb",
-      "version": "0.17.6",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.7/katana-markdown-linter-0.18.7.mcpb",
+      "version": "0.18.7",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/workflow/help.rs
+++ b/src/cli/workflow/help.rs
@@ -28,7 +28,7 @@ Options:
   --stdin                   Read Markdown from standard input.
   --fix                     Apply safe fixes during check.
   --ignore-config-errors    Continue after ignoring invalid config entries.
-  --unsafe --yes            Allow unsafe fixes for the fix command.
+  --unsafe --yes            Allow unsafe fixes for fix or check --fix.
   --include <glob>          Include paths matching a glob.
   --exclude <glob>          Exclude paths matching a glob.
   --no-ignore               Ignore .gitignore filtering.
@@ -68,7 +68,7 @@ katana-markdown-linter (kml)
   --stdin                   標準入力から Markdown を読みます。
   --fix                     check 中に安全な修正を適用します。
   --ignore-config-errors    不正な設定項目を無視して続行します。
-  --unsafe --yes            fix コマンドで unsafe fix を許可します。
+  --unsafe --yes            fix または check --fix で unsafe fix を許可します。
   --include <glob>          指定 glob に一致する path を含めます。
   --exclude <glob>          指定 glob に一致する path を除外します。
   --no-ignore               .gitignore の絞り込みを無視します。
@@ -88,6 +88,7 @@ Report Markdown lint diagnostics.
 
 Options:
   --fix                     Apply safe fixes before reporting.
+  --unsafe --yes            Allow unsafe fixes when used with --fix.
   --config <path>           Use a specific markdownlint config file.
   --ignore-config-errors    Continue after ignoring invalid config entries.
   --file <path>             Add one explicit input file.
@@ -114,6 +115,7 @@ Markdown の lint 診断を表示します。
 
 オプション:
   --fix                     報告前に安全な修正を適用します。
+  --unsafe --yes            --fix と併用して unsafe fix を許可します。
   --config <path>           指定した markdownlint 設定ファイルを使います。
   --ignore-config-errors    不正な設定項目を無視して続行します。
   --file <path>             入力ファイルを明示的に追加します。

--- a/tests/cli_core_contract.rs
+++ b/tests/cli_core_contract.rs
@@ -114,6 +114,48 @@ fn fix_json_reports_remaining_unsafe_diagnostics_without_applying_them() {
 }
 
 #[test]
+fn check_fix_unsafe_yes_applies_unsafe_fixes() {
+    let dir = TestDir::new("check-fix-unsafe-yes");
+    let file = dir.path().join("bad.md");
+    let config = dir.path().join(".markdownlint.json");
+    fs::write(&file, "**Important**\n\nText\n").expect("fixture should be written");
+    fs::write(&config, "{ \"default\": false, \"MD036\": true }\n")
+        .expect("config should be written");
+
+    let output = run_kml(
+        [
+            "check",
+            "--fix",
+            "--unsafe",
+            "--yes",
+            "--output",
+            "json",
+            "--config",
+            file_text(&config).as_str(),
+            file_text(&file).as_str(),
+        ],
+        None,
+    );
+
+    assert!(
+        output.status.success(),
+        "check --fix --unsafe --yes should apply unsafe fixes\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&file).expect("fixture should be readable"),
+        "# Important\n\nText\n"
+    );
+    let json = stdout_json(&output);
+    assert_eq!(json["command"], "check");
+    assert_eq!(json["files"][0]["changed"], true);
+    assert_eq!(json["files"][0]["applied_fixes"], 1);
+    assert_eq!(json["files"][0]["fix_details"][0]["rule_id"], "MD036");
+    assert_eq!(json["summary"]["total_issues"], 0);
+}
+
+#[test]
 fn fmt_json_uses_formatter_contract_without_lint_fixing_heading_text() {
     let dir = TestDir::new("fmt-json-contract");
     let file = dir.path().join("bad.md");
@@ -195,6 +237,22 @@ fn help_commands_print_usage_without_linting_workspace() {
         assert_contains(&stdout, "check");
         assert_contains(&stdout, "version");
     }
+}
+
+#[test]
+fn check_help_documents_unsafe_fix_opt_in() {
+    let dir = TestDir::new("check-help-unsafe-fix");
+    let output = run_kml_in(["check", "--help"], None, dir.path());
+
+    assert!(
+        output.status.success(),
+        "check --help should exit successfully\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_contains(&stdout, "--unsafe --yes");
+    assert_contains(&stdout, "Allow unsafe fixes when used with --fix.");
 }
 
 #[test]

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.17.6 --version
-npx --yes katana-markdown-linter@0.17.6 check README.md
+npx --yes katana-markdown-linter@0.18.7 --version
+npx --yes katana-markdown-linter@0.18.7 check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.17.6",
+  "version": "0.18.7",
   "description": "Thin npm launcher for the kml Markdown linter binary with localized CLI help.",
   "keywords": [
     "markdown",

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `uvx` for one-off runs:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.17.6 kml --version
-uvx --from katana-markdown-linter==0.17.6 kml check README.md
+uvx --from katana-markdown-linter==0.18.7 kml --version
+uvx --from katana-markdown-linter==0.18.7 kml check README.md
 ~~~
 
 ## Basic Usage

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.17.6"
+version = "0.18.7"
 description = "Thin Python launcher for the kml Markdown linter binary with localized CLI help."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.6"
+__version__ = "0.18.7"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -95,7 +95,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.6"
+            package_version = "0.18.7"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- release v0.18.7 metadata across Cargo, npm, PyPI, MCP, docs, and changelog
- document unsafe fix opt-in for both `kml fix` and `kml check --fix`
- add CLI contract coverage for `check --fix --unsafe --yes`
- sync and archive the v0.18.7 OpenSpec change

## Verification
- `cargo test --test cli_core_contract unsafe`
- `cargo test --test cli_core_contract`
- `make fmt-check`
- `make ast-lint`
- `make dogfood`
- `make lint`
- `cargo test --workspace --locked`
- `git diff --check`
- `make release-check VERSION=v0.18.7`
- `make release-task-ledger-check VERSION=v0.18.7`