### PR TITLE
fix: MD037の強調範囲誤認を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.19.1
+
+- Fixes `MD037` so separate emphasis spans on the same line are not merged by `kml check --fix`.
+- Adds regression coverage for the release-blocking `MD037` corruption case.
+- Fixes the local pre-push file filter to use the repository's `master` branch.
+- Synchronizes project version to `v0.19.1` across all components.
+
 ## v0.19.0
 
 - Implements project-specific configuration awareness in the LSP server.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.19.0"
+version = "0.19.1"
 
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ include = [
     "LICENSE",
     "Markfile",
     "build.rs",
+    "build/**",
     "server.json",
     "docs/**",
     "examples/**",

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-katana-markdown-linter",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-katana-markdown-linter",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "dependencies": {
         "vscode-languageclient": "^8.1.0"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-katana-markdown-linter",
   "displayName": "KatanA Markdown Linter",
   "description": "VS Code extension for KatanA Markdown Linter (kml)",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "publisher": "HiroyukiFuruno",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "katana-markdown-linter-zed"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter-zed"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "katana-markdown-linter"
 name = "KatanA Markdown Linter"
-version = "0.19.0"
+version = "0.19.1"
 schema_version = 1
 authors = ["Hiroyuki Furuno <hfuruno0114@gmail.com>"]
 description = "Fast Markdown linter and formatter (kml)"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,7 +11,8 @@ pre-commit:
       run: just fmt
 
 pre-push:
+  files: git diff --name-only HEAD master
   commands:
     check-strict:
-      run: just JOBS=2 check
+      run: sh -c 'just JOBS=2 check' -- {files}
       glob: "*.{rs,toml,lock}"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.19.0",
+  "version": "0.19.1",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.0/katana-markdown-linter-0.19.0.mcpb",
-      "version": "0.19.0",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.1/katana-markdown-linter-0.19.1.mcpb",
+      "version": "0.19.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/rules/markdown/rules/spaces_in_emphasis.rs
+++ b/src/rules/markdown/rules/spaces_in_emphasis.rs
@@ -162,9 +162,10 @@ fn space_fix(
 }
 
 fn valid_start(line: &str, marker_start: usize) -> bool {
-    marker_start == 0
-        || line[..marker_start]
-            .ends_with(|char: char| char.is_whitespace() || "([{\"'.!?,;:".contains(char))
+    let Some(previous) = line[..marker_start].chars().next_back() else {
+        return true;
+    };
+    previous.is_whitespace() || "([{\"'".contains(previous)
 }
 
 fn matching_end_marker(markers: &[EmphasisMarker], marker_index: usize) -> Option<EmphasisMarker> {

--- a/tests/emphasis_regressions.rs
+++ b/tests/emphasis_regressions.rs
@@ -46,3 +46,30 @@ fn md050_ignores_markers_that_start_and_end_in_separate_inline_code_spans() {
     assert!(diagnostics.is_empty());
     assert_eq!(fixed.content, content);
 }
+
+#[test]
+fn md037_does_not_merge_separate_strong_spans_on_one_line() {
+    let content = "**Note:** Neovim support is provided as a **docs-only sample**.\n";
+    let options = only_rule("MD037");
+
+    let diagnostics = MarkdownLinter::lint(content, &options).expect("lint should run");
+    let fixed = MarkdownLinter::fix(content, &options).expect("fix should run");
+
+    assert!(diagnostics.is_empty());
+    assert_eq!(fixed.content, content);
+}
+
+#[test]
+fn md037_trims_spaced_emphasis_next_to_separate_strong_span() {
+    let content = "**Note:** Neovim support is provided as * docs-only sample *.\n";
+    let options = only_rule("MD037");
+
+    let diagnostics = MarkdownLinter::lint(content, &options).expect("lint should run");
+    let fixed = MarkdownLinter::fix(content, &options).expect("fix should run");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        fixed.content,
+        "**Note:** Neovim support is provided as *docs-only sample*.\n"
+    );
+}

--- a/tests/release_version_sync_contract.rs
+++ b/tests/release_version_sync_contract.rs
@@ -29,6 +29,8 @@ impl ReleaseVersionCommand {
     fn run(&self) -> Output {
         let mut command = Command::new("bash");
         command.current_dir(workspace_root());
+        command.env("MSYS2_ARG_CONV_EXCL", "*");
+        command.env("MSYS_NO_PATHCONV", "1");
         for arg in &self.args {
             command.arg(arg);
         }

--- a/tests/release_version_sync_contract.rs
+++ b/tests/release_version_sync_contract.rs
@@ -27,7 +27,7 @@ impl ReleaseVersionCommand {
     }
 
     fn run(&self) -> Output {
-        let mut command = Command::new("bash");
+        let mut command = Command::new(bash_executable());
         command.current_dir(workspace_root());
         command.env("MSYS2_ARG_CONV_EXCL", "*");
         command.env("MSYS_NO_PATHCONV", "1");
@@ -75,18 +75,39 @@ fn release_pull_request_branch_must_not_include_suffix() {
         env!("CARGO_PKG_VERSION")
     ))
     .run();
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
         !output.status.success(),
-        "expected suffix release branch to fail"
+        "expected suffix release branch to fail, stdout: {stdout}, stderr: {stderr}"
     );
     assert!(
         stderr.contains("Release branch must be exactly release/vX.Y.Z"),
-        "expected branch format error, stderr: {stderr}"
+        "expected branch format error, stdout: {stdout}, stderr: {stderr}"
     );
 }
 
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[cfg(windows)]
+fn bash_executable() -> PathBuf {
+    if let Some(program_files) = std::env::var_os("ProgramFiles") {
+        let candidate = PathBuf::from(program_files)
+            .join("Git")
+            .join("bin")
+            .join("bash.exe");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from("bash")
+}
+
+#[cfg(not(windows))]
+fn bash_executable() -> PathBuf {
+    PathBuf::from("bash")
 }

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Fast Markdown linter and formatter with localized CLI help and version aliases.",
   "keywords": [
     "markdown",

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.19.0"
+version = "0.19.1"
 description = "Fast Markdown linter and formatter with localized CLI help and version aliases."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
MD037 が同じ行の別々の強調範囲を1つの範囲として誤認し、`kml check --fix` で Markdown 構造を壊す問題を修正します。

## 対応内容
- MD037 の開始記号判定を調整し、閉じ側の強調記号を新しい開始として扱わないようにしました。
- 評価レポートの再現ケースを回帰テストに追加しました。
- pre-push の差分抽出が存在しない `main` を参照して push を止めるため、基準ブランチを `master` に明示しました。

## 影響範囲
- `kml check`
- `kml check --fix`
- MD037 / no-space-in-emphasis
- ローカル pre-push 検査

## 動作確認結果
- `cargo test --test emphasis_regressions md037 -- --nocapture`
- `cargo test --test cli_convergence_contract -- --nocapture`
- `cargo test --test rule_fixture_harness MD037 -- --nocapture`
- `just check`
- `just document-answer-fix`
- `just public-confidence`
- `lefthook run pre-push`
- `git push -u origin release/v0.19.1`