### PR TITLE
fix(release): strip prerelease suffix for release note build

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Wrapper publish gate
         run: just wrapper-publish-gate
 
+      - name: Editor publish gate
+        run: just editor-publish-gate
+
       - name: Dogfood
         run: just dogfood
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,14 @@ jobs:
             --output "target/homebrew/kml@${{ steps.version.outputs.version_bare }}.rb"
 
       - name: Build release notes
-        run: scripts/release/release-notes.sh "${{ steps.version.outputs.version_bare }}" > RELEASE_NOTES.md
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            notes_version="${{ steps.version.outputs.cargo_version }}"
+          else
+            notes_version="${{ steps.version.outputs.version_bare }}"
+          fi
+
+          scripts/release/release-notes.sh "$notes_version" > RELEASE_NOTES.md
 
       - name: Create or update GitHub Release
         if: github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.18.4
+
+- Finalizes the release gate for editor extensions by explicitly defining `published` and `deferred` states.
+- Integrates editor publication gates into `just release-check` and `just release-verify`.
+- Updates the release runbook with state interpretation and stop conditions for VS Code and Zed extensions.
+- Synchronizes project version to `v0.18.4` across all distribution channels.
+
 ## v0.18.3
 
 - Hardens editor extensions for VS Code and Zed with version compatibility checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.18.3"
+version = "0.18.4"
 
 edition = "2021"
 license = "MIT"

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -47,6 +47,7 @@ For binary distribution changes, the release check includes:
 - `just npm-publish-target-check`
 - `just pypi-package-check`
 - `just wrapper-publish-gate`
+- `just editor-publish-gate`
 
 If validating upstream drift locally, clone upstream docs and run:
 
@@ -218,6 +219,18 @@ Use these trusted publisher settings:
 | --- | --- | --- | --- | --- | --- |
 | npm | `katana-markdown-linter` | `HiroyukiFuruno` | `katana-markdown-linter` | `release.yml` | Leave empty unless npm is configured with a GitHub environment |
 | PyPI | `katana-markdown-linter` | `HiroyukiFuruno` | `katana-markdown-linter` | `release.yml` | `pypi` |
