### PR TITLE
Fix npm publish tag for corrective releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,7 @@ jobs:
         run: make npm-package-check
 
       - name: Publish npm wrapper
-        run: npm publish --access public --provenance
+        run: npm publish --tag latest --access public --provenance
         working-directory: wrappers/npm
 
   publish-pypi-wrapper:

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -361,7 +361,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         (
             ".github/workflows/release.yml",
             &workflow,
-            "npm publish --access public --provenance",
+            "npm publish --tag latest --access public --provenance",
         ),
         (".github/workflows/release.yml", &workflow, "Publish PyPI wrapper"),
         (".github/workflows/release.yml", &workflow, "environment: pypi"),


### PR DESCRIPTION
## Summary
- Explicitly publish the npm wrapper with `--tag latest`
- Keep the AST guard aligned so corrective releases below a yanked higher version can publish

## Verification
- make ast-lint
- git diff --check

## Context
The v0.17.7 release workflow failed at npm publish because the yanked accidental 0.18.7 version is higher. npm requires an explicit tag for publishing a lower corrective version as latest.