+
+## Editor Extension Publication
+
+Editor extensions for VS Code and Zed are thin wrappers around `kml linter`. They follow the same versioning as the core linter but may have independent publication schedules.
+
+Keep these conditions true before publishing an editor extension:
+
+- `just editor-extension-check` passes for both `editors/vscode` and `editors/zed`.
+- `just editor-publish-gate` confirms whether publication is enabled or deferred. Local checks always defer publication.
+- Release verification (`just release-verify`) reports `published` or `deferred` status based on `PUBLISH_VSCODE_EXTENSION` and `PUBLISH_ZED_EXTENSION` flags.
+
+If an extension publication is deferred, it will not block the core linter release. However, once enabled, publication must succeed before the release can be considered complete.
 
 The PyPI project name must match `wrappers/python/pyproject.toml`. Change the
 wrapper metadata first if the package name is changed before publication.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-katana-markdown-linter",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-katana-markdown-linter",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "dependencies": {
         "vscode-languageclient": "^8.1.0"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-katana-markdown-linter",
   "displayName": "KatanA Markdown Linter",
   "description": "VS Code extension for KatanA Markdown Linter (kml)",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "publisher": "HiroyukiFuruno",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "katana-markdown-linter-zed"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter-zed"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "katana-markdown-linter"
 name = "KatanA Markdown Linter"
-version = "0.18.3"
+version = "0.18.4"
 schema_version = 1
 authors = ["Hiroyuki Furuno <hfuruno0114@gmail.com>"]
 description = "Fast Markdown linter and formatter (kml)"

--- a/just/release.just
+++ b/just/release.just
@@ -53,6 +53,10 @@ pypi-package-check:
 wrapper-publish-gate:
     scripts/release/wrapper-publish-gate.sh
 
+# Verify editor extension publish flags stay deferred outside trusted publishing
+editor-publish-gate:
+    scripts/release/editor-publish-gate.sh
+
 # Run release-equivalent tests with all optional features
 release-test:
     cargo test --all-features --locked
@@ -75,7 +79,7 @@ release-recover: bad-version-required
     python3 scripts/release/recover-accidental-release.py --bad-version "{{BAD_VERSION}}" $replacement_arg --execute
 
 # Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
-release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate document-answer-fix public-confidence editor-extension-check
+release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check
     cargo publish --dry-run --locked --allow-dirty
     cargo install --path . --locked --force --root "${TMPDIR:-/tmp}/kml-release-install-check" --bin kml
     "${TMPDIR:-/tmp}/kml-release-install-check/bin/kml" init-config --config "${TMPDIR:-/tmp}/kml-release-install-check/.markdownlint.json"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/active-roadmap.md
+++ b/openspec/changes/active-roadmap.md
@@ -41,8 +41,8 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 - `v0.18.0`: (released) config schema publication を product surface として固める。versioned schema URL、schema regression tests、editor validation docs を release gate に含める。
 - `v0.18.1`: (released) VS Code extension MVP を進める。`kml lsp` と config schema を共有エンジンにし、VS Code 側は薄い起動ラッパー（thin wrapper）として diagnostics / format / safe quick-fix を公開する。
 - `v0.18.2`: Zed extension MVP を進める。VS Code extension の実装判断を再利用しつつ、Zed の language server extension 境界で `kml lsp` を起動できることを小さく検証する。
-- `v0.18.3`: editor extension hardening を進める。VS Code / Zed の install docs、smoke tests、release verification、将来の Neovim docs-only sample をまとめて整える。
-- `v0.18.4`: v0.18.4 では release gate 最終化（editor artifact state の明示）を行う。
+- `v0.18.3`: (released) editor extension hardening を進める。VS Code / Zed の install docs、smoke tests、release verification、将来の Neovim docs-only sample をまとめて整える。
+- `v0.18.4`: (released) v0.18.4 では release gate 最終化（editor artifact state の明示）を行う。
 - `v0.18.5`: v0.18.5 では release verification hardening（partial publish fail-fast）を入れる。
 - `v0.18.6`: v0.18.6 では marketplace 公開の事前条件（account/publisher/package）と docs-only 方針を実装可レベルで固定する。
 - `v0.18.7`: `v0.18.7` 再公開不能事故を受け、`v0.18.x` は `check`/`fix`/`format` の実害解消 bugfix を優先。
@@ -56,7 +56,7 @@ This file maps visible post-`v0.3.0` work areas to OpenSpec changes.
 | Done | VS Code extension MVP for `v0.18.1` | `v0-18-1-vscode-extension-mvp` | Completed for `v0.18.1`; thin VS Code extension wrapper launches `kml lsp` and associates published config schema. |
 | P2 | Zed extension MVP for `v0.18.2` | `v0-18-2-zed-extension-mvp` | Zed is the second target. Keep it behind VS Code so the shared `kml lsp` contract is already stable, then validate only the Zed-specific extension boundary and installation flow. |
 | Done | Editor extension hardening for `v0.18.3` | `v0-18-3-editor-extension-hardening` | Completed for `v0.18.3`; docs/smoke test / release verification と Neovim docs-only 方針の土台を固めた。 |
-| P0 | Release gate finalization for `v0.18.4` | `v0-18-4-editor-release-gate-finalization` | `release-verify` で editor artifact の published/deferred を固定し、公開証跡を release gate へ結合する。 |
+| Done | Release gate finalization for `v0.18.4` | `v0-18-4-editor-release-gate-finalization` | `release-verify` で editor artifact の published/deferred を固定し、公開証跡を release gate へ結合する。 |
 | P0 | release verification hardening for `v0.18.5` | `v0-18-5-release-verification-hardening` | partial publish（GitHub Release 先行など）を fail-fast にし、workflow と release-check の分岐整合を固定する。 |
 | P1 | Publish preconditions for `v0.18.6` | `v0-18-6-editor-publication-prerequisites` | marketplace 前提条件（account / publisher / package）と docs-only 方針を実装可レベルへ整える。 |
 | P0 | Release safety policy for v0.18/v0.19 | `v0-19-0-editor-publication-gate` | `v0.18.7` 再公開不能事故を前提に、同一版再 publish 拒否・manual publish guard・`v0.19.0` の Go/No-Go を固定する。 |

--- a/openspec/changes/v0-18-4-editor-release-gate-finalization/tasks.md
+++ b/openspec/changes/v0-18-4-editor-release-gate-finalization/tasks.md
@@ -2,16 +2,16 @@
 
 ## Definition of Ready
 
-- [ ] 0.1 `v0.18.3` の editor extension hardening が完了している
-- [ ] 0.2 `release-verify` の対象 artifact が確定している
+- [x] 0.1 `v0.18.3` の editor extension hardening が完了している
+- [x] 0.2 `release-verify` の対象 artifact が確定している
 
 ## Gate Finalization
 
-- [ ] 1.1 `release-verify` 出力に editor artifact の `published` / `deferred` を追加する
-- [ ] 1.2 `release-check` が同じ定義を参照するように固定する
-- [ ] 1.3 `docs/release-runbook.md` に state 解釈と停止条件を明文化する
+- [x] 1.1 `release-verify` 出力に editor artifact の `published` / `deferred` を追加する
+- [x] 1.2 `release-check` が同じ定義を参照するように固定する
+- [x] 1.3 `docs/release-runbook.md` に state 解釈と停止条件を明文化する
 
 ## Definition of Done
 
-- [ ] 2.1 `v0.18.4` 判定時に `published` / `deferred` が説明可能である
-- [ ] 2.2 `active-roadmap` と `v0-18-4-editor-release-gate-finalization`, `v0-18-5-release-verification-hardening`, `v0-18-6-editor-publication-prerequisites` の状態定義が一致している
+- [x] 2.1 `v0.18.4` 判定時に `published` / `deferred` が説明可能である
+- [x] 2.2 `active-roadmap` と `v0-18-4-editor-release-gate-finalization`, `v0-18-5-release-verification-hardening`, `v0-18-6-editor-publication-prerequisites` の状態定義が一致している

--- a/scripts/release/editor-publish-gate.sh
+++ b/scripts/release/editor-publish-gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VSCODE_ENABLED="${PUBLISH_VSCODE_EXTENSION:-false}"
+ZED_ENABLED="${PUBLISH_ZED_EXTENSION:-false}"
+
+require_trusted_publishing_context() {
+  registry="$1"
+  if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
+    echo "${registry} extension publish requires GitHub Actions. Local release checks never publish to marketplaces." >&2
+    exit 1
+  fi
+  if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+    echo "${registry} extension publish requires id-token: write so the marketplace can exchange a GitHub OIDC token." >&2
+    exit 1
+  fi
+}
+
+if [[ "$VSCODE_ENABLED" == "true" ]]; then
+  require_trusted_publishing_context "VS Code"
+  echo "VS Code extension publish enabled."
+else
+  echo "VS Code extension publish deferred."
+fi
+
+if [[ "$ZED_ENABLED" == "true" ]]; then
+  require_trusted_publishing_context "Zed"
+  echo "Zed extension publish enabled."
+else
+  echo "Zed extension publish deferred."
+fi

--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -150,6 +150,35 @@ smoke_pypi_wrapper() {
   fi
 }
 
+verify_vscode_extension() {
+  if [[ "${PUBLISH_VSCODE_EXTENSION:-false}" == "true" ]]; then
+    # Check VS Code Marketplace availability
+    if curl -sSfL "https://marketplace.visualstudio.com/items?itemName=HiroyukiFuruno.vscode-katana-markdown-linter" > /dev/null 2>&1; then
+      echo "vscode_extension_status=published"
+    else
+      echo "VS Code extension publication check failed: extension not found in marketplace." >&2
+      exit 1
+    fi
+  else
+    echo "vscode_extension_status=deferred"
+  fi
+}
+
+verify_zed_extension() {
+  if [[ "${PUBLISH_ZED_EXTENSION:-false}" == "true" ]]; then
+    # Check Zed Extension Registry availability
+    # Note: Zed extension registry URL pattern is based on current zed ecosystem
+    if curl -sSfL "https://extensions.zed.dev/extensions/katana-markdown-linter" > /dev/null 2>&1; then
+       echo "zed_extension_status=published"
+    else
+      echo "Zed extension publication check failed: extension not found in registry." >&2
+      exit 1
+    fi
+  else
+    echo "zed_extension_status=deferred"
+  fi
+}
+
 verify_homebrew_formula() {
   formula_dist_dir="${TMP_ROOT}/homebrew-assets"
   formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml.rb"
@@ -231,6 +260,8 @@ verify_npm_registry
 verify_pypi_registry
 smoke_npm_wrapper
 smoke_pypi_wrapper
+verify_vscode_extension
+verify_zed_extension
 verify_homebrew_formula
 
 echo "tag_target=${local_target}"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.18.3",
+  "version": "0.18.4",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.3/katana-markdown-linter-0.18.3.mcpb",
-      "version": "0.18.3",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.4/katana-markdown-linter-0.18.4.mcpb",
+      "version": "0.18.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -314,7 +314,7 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
             &release_just,
             "scripts/release/recover-accidental-release.py",
         ),
-        ("just/release.just", &release_just, "release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate document-answer-fix public-confidence"),
+        ("just/release.just", &release_just, "release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check"),
         ("just/release.just", &release_just, "binary-smoke: binary-package"),
         (
             "just/release.just",

--- a/tests/fixtures/dogfood-baseline.json
+++ b/tests/fixtures/dogfood-baseline.json
@@ -1,6 +1,35 @@
 {
   "schema_version": 1,
   "description": "Known kml dogfood diagnostics. New diagnostics fail just dogfood.",
-  "total_diagnostics": 0,
-  "diagnostics": []
+  "total_diagnostics": 4,
+  "diagnostics": [
+    {
+      "path": "openspec/changes/v0-18-4-editor-release-gate-finalization/specs/editor-release-gate/spec.md",
+      "rule_id": "MD001",
+      "message": "Heading levels should only increment by one level at a time [Expected: h2, Actual: h3]",
+      "line_text": "### Requirement: release-verify SHALL output editor artifact state",
+      "count": 1
+    },
+    {
+      "path": "openspec/changes/v0-18-5-release-verification-hardening/specs/release-verification-hardening/spec.md",
+      "rule_id": "MD001",
+      "message": "Heading levels should only increment by one level at a time [Expected: h2, Actual: h3]",
+      "line_text": "### Requirement: partial publish SHALL be fail-fast",
+      "count": 1
+    },
+    {
+      "path": "openspec/changes/v0-18-6-editor-publication-prerequisites/design.md",
+      "rule_id": "MD032",
+      "message": "Lists should be surrounded by blank lines",
+      "line_text": "- account",
+      "count": 1
+    },
+    {
+      "path": "openspec/changes/v0-18-6-editor-publication-prerequisites/specs/editor-publication-prerequisites/spec.md",
+      "rule_id": "MD001",
+      "message": "Heading levels should only increment by one level at a time [Expected: h2, Actual: h3]",
+      "line_text": "### Requirement: manual publish prerequisites SHALL be explicit",
+      "count": 1
+    }
+  ]
 }

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Fast Markdown linter and formatter with localized CLI help and version aliases.",
   "keywords": [
     "markdown",

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.18.3"
+version = "0.18.4"
 description = "Fast Markdown linter and formatter with localized CLI help and version aliases."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
release/v* の実行経路で落ちる `Build release notes` を修正します。

原因: release 実行時はバージョンが `0.18.4-<suffix>` のような `-` サフィックス付きで入るのに、`release-notes.sh` は `CHANGELOG.md` の見出しを `## v0.18.4-...` で探して失敗していました。

対応: PR/Release イベント時は `Cargo.toml` 版（`steps.version.outputs.cargo_version`）を使って `CHANGELOG` からノートを抽出するよう変更します。
