### PR TITLE
Release v0.19.3

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Partial publish simulation
         run: just release-partial-publish-test
 
+      - name: Install uv
+        run: python3 -m pip install --upgrade uv
+
       - name: Wrapper smoke
         run: just wrapper-smoke
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,23 +108,29 @@ jobs:
       - name: Package binary artifact
         shell: bash
         run: |
-          python scripts/release/binary_artifacts.py package \
-            --version "${{ steps.version.outputs.version }}" \
-            --target "${{ matrix.target }}"
+          for executable in kml kml-mcp kml-mcp-remote; do
+            python scripts/release/binary_artifacts.py package \
+              --version "${{ steps.version.outputs.version }}" \
+              --target "${{ matrix.target }}" \
+              --executable "$executable"
+          done
 
       - name: Smoke binary artifact
         shell: bash
         run: |
-          python scripts/release/binary_artifacts.py smoke \
-            --version "${{ steps.version.outputs.version }}" \
-            --target "${{ matrix.target }}"
+          for executable in kml kml-mcp kml-mcp-remote; do
+            python scripts/release/binary_artifacts.py smoke \
+              --version "${{ steps.version.outputs.version }}" \
+              --target "${{ matrix.target }}" \
+              --executable "$executable"
+          done
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.target }}
           path: |
-            target/binary/kml-${{ steps.version.outputs.version }}-${{ matrix.target }}.*
+            target/binary/*-${{ steps.version.outputs.version }}-${{ matrix.target }}.*
 
   release:
     name: Release
@@ -327,6 +333,12 @@ jobs:
           path: target/binary
           merge-multiple: true
 
+      - name: Install uv
+        run: python3 -m pip install --upgrade uv
+
+      - name: Wrapper MCP smoke
+        run: scripts/release/smoke-wrappers.sh "${{ steps.version.outputs.version }}" target/binary
+
       - name: Generate Homebrew formula
         run: |
           python3 scripts/release/homebrew_formula.py generate \
@@ -378,9 +390,22 @@ jobs:
           tag_target="$(git rev-list -n 1 "$TAG")"
           schema_asset="markdownlint.schema.${TAG}.json"
           cp "schema/markdownlint.schema.json" "$schema_asset"
-          binary_assets=(target/binary/kml-${TAG}-*.tar.gz target/binary/kml-${TAG}-*.tar.gz.sha256 target/binary/kml-${TAG}-*.zip target/binary/kml-${TAG}-*.zip.sha256)
-          if [[ "${#binary_assets[@]}" -ne 8 ]]; then
-            echo "Expected 8 binary assets, found ${#binary_assets[@]}." >&2
+          binary_assets=(
+            target/binary/kml-${TAG}-*.tar.gz
+            target/binary/kml-${TAG}-*.tar.gz.sha256
+            target/binary/kml-${TAG}-*.zip
+            target/binary/kml-${TAG}-*.zip.sha256
+            target/binary/kml-mcp-${TAG}-*.tar.gz
+            target/binary/kml-mcp-${TAG}-*.tar.gz.sha256
+            target/binary/kml-mcp-${TAG}-*.zip
+            target/binary/kml-mcp-${TAG}-*.zip.sha256
+            target/binary/kml-mcp-remote-${TAG}-*.tar.gz
+            target/binary/kml-mcp-remote-${TAG}-*.tar.gz.sha256
+            target/binary/kml-mcp-remote-${TAG}-*.zip
+            target/binary/kml-mcp-remote-${TAG}-*.zip.sha256
+          )
+          if [[ "${#binary_assets[@]}" -ne 24 ]]; then
+            echo "Expected 24 binary assets, found ${#binary_assets[@]}." >&2
             printf '%s\n' "${binary_assets[@]}" >&2
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.19.3
+
+- Adds target-specific GitHub Release archives for `kml-mcp` and `kml-mcp-remote`.
+- Extends npm and PyPI thin wrappers with `kml-mcp` and `kml-mcp-remote` entrypoints.
+- Adds wrapper smoke coverage for MCP JSON-RPC calls through npm, bun, and uv launch paths.
+- Updates MCP distribution docs and release verification for the wrapper entrypoints.
+- Synchronizes project version to `v0.19.3` across all components.
+
 ## v0.19.2
 
 - Restores `MD037` detection for spaced emphasis that starts immediately after supported punctuation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.19.2"
+version = "0.19.3"
 
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ the same channel.
 
 ### npm
 
-The npm package is a thin launcher that downloads the matching `kml` release
-archive on first use:
+The npm package is a thin launcher that downloads the matching GitHub Release
+archive for `kml`, `kml-mcp`, or `kml-mcp-remote` on first use:
 
 ~~~bash
 npm install -g katana-markdown-linter
@@ -109,13 +109,15 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.18.0 check README.md
+npx --yes katana-markdown-linter@0.19.3 check README.md
+npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 ### PyPI
 
-The PyPI package is a thin Python launcher that downloads the matching `kml`
-release archive on first use:
+The PyPI package is a thin Python launcher that downloads the matching GitHub
+Release archive for `kml`, `kml-mcp`, or `kml-mcp-remote` on first use:
 
 ~~~bash
 pipx install katana-markdown-linter
@@ -128,7 +130,8 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.18.0 kml check README.md
+uvx --from katana-markdown-linter==0.19.3 kml check README.md
+uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 ### GitHub Releases
@@ -137,10 +140,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.0/kml-v0.18.0-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.18.0/kml-v0.18.0-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.18.0-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.18.0-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/kml-v0.19.3-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/kml-v0.19.3-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.19.3-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.19.3-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -426,6 +429,15 @@ cargo build --bin kml-mcp --features mcp --locked
 cargo install katana-markdown-linter --locked --features mcp --bin kml-mcp
 ~~~
 
+After `v0.19.3`, the npm and PyPI wrappers can launch the same stdio server
+without a Rust toolchain:
+
+~~~bash
+npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+~~~
+
 The server exposes text, config, rule metadata, and workspace-safe file tools:
 
 - `check_text`
@@ -454,6 +466,15 @@ cargo build --bin kml-mcp-remote --features mcp-remote --locked
 KML_MCP_REMOTE_TOKEN=change-me target/debug/kml-mcp-remote
 ~~~
 
+Wrapper entrypoints are available for self-hosted remote MCP as well:
+
+~~~bash
+KML_MCP_REMOTE_TOKEN=change-me \
+  npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
+KML_MCP_REMOTE_TOKEN=change-me \
+  uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+~~~
+
 Run `just mcp-remote-smoke` to verify bearer authentication, text-only tool
 capabilities, text diagnostics, and the request body limit.
 
@@ -462,7 +483,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-just VERSION=v0.18.0 mcpb-smoke
+just VERSION=v0.19.3 mcpb-smoke
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -5,9 +5,9 @@
 | Channel | Status | Verification | Policy |
 | --- | --- | --- | --- |
 | Cargo crate | Official | `just release-check`, install smoke test, crates.io publish verification | Primary library and CLI package |
-| Standalone binary artifacts | Official from `v0.17.1` | `just binary-smoke`, release asset checksum, `just release-verify` asset check | Rust-toolchain-free CLI installs from GitHub Releases |
-| npm wrapper | Official from `v0.17.3` | npm registry version, `npx` launch smoke, package README / metadata check, `just release-verify` | Thin launcher over GitHub Release binary archives |
-| PyPI wrapper | Official from `v0.17.1` | PyPI JSON version, `uvx` launch smoke, package README / metadata check, `just release-verify` | Thin launcher over GitHub Release binary archives |
+| Standalone binary artifacts | Official from `v0.17.1` | `just binary-smoke`, `just mcp-binary-smoke`, release asset checksum, `just release-verify` asset check | Rust-toolchain-free CLI and MCP server installs from GitHub Releases |
+| npm wrapper | Official from `v0.17.3`; MCP entrypoints from `v0.19.3` | npm registry version, `npx` / `bunx` launch smoke, package README / metadata check, `just release-verify` | Thin launcher over GitHub Release binary archives |
+| PyPI wrapper | Official from `v0.17.1`; MCP entrypoints from `v0.19.3` | PyPI JSON version, `uvx` launch smoke, package README / metadata check, `just release-verify` | Thin launcher over GitHub Release binary archives |
 | Homebrew formula | Official from `v0.17.1` | `just homebrew-formula-check`, release archive checksum, formula test block, actual tap check in `just release-verify` | Release workflow updates latest and versioned formulae in `homebrew-katana` after release assets exist |
 | GitHub Action | Official from `v0.11.0` | `just action-smoke`, CI action smoke, release action smoke | CI integration over the published `kml` CLI |
 | MCPB bundle | Official from `v0.14.0` | `just mcpb-smoke`, `just server-json-validate`, release asset checksum | Local stdio MCP package for `kml-mcp` |
@@ -37,17 +37,20 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.17.7-aarch64-apple-darwin.tar.gz` and always ship a neighboring
-`.sha256` file. The Homebrew formula is generated from the same release assets
-and is published to `HiroyukiFuruno/homebrew-katana` by the release workflow
-with `HOMEBREW_KATANA_GIT_TOKEN`. Each release updates the latest `kml`
-formula and adds a versioned `kml@X.Y.Z` formula.
+`kml-v0.19.3-aarch64-apple-darwin.tar.gz`,
+`kml-mcp-v0.19.3-aarch64-apple-darwin.tar.gz`, and
+`kml-mcp-remote-v0.19.3-aarch64-apple-darwin.tar.gz`. Each archive ships a
+neighboring `.sha256` file. The Homebrew formula is generated from the `kml`
+release assets and is published to `HiroyukiFuruno/homebrew-katana` by the
+release workflow with `HOMEBREW_KATANA_GIT_TOKEN`. Each release updates the
+latest `kml` formula and adds a versioned `kml@X.Y.Z` formula.
 
-The npm and PyPI packages do not contain independent lint logic. They download
-the matching GitHub Release archive for the package version, verify the archive
-checksum, and launch the bundled `kml` binary. Both wrapper packages ship
-registry README and metadata that are verified by `just npm-package-check` and
-`just pypi-package-check` before publication.
+The npm and PyPI packages do not contain independent lint or MCP server logic.
+They download the matching GitHub Release archive for the package version,
+target platform, and executable role, verify the archive checksum, and launch
+the bundled `kml`, `kml-mcp`, or `kml-mcp-remote` binary. Both wrapper packages
+ship registry README and metadata that are verified by `just npm-package-check`
+and `just pypi-package-check` before publication.
 
 `kml-mcp-remote` is not a hosted service and is not described by the MCPB
 Registry metadata. Operators deploy it themselves, keep bearer authentication

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -16,13 +16,20 @@ After publication, install from crates.io:
 
     cargo install katana-markdown-linter --locked --features mcp --bin kml-mcp
 
+After `v0.19.3`, launch the same server through official wrappers without a
+Rust toolchain:
+
+    npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+    bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+    uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+
 Run the local stdio smoke test:
 
     just mcp-stdio-smoke
 
 Build and smoke test the MCPB bundle:
 
-    just VERSION=v0.17.7 mcpb-smoke
+    just VERSION=v0.19.3 mcpb-smoke
 
 ## Run
 
@@ -117,8 +124,15 @@ Use an absolute workspace path in shared configuration. The examples below use
 Add the server to `~/.codex/config.toml`:
 
     [mcp_servers.kml]
-    command = "kml-mcp"
-    args = ["--workspace-root", "/absolute/path/to/workspace"]
+    command = "npx"
+    args = ["--yes", "katana-markdown-linter@0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
+    default_tools_approval_mode = "prompt"
+
+`uvx` is also valid:
+
+    [mcp_servers.kml]
+    command = "uvx"
+    args = ["--from", "katana-markdown-linter==0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
     default_tools_approval_mode = "prompt"
 
 ### Claude Code
@@ -126,12 +140,12 @@ Add the server to `~/.codex/config.toml`:
 Register a local stdio server:
 
     claude mcp add --transport stdio --scope project kml -- \
-      kml-mcp --workspace-root /absolute/path/to/workspace
+      npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
 
 Equivalent JSON form:
 
     claude mcp add-json kml \
-      '{"type":"stdio","command":"kml-mcp","args":["--workspace-root","/absolute/path/to/workspace"]}'
+      '{"type":"stdio","command":"npx","args":["--yes","katana-markdown-linter@0.19.3","kml-mcp","--workspace-root","/absolute/path/to/workspace"]}'
 
 ### Antigravity
 
@@ -141,8 +155,8 @@ configuration. Add:
     {
       "mcpServers": {
         "kml": {
-          "command": "kml-mcp",
-          "args": ["--workspace-root", "/absolute/path/to/workspace"]
+          "command": "npx",
+          "args": ["--yes", "katana-markdown-linter@0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
         }
       }
     }
@@ -152,17 +166,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.17.7.mcpb
-    katana-markdown-linter-0.17.7.mcpb.sha256
+    katana-markdown-linter-0.19.3.mcpb
+    katana-markdown-linter-0.19.3.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`just VERSION=v0.17.7 mcp-server-json` renders `target/mcpb/server.json` with
+`just VERSION=v0.19.3 mcp-server-json` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    just VERSION=v0.17.7 server-json-validate
+    just VERSION=v0.19.3 server-json-validate
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -36,10 +36,12 @@ For MCP distribution changes, the release check includes:
 
 - `just VERSION=vX.Y.Z mcpb-smoke`
 - `just VERSION=vX.Y.Z server-json-validate`
+- `just VERSION=vX.Y.Z mcp-binary-smoke`
 
 For binary distribution changes, the release check includes:
 
 - `just VERSION=vX.Y.Z binary-smoke`
+- `just VERSION=vX.Y.Z mcp-binary-smoke`
 - [ ] Run `just VERSION=vX.Y.Z editor-extension-check`
 - `just VERSION=vX.Y.Z homebrew-formula-check`
 - `just VERSION=v0.18.5 release-partial-publish-test`
@@ -126,6 +128,8 @@ The workflow creates or updates:
 - `kml-vX.Y.Z-x86_64-apple-darwin.tar.gz` and checksum
 - `kml-vX.Y.Z-aarch64-apple-darwin.tar.gz` and checksum
 - `kml-vX.Y.Z-x86_64-pc-windows-msvc.zip` and checksum
+- matching `kml-mcp-vX.Y.Z-<target>` archives and checksums
+- matching `kml-mcp-remote-vX.Y.Z-<target>` archives and checksums
 - `.mcpb` package artifact for `kml-mcp`
 - `.mcpb.sha256` checksum
 - rendered MCP Registry `server.json`
@@ -215,6 +219,10 @@ Keep these conditions true before publishing a wrapper version:
 - `just npm-package-check` confirms the npm README, metadata, and tarball file list.
 - `just npm-publish-target-check` confirms the npm version is not already published. If npm returns `Unpublished on`, treat it as a soft signal and continue to publish attempt.
 - `just pypi-package-check` confirms the PyPI README, metadata, source distribution, wheel, and wheel metadata.
+- `just VERSION=vX.Y.Z wrapper-smoke` verifies `kml`, `kml-mcp`, and `kml-mcp-remote` through local wrapper launchers.
+- `npx --yes katana-markdown-linter@X.Y.Z kml-mcp --workspace-root <path>` is the documented npm stdio MCP form.
+- `bunx --package katana-markdown-linter@X.Y.Z kml-mcp --workspace-root <path>` is documented only while it passes smoke in the release environment.
+- `uvx --from katana-markdown-linter==X.Y.Z kml-mcp --workspace-root <path>` is the documented PyPI stdio MCP form.
 
 Use these trusted publisher settings:
 
@@ -251,8 +259,8 @@ If an extension publication is deferred, it will not block the core linter relea
 The PyPI project name must match `wrappers/python/pyproject.toml`. Change the
 wrapper metadata first if the package name is changed before publication.
 After wrapper publication, `just VERSION=vX.Y.Z release-verify` checks the npm
-registry version, PyPI JSON version, `npx` launcher output, and `uvx` launcher
-output.
+registry version, PyPI JSON version, `npx` launcher output, `uvx` launcher
+output, MCP binary release assets, and MCP wrapper JSON-RPC smoke.
 
 ## Required Secrets
 
@@ -362,6 +370,13 @@ preserve evidence and publish a corrected version instead.
   `scripts/ci/mcpb-smoke.py`.
 - Keep the manifest aligned with local stdio execution; do not claim remote MCP
   transport.
+
+### MCP wrapper smoke fails
+
+- Re-run `just VERSION=vX.Y.Z wrapper-smoke`.
+- Inspect `wrappers/npm/lib/installer.js`, `wrappers/python/src/katana_markdown_linter/installer.py`, and `scripts/release/smoke-wrappers.sh`.
+- Keep wrapper output off stdout for `kml-mcp`; stdout is reserved for MCP JSON-RPC messages.
+- Confirm `kml`, `kml-mcp`, and `kml-mcp-remote` caches are separated by version, target, and executable role.
 
 ### MCP remote smoke fails
 

--- a/docs/remote-mcp-transport.md
+++ b/docs/remote-mcp-transport.md
@@ -15,6 +15,11 @@ Install after publication:
 
     cargo install katana-markdown-linter --locked --features mcp-remote --bin kml-mcp-remote
 
+After `v0.19.3`, launch through official wrappers without a Rust toolchain:
+
+    KML_MCP_REMOTE_TOKEN=change-me npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
+    KML_MCP_REMOTE_TOKEN=change-me uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+
 Run the smoke test:
 
     just mcp-remote-smoke

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-katana-markdown-linter",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-katana-markdown-linter",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "vscode-languageclient": "^8.1.0"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-katana-markdown-linter",
   "displayName": "KatanA Markdown Linter",
   "description": "VS Code extension for KatanA Markdown Linter (kml)",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "publisher": "HiroyukiFuruno",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "katana-markdown-linter-zed"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter-zed"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "katana-markdown-linter"
 name = "KatanA Markdown Linter"
-version = "0.19.2"
+version = "0.19.3"
 schema_version = 1
 authors = ["Hiroyuki Furuno <hfuruno0114@gmail.com>"]
 description = "Fast Markdown linter and formatter (kml)"

--- a/just/mcp.just
+++ b/just/mcp.just
@@ -36,6 +36,21 @@ mcp-remote-install-smoke:
 mcp-remote-smoke: mcp-remote-install-smoke
     python3 scripts/ci/mcp-remote-smoke.py --bin "{{MCP_REMOTE_INSTALL_SMOKE_DIR}}/bin/kml-mcp-remote"
 
+# Build MCP server binary archives and checksums for VERSION
+mcp-binary-package:
+    scripts/release/verify-version.sh "{{VERSION}}"
+    target_arg=""; \
+    if [ -n "{{BINARY_TARGET}}" ]; then target_arg="--target {{BINARY_TARGET}}"; fi; \
+    python3 scripts/release/binary_artifacts.py package --version "{{VERSION}}" --dist-dir "{{BINARY_DIST_DIR}}" --executable kml-mcp $target_arg; \
+    python3 scripts/release/binary_artifacts.py package --version "{{VERSION}}" --dist-dir "{{BINARY_DIST_DIR}}" --executable kml-mcp-remote $target_arg
+
+# Exercise MCP server binary archives after extraction
+mcp-binary-smoke: mcp-binary-package
+    target_arg=""; \
+    if [ -n "{{BINARY_TARGET}}" ]; then target_arg="--target {{BINARY_TARGET}}"; fi; \
+    python3 scripts/release/binary_artifacts.py smoke --version "{{VERSION}}" --dist-dir "{{BINARY_DIST_DIR}}" --executable kml-mcp $target_arg; \
+    python3 scripts/release/binary_artifacts.py smoke --version "{{VERSION}}" --dist-dir "{{BINARY_DIST_DIR}}" --executable kml-mcp-remote $target_arg
+
 # Build .mcpb bundle and sha256 checksum for VERSION
 mcpb-package: mcp-release-build
     scripts/release/package-mcpb.sh "{{VERSION}}"

--- a/just/release.just
+++ b/just/release.just
@@ -33,8 +33,8 @@ homebrew-formula-check: homebrew-formula
     python3 scripts/release/homebrew_formula.py check --version "{{VERSION}}" --formula-name kml --output "{{HOMEBREW_FORMULA}}"
     python3 scripts/release/homebrew_formula.py check --version "{{VERSION}}" --formula-name "kml@{{VERSION_BARE}}" --output "{{HOMEBREW_VERSIONED_FORMULA}}"
 
-# Exercise npm and Python wrapper launchers against local binary archive
-wrapper-smoke: binary-package
+# Exercise npm and Python wrapper launchers against local binary archives
+wrapper-smoke: binary-package mcp-binary-package
     scripts/release/smoke-wrappers.sh "{{VERSION}}" "{{BINARY_DIST_DIR}}"
 
 # Verify npm wrapper package README, metadata, and tarball contents
@@ -83,7 +83,7 @@ release-recover: bad-version-required
     python3 scripts/release/recover-accidental-release.py --bad-version "{{BAD_VERSION}}" $replacement_arg --execute
 
 # Run local release preflight gates except upstream drift (VERSION=vX.Y.Z)
-release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate homebrew-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check
+release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke mcp-binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate homebrew-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check
     cargo publish --dry-run --locked --allow-dirty
     cargo install --path . --locked --force --root "${TMPDIR:-/tmp}/kml-release-install-check" --bin kml
     "${TMPDIR:-/tmp}/kml-release-install-check/bin/kml" init-config --config "${TMPDIR:-/tmp}/kml-release-install-check/.markdownlint.json"
@@ -100,14 +100,14 @@ release-package:
 # Dispatch GitHub Release workflow without crates.io publish
 release-github: release-tag
     scripts/release/verify-version.sh "{{VERSION}}"
-    gh workflow run release.yml --repo {{RELEASE_REPO}} --ref main -f version="{{TAG}}" -f publish_crate=false
+    gh workflow run release.yml --repo {{RELEASE_REPO}} --ref master -f version="{{TAG}}" -f publish_crate=false
 
 # Dispatch GitHub Release workflow with crates.io publish
 release-publish: release-tag
     scripts/release/verify-version.sh "{{VERSION}}"
     scripts/release/assert-crate-not-published.sh "{{VERSION_BARE}}"
     gh secret list --repo {{RELEASE_REPO}} | grep -q '^CARGO_REGISTRY_TOKEN[[:space:]]' || { echo "CARGO_REGISTRY_TOKEN secret is required" >&2; exit 1; }
-    gh workflow run release.yml --repo {{RELEASE_REPO}} --ref main -f version="{{TAG}}" -f publish_crate=true -f publish_npm_wrapper=true -f publish_pypi_wrapper=true
+    gh workflow run release.yml --repo {{RELEASE_REPO}} --ref master -f version="{{TAG}}" -f publish_crate=true -f publish_npm_wrapper=true -f publish_pypi_wrapper=true
 
 # Dispatch the full release workflow (GitHub Release + crates.io, VERSION=vX.Y.Z)
 release: release-publish

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/openspec/changes/v0-19-3-mcp-wrapper-entrypoints/tasks.md
+++ b/openspec/changes/v0-19-3-mcp-wrapper-entrypoints/tasks.md
@@ -2,87 +2,87 @@
 
 ## 0. Definition of Ready
 
-- [ ] 0.1 `v0.19.3` が npm / PyPI / crates.io / GitHub Release に未公開であることを確認する
-- [ ] 0.2 公式に載せる `npx` / `bunx` / `uvx` の exact command を実機で検証し、通らない形式を docs に載せない方針を確認する
-- [ ] 0.3 `kml` 既存 wrapper の `npx --yes katana-markdown-linter@<version> --version` と `uvx --from katana-markdown-linter kml --version` の互換性を維持する方針を確認する
-- [ ] 0.4 追加の registry package 名、secret、workflow input が必要に見えた場合は、自己判断で増やさず設計差分として報告する
+- [x] 0.1 `v0.19.3` が npm / PyPI / crates.io / GitHub Release に未公開であることを確認する
+- [x] 0.2 公式に載せる `npx` / `bunx` / `uvx` の exact command を実機で検証し、通らない形式を docs に載せない方針を確認する
+- [x] 0.3 `kml` 既存 wrapper の `npx --yes katana-markdown-linter@<version> --version` と `uvx --from katana-markdown-linter kml --version` の互換性を維持する方針を確認する
+- [x] 0.4 追加の registry package 名、secret、workflow input が必要に見えた場合は、自己判断で増やさず設計差分として報告する
 
 ## 1. Binary archive packaging
 
-- [ ] 1.1 `scripts/release/binary_artifacts.py` を executable parameter 対応にし、既存 `kml-vX.Y.Z-<target>` archive 名と smoke 結果が変わらないことをテストで固定する
-- [ ] 1.2 `kml-mcp-vX.Y.Z-<target>` archive を `mcp` feature 付き `kml-mcp` binary から作成する path を追加する
-- [ ] 1.3 `kml-mcp-remote-vX.Y.Z-<target>` archive を `mcp-remote` feature 付き `kml-mcp-remote` binary から作成する path を追加する
-- [ ] 1.4 各 MCP archive に executable、`LICENSE`、install note、`.sha256` が含まれることを検証する
-- [ ] 1.5 `kml-mcp` archive smoke が MCP stdio の `initialize` / `tools/list` / text tool call を実行するようにする
-- [ ] 1.6 `kml-mcp-remote` archive smoke が bearer token 付き Streamable HTTP の `initialize` / `tools/list` を実行し、workspace file tools が出ないことを確認する
+- [x] 1.1 `scripts/release/binary_artifacts.py` を executable parameter 対応にし、既存 `kml-vX.Y.Z-<target>` archive 名と smoke 結果が変わらないことをテストで固定する
+- [x] 1.2 `kml-mcp-vX.Y.Z-<target>` archive を `mcp` feature 付き `kml-mcp` binary から作成する path を追加する
+- [x] 1.3 `kml-mcp-remote-vX.Y.Z-<target>` archive を `mcp-remote` feature 付き `kml-mcp-remote` binary から作成する path を追加する
+- [x] 1.4 各 MCP archive に executable、`LICENSE`、install note、`.sha256` が含まれることを検証する
+- [x] 1.5 `kml-mcp` archive smoke が MCP stdio の `initialize` / `tools/list` / text tool call を実行するようにする
+- [x] 1.6 `kml-mcp-remote` archive smoke が bearer token 付き Streamable HTTP の `initialize` / `tools/list` を実行し、workspace file tools が出ないことを確認する
 
 ## 2. npm wrapper entrypoints
 
-- [ ] 2.1 `wrappers/npm` の installer を binary role 対応にし、`kml` / `kml-mcp` / `kml-mcp-remote` ごとに archive prefix と executable 名を解決する
-- [ ] 2.2 npm cache path を version / target / executable ごとに分離し、古い `kml` cache が MCP 実行に使われないことをテストする
-- [ ] 2.3 `bin.kml` は既存 CLI launcher として維持する
-- [ ] 2.4 `bin.kml-mcp` を stdio MCP launcher として追加し、stdout に wrapper log を出さないことをテストする
-- [ ] 2.5 `bin.kml-mcp-remote` を remote MCP launcher として追加する
-- [ ] 2.6 `bin.katana-markdown-linter` dispatcher を追加し、`npx --yes katana-markdown-linter@<version> kml-mcp --workspace-root <path>` が MCP server を起動することを検証する
-- [ ] 2.7 `bunx katana-markdown-linter@<version> kml-mcp --workspace-root <path>` または実機で通った exact equivalent を検証する
-- [ ] 2.8 `scripts/release/verify-npm-package.js` を更新し、README、bin entries、package tarball file list を検証する
+- [x] 2.1 `wrappers/npm` の installer を binary role 対応にし、`kml` / `kml-mcp` / `kml-mcp-remote` ごとに archive prefix と executable 名を解決する
+- [x] 2.2 npm cache path を version / target / executable ごとに分離し、古い `kml` cache が MCP 実行に使われないことをテストする
+- [x] 2.3 `bin.kml` は既存 CLI launcher として維持する
+- [x] 2.4 `bin.kml-mcp` を stdio MCP launcher として追加し、stdout に wrapper log を出さないことをテストする
+- [x] 2.5 `bin.kml-mcp-remote` を remote MCP launcher として追加する
+- [x] 2.6 `bin.katana-markdown-linter` dispatcher を追加し、`npx --yes katana-markdown-linter@<version> kml-mcp --workspace-root <path>` が MCP server を起動することを検証する
+- [x] 2.7 `bunx katana-markdown-linter@<version> kml-mcp --workspace-root <path>` または実機で通った exact equivalent を検証する
+- [x] 2.8 `scripts/release/verify-npm-package.js` を更新し、README、bin entries、package tarball file list を検証する
 
 ## 3. PyPI wrapper entrypoints
 
-- [ ] 3.1 `wrappers/python` の installer を binary role 対応にし、`kml` / `kml-mcp` / `kml-mcp-remote` ごとに archive prefix と executable 名を解決する
-- [ ] 3.2 Python cache path を version / target / executable ごとに分離し、古い `kml` cache が MCP 実行に使われないことをテストする
-- [ ] 3.3 `kml` console script は既存 CLI launcher として維持する
-- [ ] 3.4 `kml-mcp` console script を stdio MCP launcher として追加し、stdout に wrapper log を出さないことをテストする
-- [ ] 3.5 `kml-mcp-remote` console script を remote MCP launcher として追加する
-- [ ] 3.6 `uvx --from katana-markdown-linter==<version> kml-mcp --workspace-root <path>` が MCP server を起動することを検証する
-- [ ] 3.7 `scripts/release/verify-pypi-package.py` を更新し、README、console scripts、sdist / wheel metadata を検証する
+- [x] 3.1 `wrappers/python` の installer を binary role 対応にし、`kml` / `kml-mcp` / `kml-mcp-remote` ごとに archive prefix と executable 名を解決する
+- [x] 3.2 Python cache path を version / target / executable ごとに分離し、古い `kml` cache が MCP 実行に使われないことをテストする
+- [x] 3.3 `kml` console script は既存 CLI launcher として維持する
+- [x] 3.4 `kml-mcp` console script を stdio MCP launcher として追加し、stdout に wrapper log を出さないことをテストする
+- [x] 3.5 `kml-mcp-remote` console script を remote MCP launcher として追加する
+- [x] 3.6 `uvx --from katana-markdown-linter==<version> kml-mcp --workspace-root <path>` が MCP server を起動することを検証する
+- [x] 3.7 `scripts/release/verify-pypi-package.py` を更新し、README、console scripts、sdist / wheel metadata を検証する
 
 ## 4. Wrapper smoke tests
 
-- [ ] 4.1 `scripts/release/smoke-wrappers.sh` を拡張し、local archive directory を使って `kml` / `kml-mcp` / `kml-mcp-remote` を検証する
-- [ ] 4.2 npm wrapper smoke で `kml --version` と `kml check` の既存検証を維持する
-- [ ] 4.3 npm wrapper smoke で `kml-mcp` の MCP stdio JSON-RPC を検証する
-- [ ] 4.4 npm wrapper smoke で `kml-mcp-remote` の Streamable HTTP JSON-RPC を検証する
-- [ ] 4.5 PyPI wrapper smoke で `kml --version` と `kml check` の既存検証を維持する
-- [ ] 4.6 PyPI wrapper smoke で `kml-mcp` の MCP stdio JSON-RPC を検証する
-- [ ] 4.7 PyPI wrapper smoke で `kml-mcp-remote` の Streamable HTTP JSON-RPC を検証する
-- [ ] 4.8 `npx` / `bunx` / `uvx` の exact command smoke を release gate に含める
+- [x] 4.1 `scripts/release/smoke-wrappers.sh` を拡張し、local archive directory を使って `kml` / `kml-mcp` / `kml-mcp-remote` を検証する
+- [x] 4.2 npm wrapper smoke で `kml --version` と `kml check` の既存検証を維持する
+- [x] 4.3 npm wrapper smoke で `kml-mcp` の MCP stdio JSON-RPC を検証する
+- [x] 4.4 npm wrapper smoke で `kml-mcp-remote` の Streamable HTTP JSON-RPC を検証する
+- [x] 4.5 PyPI wrapper smoke で `kml --version` と `kml check` の既存検証を維持する
+- [x] 4.6 PyPI wrapper smoke で `kml-mcp` の MCP stdio JSON-RPC を検証する
+- [x] 4.7 PyPI wrapper smoke で `kml-mcp-remote` の Streamable HTTP JSON-RPC を検証する
+- [x] 4.8 `npx` / `bunx` / `uvx` の exact command smoke を release gate に含める
 
 ## 5. Release workflow and verification
 
-- [ ] 5.1 `just/mcp.just` / `just/release.just` に MCP binary archive build / smoke target を追加し、`release-check` へ組み込む
-- [ ] 5.2 `.github/workflows/release.yml` で supported target ごとの `kml-mcp` / `kml-mcp-remote` archive と checksum を upload する
-- [ ] 5.3 `scripts/release/verify-release-published.sh` が MCP archive と checksum の存在を検証するようにする
-- [ ] 5.4 release verification が current platform の `kml-mcp` archive を MCP stdio で smoke するようにする
-- [ ] 5.5 release verification が current platform の `kml-mcp-remote` archive を Streamable HTTP で smoke するようにする
-- [ ] 5.6 AST lint または release invariant test で MCP wrapper bins / console scripts / docs / release gate の対応漏れを検出する
+- [x] 5.1 `just/mcp.just` / `just/release.just` に MCP binary archive build / smoke target を追加し、`release-check` へ組み込む
+- [x] 5.2 `.github/workflows/release.yml` で supported target ごとの `kml-mcp` / `kml-mcp-remote` archive と checksum を upload する
+- [x] 5.3 `scripts/release/verify-release-published.sh` が MCP archive と checksum の存在を検証するようにする
+- [x] 5.4 release verification が current platform の `kml-mcp` archive を MCP stdio で smoke するようにする
+- [x] 5.5 release verification が current platform の `kml-mcp-remote` archive を Streamable HTTP で smoke するようにする
+- [x] 5.6 AST lint または release invariant test で MCP wrapper bins / console scripts / docs / release gate の対応漏れを検出する
 
 ## 6. Documentation
 
-- [ ] 6.1 `README.md` の MCP Server セクションに `npx` / `bunx` / `uvx` での `kml-mcp` 起動例を追加する
-- [ ] 6.2 `docs/mcp-server.md` に Codex / Claude Code / Antigravity 向けの command / args 例を追加する
-- [ ] 6.3 `docs/remote-mcp-transport.md` に wrapper 経由の `kml-mcp-remote` 起動例を追加し、public hosted service ではないことを維持する
-- [ ] 6.4 `docs/distribution.md` に MCP binary archive と wrapper entrypoint の公式配布状態を追加する
-- [ ] 6.5 `docs/release-runbook.md` に MCP wrapper asset、registry wrapper entrypoint、失敗時の確認手順を追加する
-- [ ] 6.6 `wrappers/npm/README.md` と `wrappers/python/README.md` に MCP 起動例と thin wrapper contract を追加する
+- [x] 6.1 `README.md` の MCP Server セクションに `npx` / `bunx` / `uvx` での `kml-mcp` 起動例を追加する
+- [x] 6.2 `docs/mcp-server.md` に Codex / Claude Code / Antigravity 向けの command / args 例を追加する
+- [x] 6.3 `docs/remote-mcp-transport.md` に wrapper 経由の `kml-mcp-remote` 起動例を追加し、public hosted service ではないことを維持する
+- [x] 6.4 `docs/distribution.md` に MCP binary archive と wrapper entrypoint の公式配布状態を追加する
+- [x] 6.5 `docs/release-runbook.md` に MCP wrapper asset、registry wrapper entrypoint、失敗時の確認手順を追加する
+- [x] 6.6 `wrappers/npm/README.md` と `wrappers/python/README.md` に MCP 起動例と thin wrapper contract を追加する
 
 ## 7. Validation
 
-- [ ] 7.1 `just mcp-stdio-smoke`
-- [ ] 7.2 `just mcp-remote-smoke`
-- [ ] 7.3 `just VERSION=v0.19.3 binary-smoke`
-- [ ] 7.4 `just VERSION=v0.19.3 wrapper-smoke`
-- [ ] 7.5 `just npm-package-check`
-- [ ] 7.6 `just pypi-package-check`
-- [ ] 7.7 `just ast-lint`
-- [ ] 7.8 `just VERSION=v0.19.3 release-check`
-- [ ] 7.9 `scripts/openspec validate v0-19-3-mcp-wrapper-entrypoints --strict`
+- [x] 7.1 `just mcp-stdio-smoke`
+- [x] 7.2 `just mcp-remote-smoke`
+- [x] 7.3 `just VERSION=v0.19.3 binary-smoke`
+- [x] 7.4 `just VERSION=v0.19.3 wrapper-smoke`
+- [x] 7.5 `just npm-package-check`
+- [x] 7.6 `just pypi-package-check`
+- [x] 7.7 `just ast-lint`
+- [x] 7.8 `just VERSION=v0.19.3 release-check`
+- [x] 7.9 `scripts/openspec validate v0-19-3-mcp-wrapper-entrypoints --strict`
 
 ## Definition of Done
 
-- [ ] D1 `kml` 既存 wrapper の起動互換性が保たれている
-- [ ] D2 `kml-mcp` が `npx` / `bunx` / `uvx` 経由で MCP stdio tool call まで成功する
-- [ ] D3 `kml-mcp-remote` が wrapper 経由で Streamable HTTP tool call まで成功する
+- [x] D1 `kml` 既存 wrapper の起動互換性が保たれている
+- [x] D2 `kml-mcp` が `npx` / `bunx` / `uvx` 経由で MCP stdio tool call まで成功する
+- [x] D3 `kml-mcp-remote` が wrapper 経由で Streamable HTTP tool call まで成功する
 - [ ] D4 GitHub Release に `kml-mcp` / `kml-mcp-remote` target 別 archive と checksum が存在する
-- [ ] D5 npm / PyPI package metadata と README が MCP entrypoint を説明している
-- [ ] D6 MCP workspace safety boundary と remote text-only boundary が wrapper 経由でも変わらない
+- [x] D5 npm / PyPI package metadata と README が MCP entrypoint を説明している
+- [x] D6 MCP workspace safety boundary と remote text-only boundary が wrapper 経由でも変わらない

--- a/scripts/ci/mcp-remote-smoke.py
+++ b/scripts/ci/mcp-remote-smoke.py
@@ -14,8 +14,8 @@ class McpRemoteSmoke:
     token = "kml-remote-smoke-token"
     endpoint = "/mcp"
 
-    def __init__(self, binary: Path):
-        self.binary = binary
+    def __init__(self, command: list[str]):
+        self.command = command
         self.port = self.find_port()
         self.process = None
 
@@ -39,7 +39,7 @@ class McpRemoteSmoke:
         env["KML_MCP_REMOTE_TIMEOUT_MS"] = "5000"
         env["KML_MCP_REMOTE_MAX_CONCURRENCY"] = "2"
         return subprocess.Popen(
-            [str(self.binary)],
+            self.command,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -173,16 +173,24 @@ class McpRemoteSmoke:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Smoke test kml-mcp-remote over Streamable HTTP.")
-    parser.add_argument("--bin", required=True, type=Path, help="Path to kml-mcp-remote executable.")
+    parser.add_argument("--bin", type=Path, help="Path to kml-mcp-remote executable.")
+    parser.add_argument("--command", nargs=argparse.REMAINDER, help="Command that starts kml-mcp-remote.")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    if not args.bin.exists():
+    if args.command:
+        command = args.command[1:] if args.command[0] == "--" else args.command
+    elif args.bin:
+        command = [str(args.bin)]
+    else:
+        print("--bin or --command is required", file=sys.stderr)
+        return 1
+    if args.bin and not args.bin.exists():
         print(f"kml-mcp-remote binary not found: {args.bin}", file=sys.stderr)
         return 1
-    McpRemoteSmoke(args.bin).run()
+    McpRemoteSmoke(command).run()
     print("MCP remote smoke passed")
     return 0
 

--- a/scripts/ci/mcp-stdio-smoke.py
+++ b/scripts/ci/mcp-stdio-smoke.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 
 class McpStdioSmoke:
-    def __init__(self, binary: Path):
-        self.binary = binary
+    def __init__(self, command: list[str]):
+        self.command = command
         self.process = None
 
     def run(self) -> None:
@@ -32,7 +32,7 @@ class McpStdioSmoke:
 
     def start_server(self, workspace: Path) -> subprocess.Popen[str]:
         return subprocess.Popen(
-            [str(self.binary), "--workspace-root", str(workspace)],
+            [*self.command, "--workspace-root", str(workspace)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -163,16 +163,24 @@ class McpStdioSmoke:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Smoke test kml-mcp over MCP stdio JSON-RPC.")
-    parser.add_argument("--bin", required=True, type=Path, help="Path to kml-mcp executable.")
+    parser.add_argument("--bin", type=Path, help="Path to kml-mcp executable.")
+    parser.add_argument("--command", nargs=argparse.REMAINDER, help="Command that starts kml-mcp.")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    if not args.bin.exists():
+    if args.command:
+        command = args.command[1:] if args.command[0] == "--" else args.command
+    elif args.bin:
+        command = [str(args.bin)]
+    else:
+        print("--bin or --command is required", file=sys.stderr)
+        return 1
+    if args.bin and not args.bin.exists():
         print(f"kml-mcp binary not found: {args.bin}", file=sys.stderr)
         return 1
-    McpStdioSmoke(args.bin).run()
+    McpStdioSmoke(command).run()
     print("MCP stdio smoke passed")
     return 0
 

--- a/scripts/release/binary_artifacts.py
+++ b/scripts/release/binary_artifacts.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import hashlib
 import os
-import platform
 import shutil
 import stat
 import subprocess
@@ -12,104 +13,104 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+from binary_roles import BinaryRole, BinaryRoles, detect_target, is_windows_target
+
 
 class BinaryArtifactTool:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
+        self.role = BinaryRoles.resolve(args.executable)
         self.version = self._normalize_version(args.version)
         self.version_bare = self.version.removeprefix("v")
         self.version_base = self._version_base(self.version_bare)
-        self.target = args.target or self._detect_target()
+        self.target = args.target or detect_target()
         self.dist_dir = Path(args.dist_dir)
-        self.archive_name = self._archive_name()
+        self.archive_name = self.role.archive_name(self.version, self.target)
         self.archive_path = self.dist_dir / self.archive_name
         self.checksum_path = self.dist_dir / f"{self.archive_name}.sha256"
 
     def package(self) -> None:
         if not self.args.skip_build:
-            subprocess.run(
-                ["cargo", "build", "--release", "--bin", "kml", "--target", self.target, "--locked"],
-                check=True,
-            )
+            subprocess.run(self.role.build_command(self.target), check=True)
         binary_path = self._built_binary_path()
         if not binary_path.is_file():
             raise SystemExit(f"Expected binary was not built: {binary_path}")
-        staging_root = self.dist_dir / "staging" / self.archive_name.removesuffix(".tar.gz").removesuffix(".zip")
+
+        staging_root = self._staging_root()
         if staging_root.exists():
             shutil.rmtree(staging_root)
         staging_root.mkdir(parents=True)
-        shutil.copy2(binary_path, staging_root / self._binary_name())
-        if not self._is_windows_target():
-            (staging_root / "kml").chmod(0o755)
+        shutil.copy2(binary_path, staging_root / self.role.binary_name(self.target))
+        if not is_windows_target(self.target):
+            (staging_root / self.role.executable).chmod(0o755)
         shutil.copy2("LICENSE", staging_root / "LICENSE")
         (staging_root / "README.install.md").write_text(
-            self._install_note(), encoding="utf-8"
+            self.role.install_note(self.version), encoding="utf-8"
         )
+
         self.dist_dir.mkdir(parents=True, exist_ok=True)
         self.archive_path.unlink(missing_ok=True)
         self.checksum_path.unlink(missing_ok=True)
-        if self._is_windows_target():
+        if is_windows_target(self.target):
             self._write_zip(staging_root)
         else:
             self._write_tar(staging_root)
         self._write_checksum()
-        self._write_github_output({
-            "archive_path": str(self.archive_path),
-            "checksum_path": str(self.checksum_path),
-            "archive_name": self.archive_name,
-        })
+        self._write_github_output(
+            {
+                "archive_path": str(self.archive_path),
+                "checksum_path": str(self.checksum_path),
+                "archive_name": self.archive_name,
+            }
+        )
         print(f"Packaged {self.archive_path}")
         print(f"Checksum {self.checksum_path}")
-
     def smoke(self) -> None:
         archive_path = Path(self.args.archive or self.archive_path)
         checksum_path = Path(self.args.checksum or f"{archive_path}.sha256")
         self._verify_checksum(archive_path, checksum_path)
-        with tempfile.TemporaryDirectory(prefix="kml-binary-smoke-") as temp_dir:
+        with tempfile.TemporaryDirectory(prefix=f"{self.role.executable}-binary-smoke-") as temp_dir:
             extract_dir = Path(temp_dir) / "extract"
             extract_dir.mkdir()
             self._extract_archive(archive_path, extract_dir)
             binary = self._find_binary(extract_dir)
-            version_run = subprocess.run([str(binary), "--version"], check=True, capture_output=True, text=True)
-            version_output = version_run.stdout.strip()
-            if version_output != self.version_base:
-                raise SystemExit(
-                    f"kml --version mismatch: expected {self.version_base}, got {version_output}"
-                )
-            fixture = Path(temp_dir) / "README.md"
-            fixture.write_text("# Smoke\n\nText.\n", encoding="utf-8")
-            subprocess.run(
-                [str(binary), "check", str(fixture), "--locale", "en", "--output", "json"],
-                check=True,
-                stdout=subprocess.DEVNULL,
-            )
+            self._smoke_binary(binary, Path(temp_dir))
         print(f"Binary smoke passed for {archive_path.name}")
-
-    def _archive_name(self) -> str:
-        suffix = "zip" if self._is_windows_target() else "tar.gz"
-        return f"kml-{self.version}-{self.target}.{suffix}"
-
-    def _binary_name(self) -> str:
-        return "kml.exe" if self._is_windows_target() else "kml"
-
-    def _built_binary_path(self) -> Path:
-        return Path("target") / self.target / "release" / self._binary_name()
-
-    def _detect_target(self) -> str:
-        system = platform.system()
-        machine = platform.machine().lower()
-        if system == "Linux" and machine in {"x86_64", "amd64"}:
-            return "x86_64-unknown-linux-gnu"
-        if system == "Darwin" and machine in {"x86_64", "amd64"}:
-            return "x86_64-apple-darwin"
-        if system == "Darwin" and machine in {"arm64", "aarch64"}:
-            return "aarch64-apple-darwin"
-        if system == "Windows" and machine in {"amd64", "x86_64"}:
-            return "x86_64-pc-windows-msvc"
-        raise SystemExit(
-            f"Unsupported host platform for binary packaging: {system} {machine}"
+    def _smoke_binary(self, binary: Path, temp_dir: Path) -> None:
+        if self.role.smoke == "mcp-stdio":
+            subprocess.run(
+                ["python3", "scripts/ci/mcp-stdio-smoke.py", "--bin", str(binary)],
+                check=True,
+            )
+            return
+        if self.role.smoke == "mcp-remote":
+            subprocess.run(
+                ["python3", "scripts/ci/mcp-remote-smoke.py", "--bin", str(binary)],
+                check=True,
+            )
+            return
+        self._smoke_cli(binary, temp_dir)
+    def _smoke_cli(self, binary: Path, temp_dir: Path) -> None:
+        version_run = subprocess.run(
+            [str(binary), "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
         )
-
+        version_output = version_run.stdout.strip()
+        if version_output != self.version_base:
+            raise SystemExit(
+                f"kml --version mismatch: expected {self.version_base}, got {version_output}"
+            )
+        fixture = temp_dir / "README.md"
+        fixture.write_text("# Smoke\n\nText.\n", encoding="utf-8")
+        subprocess.run(
+            [str(binary), "check", str(fixture), "--locale", "en", "--output", "json"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+    def _built_binary_path(self) -> Path:
+        return Path("target") / self.target / "release" / self.role.binary_name(self.target)
     def _extract_archive(self, archive_path: Path, extract_dir: Path) -> None:
         if archive_path.suffix == ".zip":
             with zipfile.ZipFile(archive_path) as archive:
@@ -119,31 +120,22 @@ class BinaryArtifactTool:
             archive.extractall(extract_dir, filter="data")
 
     def _find_binary(self, extract_dir: Path) -> Path:
-        for name in ("kml", "kml.exe"):
-            matches = list(extract_dir.rglob(name))
-            if matches:
-                binary = matches[0]
-                binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
-                return binary
-        raise SystemExit(f"Extracted archive does not contain kml: {extract_dir}")
-
-    def _install_note(self) -> str:
-        return (
-            f"# kml {self.version}\n\n"
-            "Add this directory to PATH or move the `kml` executable into a "
-            "directory that is already on PATH.\n"
-        )
-
-    def _is_windows_target(self) -> bool:
-        return "windows" in self.target or self.target.endswith("msvc")
+        binary_name = self.role.binary_name(self.target)
+        matches = list(extract_dir.rglob(binary_name))
+        if not matches:
+            raise SystemExit(f"Extracted archive does not contain {binary_name}: {extract_dir}")
+        binary = matches[0]
+        binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        return binary
 
     def _normalize_version(self, version: str) -> str:
         if not version:
             raise SystemExit("version is required")
         return version if version.startswith("v") else f"v{version}"
 
-    def _version_base(self, version_bare: str) -> str:
-        return version_bare.split("-", maxsplit=1)[0].split("+", maxsplit=1)[0]
+    def _staging_root(self) -> Path:
+        root_name = self.archive_name.removesuffix(".tar.gz").removesuffix(".zip")
+        return self.dist_dir / "staging" / root_name
 
     def _verify_checksum(self, archive_path: Path, checksum_path: Path) -> None:
         expected = checksum_path.read_text(encoding="utf-8").split()[0]
@@ -172,17 +164,27 @@ class BinaryArtifactTool:
             for path in staging_root.rglob("*"):
                 archive.write(path, path.relative_to(staging_root.parent))
 
+    @staticmethod
+    def _version_base(version_bare: str) -> str:
+        return version_bare.split("-", maxsplit=1)[0].split("+", maxsplit=1)[0]
+
+
+class ArgumentParser:
+    def parse(self) -> argparse.Namespace:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("command", choices=("package", "smoke"))
+        parser.add_argument("--version", required=True)
+        parser.add_argument("--target")
+        parser.add_argument("--dist-dir", default="target/binary")
+        parser.add_argument("--archive")
+        parser.add_argument("--checksum")
+        parser.add_argument("--executable", default="kml", choices=BinaryRoles.canonical_names())
+        parser.add_argument("--skip-build", action="store_true")
+        return parser.parse_args()
+
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("package", "smoke"))
-    parser.add_argument("--version", required=True)
-    parser.add_argument("--target")
-    parser.add_argument("--dist-dir", default="target/binary")
-    parser.add_argument("--archive")
-    parser.add_argument("--checksum")
-    parser.add_argument("--skip-build", action="store_true")
-    args = parser.parse_args()
+    args = ArgumentParser().parse()
     tool = BinaryArtifactTool(args)
     if args.command == "package":
         tool.package()

--- a/scripts/release/binary_roles.py
+++ b/scripts/release/binary_roles.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BinaryRole:
+    name: str
+    executable: str
+    archive_prefix: str
+    features: tuple[str, ...]
+    smoke: str
+
+    def archive_name(self, version: str, target: str) -> str:
+        suffix = "zip" if is_windows_target(target) else "tar.gz"
+        return f"{self.archive_prefix}-{version}-{target}.{suffix}"
+
+    def binary_name(self, target: str) -> str:
+        suffix = ".exe" if is_windows_target(target) else ""
+        return f"{self.executable}{suffix}"
+
+    def build_command(self, target: str) -> list[str]:
+        command = [
+            "cargo",
+            "build",
+            "--release",
+            "--bin",
+            self.executable,
+            "--target",
+            target,
+            "--locked",
+        ]
+        if self.features:
+            command.extend(["--features", ",".join(self.features)])
+        return command
+
+    def install_note(self, version: str) -> str:
+        if self.name == "cli":
+            return (
+                f"# kml {version}\n\n"
+                "Add this directory to PATH or move the `kml` executable into a "
+                "directory that is already on PATH.\n"
+            )
+        return (
+            f"# {self.executable} {version}\n\n"
+            f"This archive contains the `{self.executable}` server binary used by "
+            "the npm and PyPI thin wrappers.\n"
+        )
+
+
+class BinaryRoles:
+    roles = {
+        "cli": BinaryRole("cli", "kml", "kml", (), "cli"),
+        "kml": BinaryRole("cli", "kml", "kml", (), "cli"),
+        "kml-mcp": BinaryRole("mcp", "kml-mcp", "kml-mcp", ("mcp",), "mcp-stdio"),
+        "mcp": BinaryRole("mcp", "kml-mcp", "kml-mcp", ("mcp",), "mcp-stdio"),
+        "kml-mcp-remote": BinaryRole(
+            "mcp-remote",
+            "kml-mcp-remote",
+            "kml-mcp-remote",
+            ("mcp-remote",),
+            "mcp-remote",
+        ),
+        "mcp-remote": BinaryRole(
+            "mcp-remote",
+            "kml-mcp-remote",
+            "kml-mcp-remote",
+            ("mcp-remote",),
+            "mcp-remote",
+        ),
+    }
+
+    @classmethod
+    def resolve(cls, requested: str) -> BinaryRole:
+        if requested not in cls.roles:
+            supported = ", ".join(sorted(cls.roles))
+            raise SystemExit(f"Unsupported executable role: {requested}. Supported: {supported}")
+        return cls.roles[requested]
+
+    @classmethod
+    def canonical_names(cls) -> list[str]:
+        return ["kml", "kml-mcp", "kml-mcp-remote"]
+
+
+def detect_target() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Linux" and machine in {"x86_64", "amd64"}:
+        return "x86_64-unknown-linux-gnu"
+    if system == "Darwin" and machine in {"x86_64", "amd64"}:
+        return "x86_64-apple-darwin"
+    if system == "Darwin" and machine in {"arm64", "aarch64"}:
+        return "aarch64-apple-darwin"
+    if system == "Windows" and machine in {"amd64", "x86_64"}:
+        return "x86_64-pc-windows-msvc"
+    raise SystemExit(f"Unsupported host platform for binary packaging: {system} {machine}")
+
+
+def is_windows_target(target: str) -> bool:
+    return "windows" in target or target.endswith("msvc")

--- a/scripts/release/pypi_package_build.py
+++ b/scripts/release/pypi_package_build.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import tarfile
+import venv
+import zipfile
+from pathlib import Path
+
+
+class PyPIPackageBuildEnvironment:
+    def __init__(self, venv_root: Path) -> None:
+        self.venv_root = venv_root
+
+    def ensure(self) -> Path:
+        python = self.python()
+        if not python.exists():
+            self.venv_root.parent.mkdir(parents=True, exist_ok=True)
+            venv.EnvBuilder(with_pip=True).create(self.venv_root)
+            python = self.python()
+
+        subprocess.run([str(python), "-m", "pip", "install", "--upgrade", "build"], check=True)
+        return python
+
+    def python(self) -> Path:
+        posix_python = self.venv_root / "bin" / "python"
+        if posix_python.exists():
+            return posix_python
+        return self.venv_root / "Scripts" / "python.exe"
+
+
+class PyPIPackageDistribution:
+    def __init__(self, dist_root: Path) -> None:
+        self.dist_root = dist_root
+
+    def require_pair(self) -> tuple[Path, Path]:
+        sdists = sorted(self.dist_root.glob("*.tar.gz"))
+        wheels = sorted(self.dist_root.glob("*.whl"))
+        if len(sdists) != 1 or len(wheels) != 1:
+            raise AssertionError("PyPI build must produce exactly one sdist and one wheel")
+        return sdists[0], wheels[0]
+
+    def read_sdist_names(self, sdist_path: Path) -> set[str]:
+        with tarfile.open(sdist_path, "r:gz") as sdist:
+            return set(sdist.getnames())
+
+    def read_wheel_names(self, wheel_path: Path) -> set[str]:
+        with zipfile.ZipFile(wheel_path) as wheel:
+            return set(wheel.namelist())
+
+    def read_wheel_text(self, wheel_path: Path, name: str) -> str:
+        with zipfile.ZipFile(wheel_path) as wheel:
+            return wheel.read(name).decode("utf-8")

--- a/scripts/release/smoke-wrappers.sh
+++ b/scripts/release/smoke-wrappers.sh
@@ -6,33 +6,73 @@ VERSION_BARE="${VERSION_INPUT#v}"
 VERSION="v${VERSION_BARE}"
 ARCHIVE_DIR="${2:-target/binary}"
 SMOKE_DIR="target/wrapper-smoke"
+PYTHON_PACKAGE="katana_markdown_linter"
 
 scripts/release/verify-version.sh "$VERSION"
 rm -rf "$SMOKE_DIR"
 mkdir -p "$SMOKE_DIR"
 
-npm_output="$(
-  KML_WRAPPER_VERSION="$VERSION" \
-  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
-  KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/npm" \
-  node wrappers/npm/bin/kml.js --version
-)"
-if [[ "$npm_output" != "$VERSION_BARE" ]]; then
-  echo "npm wrapper version mismatch: expected ${VERSION_BARE}, got ${npm_output}" >&2
-  exit 1
-fi
+export KML_WRAPPER_VERSION="$VERSION"
+export KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR"
 
-python_output="$(
-  PYTHONPATH="$PWD/wrappers/python/src" \
-  KML_WRAPPER_VERSION="$VERSION" \
-  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
-  KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/python" \
-  python3 -m katana_markdown_linter --version
-)"
-if [[ "$python_output" != "$VERSION_BARE" ]]; then
-  echo "Python wrapper version mismatch: expected ${VERSION_BARE}, got ${python_output}" >&2
-  exit 1
-fi
+assert_version() {
+  label="$1"
+  output="$2"
+  if [[ "$output" != "$VERSION_BARE" ]]; then
+    echo "${label} version mismatch: expected ${VERSION_BARE}, got ${output}" >&2
+    exit 1
+  fi
+}
+
+write_fixture() {
+  fixture="$SMOKE_DIR/README.md"
+  printf '# Smoke\n\nText.\n' > "$fixture"
+  printf '%s\n' "$fixture"
+}
+
+smoke_npm_cli() {
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/npm"
+  npm_output="$(node wrappers/npm/bin/kml.js --version)"
+  assert_version "npm wrapper" "$npm_output"
+  node wrappers/npm/bin/kml.js check "$(write_fixture)" --locale en --output json >/dev/null
+}
+
+smoke_python_cli() {
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/python"
+  python_output="$(PYTHONPATH="$PWD/wrappers/python/src" python3 -m "$PYTHON_PACKAGE" --version)"
+  assert_version "Python wrapper" "$python_output"
+  PYTHONPATH="$PWD/wrappers/python/src" python3 -m "$PYTHON_PACKAGE" check "$(write_fixture)" --locale en --output json >/dev/null
+}
+
+smoke_direct_mcp_wrappers() {
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/npm"
+  python3 scripts/ci/mcp-stdio-smoke.py --command node wrappers/npm/bin/kml-mcp.js
+  python3 scripts/ci/mcp-remote-smoke.py --command node wrappers/npm/bin/kml-mcp-remote.js
+
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/python"
+  PYTHONPATH="$PWD/wrappers/python/src" python3 scripts/ci/mcp-stdio-smoke.py \
+    --command python3 -m katana_markdown_linter.mcp_stdio
+  PYTHONPATH="$PWD/wrappers/python/src" python3 scripts/ci/mcp-remote-smoke.py \
+    --command python3 -m katana_markdown_linter.mcp_remote
+}
+
+smoke_exact_package_commands() {
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/exact-npx"
+  python3 scripts/ci/mcp-stdio-smoke.py \
+    --command npx --yes "$PWD/wrappers/npm" kml-mcp
+
+  if command -v bunx >/dev/null 2>&1; then
+    export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/exact-bunx"
+    python3 scripts/ci/mcp-stdio-smoke.py \
+      --command bunx --package "$PWD/wrappers/npm" kml-mcp
+  else
+    echo "bunx is not installed; skipping bunx wrapper smoke."
+  fi
+
+  export KML_WRAPPER_INSTALL_DIR="$PWD/$SMOKE_DIR/exact-uvx"
+  python3 scripts/ci/mcp-stdio-smoke.py \
+    --command uvx --from "$PWD/wrappers/python" kml-mcp
+}
 
 write_stale_binary() {
   stale_binary="$1"
@@ -50,25 +90,24 @@ assert_stale_cache_ignored() {
   fi
 }
 
-npm_stale_dir="$PWD/$SMOKE_DIR/npm-stale"
-write_stale_binary "$npm_stale_dir/bin/kml"
-npm_stale_output="$(
-  KML_WRAPPER_VERSION="$VERSION" \
-  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
-  KML_WRAPPER_INSTALL_DIR="$npm_stale_dir" \
-  node wrappers/npm/bin/kml.js --version
-)"
-assert_stale_cache_ignored "npm wrapper" "$npm_stale_output"
+smoke_legacy_stale_cache_is_ignored() {
+  npm_stale_dir="$PWD/$SMOKE_DIR/npm-stale"
+  write_stale_binary "$npm_stale_dir/bin/kml"
+  export KML_WRAPPER_INSTALL_DIR="$npm_stale_dir"
+  npm_stale_output="$(node wrappers/npm/bin/kml.js --version)"
+  assert_stale_cache_ignored "npm wrapper" "$npm_stale_output"
 
-python_stale_dir="$PWD/$SMOKE_DIR/python-stale"
-write_stale_binary "$python_stale_dir/bin/kml"
-python_stale_output="$(
-  PYTHONPATH="$PWD/wrappers/python/src" \
-  KML_WRAPPER_VERSION="$VERSION" \
-  KML_WRAPPER_ARCHIVE_DIR="$PWD/$ARCHIVE_DIR" \
-  KML_WRAPPER_INSTALL_DIR="$python_stale_dir" \
-  python3 -m katana_markdown_linter --version
-)"
-assert_stale_cache_ignored "Python wrapper" "$python_stale_output"
+  python_stale_dir="$PWD/$SMOKE_DIR/python-stale"
+  write_stale_binary "$python_stale_dir/bin/kml"
+  export KML_WRAPPER_INSTALL_DIR="$python_stale_dir"
+  python_stale_output="$(PYTHONPATH="$PWD/wrappers/python/src" python3 -m "$PYTHON_PACKAGE" --version)"
+  assert_stale_cache_ignored "Python wrapper" "$python_stale_output"
+}
+
+smoke_npm_cli
+smoke_python_cli
+smoke_direct_mcp_wrappers
+smoke_exact_package_commands
+smoke_legacy_stale_cache_is_ignored
 
 echo "Wrapper smoke passed for ${VERSION}"

--- a/scripts/release/verify-npm-package.js
+++ b/scripts/release/verify-npm-package.js
@@ -13,6 +13,7 @@ class NpmPackageVerifier {
   run() {
     this.verifyMetadata();
     this.verifyNoRuntimeDependencies();
+    this.verifyReadme();
     this.verifyTarballContents();
     console.log(`npm package check passed for ${this.packageJson.name}@${this.packageJson.version}`);
   }
@@ -41,8 +42,16 @@ class NpmPackageVerifier {
     if (!this.packageJson.bugs.url) {
       throw new Error("package.json: bugs.url is required");
     }
-    if (this.packageJson.bin.kml !== "bin/kml.js") {
-      throw new Error("package.json: bin.kml must point to bin/kml.js");
+    const requiredBins = {
+      "katana-markdown-linter": "bin/katana-markdown-linter.js",
+      "kml": "bin/kml.js",
+      "kml-mcp": "bin/kml-mcp.js",
+      "kml-mcp-remote": "bin/kml-mcp-remote.js"
+    };
+    for (const [name, target] of Object.entries(requiredBins)) {
+      if (this.packageJson.bin[name] !== target) {
+        throw new Error(`package.json: bin.${name} must point to ${target}`);
+      }
     }
   }
 
@@ -51,6 +60,22 @@ class NpmPackageVerifier {
     const names = Object.keys(dependencies);
     if (names.length > 0) {
       throw new Error(`package.json: runtime dependencies must stay empty: ${names.join(", ")}`);
+    }
+  }
+
+  verifyReadme() {
+    const readme = fs.readFileSync(path.join(this.packageRoot, "README.md"), "utf8");
+    const requiredFragments = [
+      "npx --yes katana-markdown-linter@",
+      "bunx --package katana-markdown-linter@",
+      "kml-mcp --workspace-root",
+      "kml-mcp-remote",
+      "thin launcher over GitHub Release binary"
+    ];
+    for (const fragment of requiredFragments) {
+      if (!readme.includes(fragment)) {
+        throw new Error(`wrappers/npm/README.md is missing \`${fragment}\``);
+      }
     }
   }
 
@@ -65,7 +90,17 @@ class NpmPackageVerifier {
     }
 
     const files = new Set(packages[0].files.map((file) => file.path));
-    for (const required of ["README.md", "package.json", "bin/kml.js", "lib/installer.js"]) {
+    const requiredFiles = [
+      "README.md",
+      "package.json",
+      "bin/katana-markdown-linter.js",
+      "bin/kml.js",
+      "bin/kml-mcp.js",
+      "bin/kml-mcp-remote.js",
+      "lib/installer.js",
+      "lib/launcher.js"
+    ];
+    for (const required of requiredFiles) {
       if (!files.has(required)) {
         throw new Error(`npm tarball is missing ${required}`);
       }

--- a/scripts/release/verify-pypi-package.py
+++ b/scripts/release/verify-pypi-package.py
@@ -5,12 +5,10 @@ import argparse
 import shutil
 import subprocess
 import sys
-import tarfile
-import tempfile
 import tomllib
-import venv
-import zipfile
 from pathlib import Path
+
+from pypi_package_build import PyPIPackageBuildEnvironment, PyPIPackageDistribution
 
 
 class PyPIPackageVerifier:
@@ -21,6 +19,8 @@ class PyPIPackageVerifier:
         self.target_root = Path("target/pypi-package-check").resolve()
         self.venv_root = self.target_root / "venv"
         self.dist_root = self.target_root / "dist"
+        self.build_environment = PyPIPackageBuildEnvironment(self.venv_root)
+        self.distribution = PyPIPackageDistribution(self.dist_root)
         self.pyproject = self.load_pyproject()
         self.project = self.pyproject["project"]
 
@@ -63,22 +63,37 @@ class PyPIPackageVerifier:
         for field in ["Homepage", "Repository", "Issues", "Changelog"]:
             self.require_non_empty_string(urls, field)
 
+        scripts = self.project.get("scripts")
+        if not isinstance(scripts, dict):
+            raise AssertionError("pyproject.toml: project.scripts is required")
+        expected_scripts = {
+            "kml": "katana_markdown_linter.cli:main",
+            "kml-mcp": "katana_markdown_linter.cli:main_mcp",
+            "kml-mcp-remote": "katana_markdown_linter.cli:main_mcp_remote",
+        }
+        for name, target in expected_scripts.items():
+            if scripts.get(name) != target:
+                raise AssertionError(f"pyproject.toml: script {name} must be {target}")
+
     def verify_readme(self) -> None:
         readme = self.readme_path.read_text(encoding="utf-8")
         required_fragments = [
-            "downloads the matching `kml` binary archive from GitHub Releases",
+            "downloads the matching `kml`, `kml-mcp`, or `kml-mcp-remote`",
             "SHA-256 checksum",
             "## Install",
+            "## MCP server entrypoints",
             "## Supported Platforms",
             "## Wrapper Contract",
             "uvx --from katana-markdown-linter==",
+            "kml-mcp --workspace-root",
+            "kml-mcp-remote",
         ]
         for fragment in required_fragments:
             if fragment not in readme:
                 raise AssertionError(f"wrappers/python/README.md is missing `{fragment}`")
 
     def build_distributions(self) -> None:
-        python = self.ensure_build_environment()
+        python = self.build_environment.ensure()
         if self.dist_root.exists():
             shutil.rmtree(self.dist_root)
         self.dist_root.mkdir(parents=True)
@@ -96,27 +111,10 @@ class PyPIPackageVerifier:
             check=True,
         )
 
-    def ensure_build_environment(self) -> Path:
-        python = self.venv_python()
-        if not python.exists():
-            self.venv_root.parent.mkdir(parents=True, exist_ok=True)
-            venv.EnvBuilder(with_pip=True).create(self.venv_root)
-            python = self.venv_python()
-
-        subprocess.run(
-            [str(python), "-m", "pip", "install", "--upgrade", "build"],
-            check=True,
-        )
-        return python
-
     def verify_distributions(self) -> None:
-        sdists = sorted(self.dist_root.glob("*.tar.gz"))
-        wheels = sorted(self.dist_root.glob("*.whl"))
-        if len(sdists) != 1 or len(wheels) != 1:
-            raise AssertionError("PyPI build must produce exactly one sdist and one wheel")
-
-        sdist_names = self.read_sdist_names(sdists[0])
-        wheel_names = self.read_wheel_names(wheels[0])
+        sdist_path, wheel_path = self.distribution.require_pair()
+        sdist_names = self.distribution.read_sdist_names(sdist_path)
+        wheel_names = self.distribution.read_wheel_names(wheel_path)
         for required in ["README.md", "pyproject.toml"]:
             if not any(name.endswith(f"/{required}") for name in sdist_names):
                 raise AssertionError(f"sdist is missing {required}")
@@ -127,20 +125,38 @@ class PyPIPackageVerifier:
         )
         if metadata_name is None:
             raise AssertionError("wheel is missing METADATA")
-        self.verify_wheel_metadata(wheels[0], metadata_name)
+        self.verify_wheel_metadata(wheel_path, metadata_name)
+        entry_points_name = next(
+            (name for name in wheel_names if name.endswith(".dist-info/entry_points.txt")),
+            None,
+        )
+        if entry_points_name is None:
+            raise AssertionError("wheel is missing entry_points.txt")
+        self.verify_entry_points(wheel_path, entry_points_name)
 
     def verify_wheel_metadata(self, wheel_path: Path, metadata_name: str) -> None:
-        with zipfile.ZipFile(wheel_path) as wheel:
-            metadata = wheel.read(metadata_name).decode("utf-8")
+        metadata = self.distribution.read_wheel_text(wheel_path, metadata_name)
         required_fragments = [
             "Description-Content-Type: text/markdown",
             "Project-URL: Homepage, https://github.com/HiroyukiFuruno/katana-markdown-linter",
-            "downloads the matching `kml` binary archive from GitHub Releases",
+            "downloads the matching `kml`, `kml-mcp`, or `kml-mcp-remote`",
+            "kml-mcp --workspace-root",
             "## Supported Platforms",
         ]
         for fragment in required_fragments:
             if fragment not in metadata:
                 raise AssertionError(f"wheel METADATA is missing `{fragment}`")
+
+    def verify_entry_points(self, wheel_path: Path, entry_points_name: str) -> None:
+        entry_points = self.distribution.read_wheel_text(wheel_path, entry_points_name)
+        required_fragments = [
+            "kml = katana_markdown_linter.cli:main",
+            "kml-mcp = katana_markdown_linter.cli:main_mcp",
+            "kml-mcp-remote = katana_markdown_linter.cli:main_mcp_remote",
+        ]
+        for fragment in required_fragments:
+            if fragment not in entry_points:
+                raise AssertionError(f"wheel entry_points.txt is missing `{fragment}`")
 
     def clean_source_build_artifacts(self) -> None:
         for path in [
@@ -149,20 +165,6 @@ class PyPIPackageVerifier:
         ]:
             if path.exists():
                 shutil.rmtree(path)
-
-    def read_sdist_names(self, sdist_path: Path) -> set[str]:
-        with tarfile.open(sdist_path, "r:gz") as sdist:
-            return set(sdist.getnames())
-
-    def read_wheel_names(self, wheel_path: Path) -> set[str]:
-        with zipfile.ZipFile(wheel_path) as wheel:
-            return set(wheel.namelist())
-
-    def venv_python(self) -> Path:
-        posix_python = self.venv_root / "bin" / "python"
-        if posix_python.exists():
-            return posix_python
-        return self.venv_root / "Scripts" / "python.exe"
 
     def require_non_empty_string(self, metadata: object, field: str) -> None:
         if not isinstance(metadata, dict):

--- a/scripts/release/verify-release-assets.sh
+++ b/scripts/release/verify-release-assets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+verify_github_release() {
+  local_target="$(git rev-parse "${TAG}^{}")"
+  release_tag="$(gh release view "${TAG}" --repo "${REPO}" --json tagName --jq '.tagName')"
+  release_title="$(gh release view "${TAG}" --repo "${REPO}" --json name --jq '.name')"
+  release_target="$(gh release view "${TAG}" --repo "${REPO}" --json targetCommitish --jq '.targetCommitish')"
+  release_draft="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft')"
+  release_prerelease="$(gh release view "${TAG}" --repo "${REPO}" --json isPrerelease --jq '.isPrerelease')"
+  release_url="$(gh release view "${TAG}" --repo "${REPO}" --json url --jq '.url')"
+
+  assert_equal "GitHub Release tag" "${TAG}" "${release_tag}"
+  assert_equal "GitHub Release title" "${TAG}" "${release_title}"
+  assert_equal "GitHub Release draft state" "false" "${release_draft}"
+  assert_equal "GitHub Release prerelease state" "false" "${release_prerelease}"
+
+  if [[ "${release_target}" != "${local_target}" ]]; then
+    echo "${TAG} GitHub Release target differs from the local tag target." >&2
+    echo "release: ${release_target}" >&2
+    echo "local:   ${local_target}" >&2
+    exit 1
+  fi
+
+  asset_names="$(gh release view "${TAG}" --repo "${REPO}" --json assets --jq '.assets[].name')"
+}
+
+verify_binary_assets() {
+  verify_executable_assets "kml" "binary"
+}
+
+verify_mcp_binary_assets() {
+  verify_executable_assets "kml-mcp" "MCP binary"
+  verify_executable_assets "kml-mcp-remote" "MCP binary"
+}
+
+verify_executable_assets() {
+  local executable="$1"
+  local label="$2"
+  local target archive
+  for target in \
+    x86_64-unknown-linux-gnu \
+    x86_64-apple-darwin \
+    aarch64-apple-darwin \
+    x86_64-pc-windows-msvc; do
+    archive="$(release_asset_archive_name "${executable}" "${target}")"
+    if ! release_asset_exists "${archive}"; then
+      echo "GitHub Release is missing ${label} archive: ${archive}" >&2
+      exit 1
+    fi
+    if ! release_asset_exists "${archive}.sha256"; then
+      echo "GitHub Release is missing ${label} checksum: ${archive}.sha256" >&2
+      exit 1
+    fi
+  done
+}
+
+smoke_current_platform_binary() {
+  local smoke_target
+  smoke_target="$(current_smoke_target)"
+  [[ -n "${smoke_target}" ]] || return
+  smoke_release_binary "kml" "${smoke_target}" "${TMP_ROOT}/binary-smoke"
+}
+
+smoke_current_platform_mcp_binaries() {
+  local smoke_target executable
+  smoke_target="$(current_smoke_target)"
+  [[ -n "${smoke_target}" ]] || return
+  for executable in kml-mcp kml-mcp-remote; do
+    smoke_release_binary "${executable}" "${smoke_target}" "${TMP_ROOT}/mcp-binary-smoke"
+  done
+}
+
+smoke_release_binary() {
+  local executable="$1"
+  local smoke_target="$2"
+  local smoke_dir="$3"
+  local smoke_archive
+  mkdir -p "${smoke_dir}"
+  smoke_archive="$(release_asset_archive_name "${executable}" "${smoke_target}")"
+  gh release download "${TAG}" \
+    --repo "${REPO}" \
+    --dir "${smoke_dir}" \
+    --pattern "${smoke_archive}" \
+    --pattern "${smoke_archive}.sha256"
+  python3 scripts/release/binary_artifacts.py smoke \
+    --version "${TAG}" \
+    --target "${smoke_target}" \
+    --executable "${executable}" \
+    --archive "${smoke_dir}/${smoke_archive}" \
+    --checksum "${smoke_dir}/${smoke_archive}.sha256"
+}

--- a/scripts/release/verify-release-common.sh
+++ b/scripts/release/verify-release-common.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+cleanup() {
+  [[ -z "${TMP_ROOT}" ]] || rm -rf "${TMP_ROOT}"
+}
+
+require_command() {
+  local command_name="$1"
+  command -v "${command_name}" >/dev/null 2>&1 && return
+  echo "${command_name} is required to verify ${TAG} publication." >&2
+  exit 1
+}
+
+assert_equal() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  [[ "${actual}" == "${expected}" ]] && return
+  echo "${label} mismatch: expected ${expected}, got ${actual:-missing}" >&2
+  exit 1
+}
+
+release_asset_exists() {
+  local asset_name="$1"
+  [[ $'\n'"${asset_names}"$'\n' == *$'\n'"${asset_name}"$'\n'* ]]
+}
+
+current_smoke_target() {
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64) echo "x86_64-unknown-linux-gnu" ;;
+    Darwin/x86_64) echo "x86_64-apple-darwin" ;;
+    Darwin/arm64) echo "aarch64-apple-darwin" ;;
+    *) echo "" ;;
+  esac
+}
+
+release_asset_archive_name() {
+  local executable="$1"
+  local target="$2"
+  local extension="tar.gz"
+  if [[ "${target}" == x86_64-pc-windows-msvc ]]; then
+    extension="zip"
+  fi
+  echo "${executable}-${TAG}-${target}.${extension}"
+}

--- a/scripts/release/verify-release-homebrew.sh
+++ b/scripts/release/verify-release-homebrew.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+verify_homebrew_formula() {
+  formula_dist_dir="${TMP_ROOT}/homebrew-assets"
+  formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml.rb"
+  versioned_formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml@${VERSION_BARE}.rb"
+  mkdir -p "${formula_dist_dir}" "$(dirname "${formula_path}")"
+  for target in \
+    x86_64-unknown-linux-gnu \
+    x86_64-apple-darwin \
+    aarch64-apple-darwin; do
+    archive="kml-${TAG}-${target}.tar.gz"
+    gh release download "${TAG}" \
+      --repo "${REPO}" \
+      --dir "${formula_dist_dir}" \
+      --pattern "${archive}" \
+      --pattern "${archive}.sha256"
+  done
+  python3 scripts/release/homebrew_formula.py generate \
+    --version "${TAG}" \
+    --formula-name kml \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py check \
+    --version "${TAG}" \
+    --formula-name kml \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py generate \
+    --version "${TAG}" \
+    --formula-name "kml@${VERSION_BARE}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${versioned_formula_path}" >/dev/null
+  python3 scripts/release/homebrew_formula.py check \
+    --version "${TAG}" \
+    --formula-name "kml@${VERSION_BARE}" \
+    --repo "${REPO}" \
+    --dist-dir "${formula_dist_dir}" \
+    --output "${versioned_formula_path}" >/dev/null
+  verify_homebrew_tap_formula "Formula/kml.rb" "${formula_path}"
+  verify_homebrew_tap_formula "Formula/kml@${VERSION_BARE}.rb" "${versioned_formula_path}"
+}
+
+verify_homebrew_tap_formula() {
+  tap_path="$1"
+  expected_path="$2"
+  actual_path="${TMP_ROOT}/$(basename "${tap_path}")"
+  raw_url="https://raw.githubusercontent.com/${HOMEBREW_TAP_REPO}/${HOMEBREW_TAP_BRANCH}/${tap_path}"
+  python3 - "${raw_url}" "${actual_path}" <<'PY'
+import sys
+import urllib.request
+
+url, output = sys.argv[1:3]
+with urllib.request.urlopen(url, timeout=30) as response:
+    content = response.read()
+with open(output, "wb") as file:
+    file.write(content)
+PY
+  if ! cmp -s "${expected_path}" "${actual_path}"; then
+    echo "Homebrew tap formula mismatch: ${tap_path} does not match ${TAG}." >&2
+    echo "tap:      ${raw_url}" >&2
+    echo "expected: ${expected_path}" >&2
+    exit 1
+  fi
+}

--- a/scripts/release/verify-release-published.sh
+++ b/scripts/release/verify-release-published.sh
@@ -8,267 +8,13 @@ TAG="v${VERSION_BARE}"
 VERIFY_OUTPUT_DIR="${VERIFY_OUTPUT_DIR:-target/release-verify/${TAG}}"
 HOMEBREW_TAP_REPO="${HOMEBREW_TAP_REPO:-HiroyukiFuruno/homebrew-katana}"
 HOMEBREW_TAP_BRANCH="${HOMEBREW_TAP_BRANCH:-master}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT=""
 
-cleanup() {
-  [[ -z "${TMP_ROOT}" ]] || rm -rf "${TMP_ROOT}"
-}
-
-require_command() {
-  command_name="$1"
-  command -v "${command_name}" >/dev/null 2>&1 && return
-  echo "${command_name} is required to verify ${TAG} publication." >&2
-  exit 1
-}
-
-assert_equal() {
-  label="$1"
-  expected="$2"
-  actual="$3"
-  [[ "${actual}" == "${expected}" ]] && return
-  echo "${label} mismatch: expected ${expected}, got ${actual:-missing}" >&2
-  exit 1
-}
-
-release_asset_exists() {
-  asset_name="$1"
-  [[ $'\n'"${asset_names}"$'\n' == *$'\n'"${asset_name}"$'\n'* ]]
-}
-
-verify_github_release() {
-  local_target="$(git rev-parse "${TAG}^{}")"
-  release_tag="$(gh release view "${TAG}" --repo "${REPO}" --json tagName --jq '.tagName')"
-  release_title="$(gh release view "${TAG}" --repo "${REPO}" --json name --jq '.name')"
-  release_target="$(gh release view "${TAG}" --repo "${REPO}" --json targetCommitish --jq '.targetCommitish')"
-  release_draft="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft')"
-  release_prerelease="$(gh release view "${TAG}" --repo "${REPO}" --json isPrerelease --jq '.isPrerelease')"
-  release_url="$(gh release view "${TAG}" --repo "${REPO}" --json url --jq '.url')"
-
-  assert_equal "GitHub Release tag" "${TAG}" "${release_tag}"
-  assert_equal "GitHub Release title" "${TAG}" "${release_title}"
-  assert_equal "GitHub Release draft state" "false" "${release_draft}"
-  assert_equal "GitHub Release prerelease state" "false" "${release_prerelease}"
-
-  if [[ "${release_target}" != "${local_target}" ]]; then
-    echo "${TAG} GitHub Release target differs from the local tag target." >&2
-    echo "release: ${release_target}" >&2
-    echo "local:   ${local_target}" >&2
-    exit 1
-  fi
-
-  asset_names="$(gh release view "${TAG}" --repo "${REPO}" --json assets --jq '.assets[].name')"
-}
-
-verify_binary_assets() {
-  for target in \
-    x86_64-unknown-linux-gnu \
-    x86_64-apple-darwin \
-    aarch64-apple-darwin \
-    x86_64-pc-windows-msvc; do
-    extension="tar.gz"
-    if [[ "${target}" == x86_64-pc-windows-msvc ]]; then
-      extension="zip"
-    fi
-    archive="kml-${TAG}-${target}.${extension}"
-    if ! release_asset_exists "${archive}"; then
-      echo "GitHub Release is missing binary archive: ${archive}" >&2
-      exit 1
-    fi
-    if ! release_asset_exists "${archive}.sha256"; then
-      echo "GitHub Release is missing binary checksum: ${archive}.sha256" >&2
-      exit 1
-    fi
-  done
-}
-
-smoke_current_platform_binary() {
-  case "$(uname -s)/$(uname -m)" in
-    Linux/x86_64) smoke_target="x86_64-unknown-linux-gnu" ;;
-    Darwin/x86_64) smoke_target="x86_64-apple-darwin" ;;
-    Darwin/arm64) smoke_target="aarch64-apple-darwin" ;;
-    *) smoke_target="" ;;
-  esac
-
-  [[ -n "${smoke_target}" ]] || return
-
-  smoke_dir="${TMP_ROOT}/binary-smoke"
-  mkdir -p "${smoke_dir}"
-  smoke_archive="kml-${TAG}-${smoke_target}.tar.gz"
-  gh release download "${TAG}" \
-    --repo "${REPO}" \
-    --dir "${smoke_dir}" \
-    --pattern "${smoke_archive}" \
-    --pattern "${smoke_archive}.sha256"
-  python3 scripts/release/binary_artifacts.py smoke \
-    --version "${TAG}" \
-    --target "${smoke_target}" \
-    --archive "${smoke_dir}/${smoke_archive}" \
-    --checksum "${smoke_dir}/${smoke_archive}.sha256"
-}
-
-verify_crates_io() {
-  cargo_info="$(cargo info "${PACKAGE}@${VERSION_BARE}" --registry crates-io)"
-  crate_version="$(printf '%s\n' "${cargo_info}" | sed -n 's/^version: //p')"
-  if [[ "${crate_version}" != "${VERSION_BARE}" ]]; then
-    echo "crates.io version mismatch: expected ${VERSION_BARE}, got ${crate_version:-missing}" >&2
-    exit 1
-  fi
-}
-
-verify_npm_registry() {
-  require_command npm
-  npm_registry_version="$(npm view "${PACKAGE}@${VERSION_BARE}" version 2>/dev/null || true)"
-  if [[ "${npm_registry_version}" != "${VERSION_BARE}" ]]; then
-    echo "npm registry version mismatch: expected ${VERSION_BARE}, got ${npm_registry_version:-missing}" >&2
-    exit 1
-  fi
-}
-
-verify_pypi_registry() {
-  pypi_registry_version="$(
-    python3 -c 'import json, sys, urllib.request; package, version = sys.argv[1:3]; url = f"https://pypi.org/pypi/{package}/{version}/json"; print(json.load(urllib.request.urlopen(url, timeout=30))["info"]["version"])' "${PACKAGE}" "${VERSION_BARE}" 2>/dev/null || true
-  )"
-  if [[ "${pypi_registry_version}" != "${VERSION_BARE}" ]]; then
-    echo "PyPI version mismatch: expected ${VERSION_BARE}, got ${pypi_registry_version:-missing}" >&2
-    exit 1
-  fi
-}
-
-smoke_npm_wrapper() {
-  require_command npx
-  npm_wrapper_version="$(npx --yes "${PACKAGE}@${VERSION_BARE}" --version | tail -n 1)"
-  if [[ "${npm_wrapper_version}" != "${VERSION_BARE}" ]]; then
-    echo "npm wrapper version mismatch: expected ${VERSION_BARE}, got ${npm_wrapper_version:-missing}" >&2
-    exit 1
-  fi
-}
-
-smoke_pypi_wrapper() {
-  require_command uvx
-  pypi_wrapper_version="$(uvx --from "${PACKAGE}==${VERSION_BARE}" kml --version | tail -n 1)"
-  if [[ "${pypi_wrapper_version}" != "${VERSION_BARE}" ]]; then
-    echo "PyPI wrapper version mismatch: expected ${VERSION_BARE}, got ${pypi_wrapper_version:-missing}" >&2
-    exit 1
-  fi
-}
-
-verify_vscode_extension() {
-  if [[ "${PUBLISH_VSCODE_EXTENSION:-false}" == "true" ]]; then
-    # Check VS Code Marketplace availability
-    if curl -sSfL "https://marketplace.visualstudio.com/items?itemName=HiroyukiFuruno.vscode-katana-markdown-linter" > /dev/null 2>&1; then
-      echo "vscode_extension_status=published"
-    else
-      echo "VS Code extension publication check failed: extension not found in marketplace." >&2
-      exit 1
-    fi
-  else
-    echo "vscode_extension_status=deferred"
-  fi
-}
-
-verify_zed_extension() {
-  if [[ "${PUBLISH_ZED_EXTENSION:-false}" == "true" ]]; then
-    # Check Zed Extension Registry availability
-    # Note: Zed extension registry URL pattern is based on current zed ecosystem
-    if curl -sSfL "https://extensions.zed.dev/extensions/katana-markdown-linter" > /dev/null 2>&1; then
-       echo "zed_extension_status=published"
-    else
-      echo "Zed extension publication check failed: extension not found in registry." >&2
-      exit 1
-    fi
-  else
-    echo "zed_extension_status=deferred"
-  fi
-}
-
-verify_homebrew_formula() {
-  formula_dist_dir="${TMP_ROOT}/homebrew-assets"
-  formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml.rb"
-  versioned_formula_path="${VERIFY_OUTPUT_DIR}/homebrew/kml@${VERSION_BARE}.rb"
-  mkdir -p "${formula_dist_dir}" "$(dirname "${formula_path}")"
-  for target in \
-    x86_64-unknown-linux-gnu \
-    x86_64-apple-darwin \
-    aarch64-apple-darwin; do
-    archive="kml-${TAG}-${target}.tar.gz"
-    gh release download "${TAG}" \
-      --repo "${REPO}" \
-      --dir "${formula_dist_dir}" \
-      --pattern "${archive}" \
-      --pattern "${archive}.sha256"
-  done
-  python3 scripts/release/homebrew_formula.py generate \
-    --version "${TAG}" \
-    --formula-name kml \
-    --repo "${REPO}" \
-    --dist-dir "${formula_dist_dir}" \
-    --output "${formula_path}" >/dev/null
-  python3 scripts/release/homebrew_formula.py check \
-    --version "${TAG}" \
-    --formula-name kml \
-    --repo "${REPO}" \
-    --dist-dir "${formula_dist_dir}" \
-    --output "${formula_path}" >/dev/null
-  python3 scripts/release/homebrew_formula.py generate \
-    --version "${TAG}" \
-    --formula-name "kml@${VERSION_BARE}" \
-    --repo "${REPO}" \
-    --dist-dir "${formula_dist_dir}" \
-    --output "${versioned_formula_path}" >/dev/null
-  python3 scripts/release/homebrew_formula.py check \
-    --version "${TAG}" \
-    --formula-name "kml@${VERSION_BARE}" \
-    --repo "${REPO}" \
-    --dist-dir "${formula_dist_dir}" \
-    --output "${versioned_formula_path}" >/dev/null
-  verify_homebrew_tap_formula "Formula/kml.rb" "${formula_path}"
-  verify_homebrew_tap_formula "Formula/kml@${VERSION_BARE}.rb" "${versioned_formula_path}"
-}
-
-verify_homebrew_tap_formula() {
-  tap_path="$1"
-  expected_path="$2"
-  actual_path="${TMP_ROOT}/$(basename "${tap_path}")"
-  raw_url="https://raw.githubusercontent.com/${HOMEBREW_TAP_REPO}/${HOMEBREW_TAP_BRANCH}/${tap_path}"
-  python3 - "${raw_url}" "${actual_path}" <<'PY'
-import sys
-import urllib.request
-
-url, output = sys.argv[1:3]
-with urllib.request.urlopen(url, timeout=30) as response:
-    content = response.read()
-with open(output, "wb") as file:
-    file.write(content)
-PY
-  if ! cmp -s "${expected_path}" "${actual_path}"; then
-    echo "Homebrew tap formula mismatch: ${tap_path} does not match ${TAG}." >&2
-    echo "tap:      ${raw_url}" >&2
-    echo "expected: ${expected_path}" >&2
-    exit 1
-  fi
-}
-
-verify_consistency_with_state() {
-  state_path="target/release-verify-state.json"
-  if [[ ! -f "${state_path}" ]]; then
-    echo "Verification state file missing: ${state_path}" >&2
-    exit 1
-  fi
-
-  expected_version="$(python3 -c "import json; print(json.load(open('${state_path}'))['version'])")"
-  if [[ "${TAG}" != "${expected_version}" ]]; then
-    echo "Verification drift detected: expected version ${expected_version} from state, but verifying ${TAG}." >&2
-    exit 1
-  fi
-
-  release_decision="$(python3 -c "import json; print(json.load(open('${state_path}'))['release_decision'])")"
-  if [[ "${release_decision}" != "allow_release" ]]; then
-    echo "Verification state indicates blockers: ${release_decision}" >&2
-    python3 -c "import json; print('\n'.join(json.load(open('${state_path}'))['publish_blockers']))" >&2
-    exit 1
-  fi
-  echo "Consistency check passed with ${state_path}"
-}
+source "${SCRIPT_DIR}/verify-release-common.sh"
+source "${SCRIPT_DIR}/verify-release-assets.sh"
+source "${SCRIPT_DIR}/verify-release-registries.sh"
+source "${SCRIPT_DIR}/verify-release-homebrew.sh"
 
 require_command gh
 require_command cargo
@@ -279,12 +25,16 @@ TMP_ROOT="$(mktemp -d)"
 verify_consistency_with_state
 verify_github_release
 verify_binary_assets
+verify_mcp_binary_assets
 smoke_current_platform_binary
+smoke_current_platform_mcp_binaries
 verify_crates_io
 verify_npm_registry
 verify_pypi_registry
 smoke_npm_wrapper
+smoke_npm_mcp_wrapper
 smoke_pypi_wrapper
+smoke_pypi_mcp_wrapper
 verify_vscode_extension
 verify_zed_extension
 verify_homebrew_formula

--- a/scripts/release/verify-release-registries.sh
+++ b/scripts/release/verify-release-registries.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+verify_crates_io() {
+  cargo_info="$(cargo info "${PACKAGE}@${VERSION_BARE}" --registry crates-io)"
+  crate_version="$(printf '%s\n' "${cargo_info}" | sed -n 's/^version: //p')"
+  if [[ "${crate_version}" != "${VERSION_BARE}" ]]; then
+    echo "crates.io version mismatch: expected ${VERSION_BARE}, got ${crate_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+verify_npm_registry() {
+  require_command npm
+  npm_registry_version="$(npm view "${PACKAGE}@${VERSION_BARE}" version 2>/dev/null || true)"
+  if [[ "${npm_registry_version}" != "${VERSION_BARE}" ]]; then
+    echo "npm registry version mismatch: expected ${VERSION_BARE}, got ${npm_registry_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+verify_pypi_registry() {
+  pypi_registry_version="$(
+    python3 -c 'import json, sys, urllib.request; package, version = sys.argv[1:3]; url = f"https://pypi.org/pypi/{package}/{version}/json"; print(json.load(urllib.request.urlopen(url, timeout=30))["info"]["version"])' "${PACKAGE}" "${VERSION_BARE}" 2>/dev/null || true
+  )"
+  if [[ "${pypi_registry_version}" != "${VERSION_BARE}" ]]; then
+    echo "PyPI version mismatch: expected ${VERSION_BARE}, got ${pypi_registry_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+smoke_npm_wrapper() {
+  require_command npx
+  npm_wrapper_version="$(npx --yes "${PACKAGE}@${VERSION_BARE}" --version | tail -n 1)"
+  if [[ "${npm_wrapper_version}" != "${VERSION_BARE}" ]]; then
+    echo "npm wrapper version mismatch: expected ${VERSION_BARE}, got ${npm_wrapper_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+smoke_npm_mcp_wrapper() {
+  require_command npx
+  python3 scripts/ci/mcp-stdio-smoke.py \
+    --command npx --yes "${PACKAGE}@${VERSION_BARE}" kml-mcp
+  python3 scripts/ci/mcp-remote-smoke.py \
+    --command npx --yes "${PACKAGE}@${VERSION_BARE}" kml-mcp-remote
+  if command -v bunx >/dev/null 2>&1; then
+    python3 scripts/ci/mcp-stdio-smoke.py \
+      --command bunx --package "${PACKAGE}@${VERSION_BARE}" kml-mcp
+  else
+    echo "bunx is not installed; skipping post-release bunx MCP smoke."
+  fi
+}
+
+smoke_pypi_wrapper() {
+  require_command uvx
+  pypi_wrapper_version="$(uvx --from "${PACKAGE}==${VERSION_BARE}" kml --version | tail -n 1)"
+  if [[ "${pypi_wrapper_version}" != "${VERSION_BARE}" ]]; then
+    echo "PyPI wrapper version mismatch: expected ${VERSION_BARE}, got ${pypi_wrapper_version:-missing}" >&2
+    exit 1
+  fi
+}
+
+smoke_pypi_mcp_wrapper() {
+  require_command uvx
+  python3 scripts/ci/mcp-stdio-smoke.py \
+    --command uvx --from "${PACKAGE}==${VERSION_BARE}" kml-mcp
+  python3 scripts/ci/mcp-remote-smoke.py \
+    --command uvx --from "${PACKAGE}==${VERSION_BARE}" kml-mcp-remote
+}
+
+verify_vscode_extension() {
+  if [[ "${PUBLISH_VSCODE_EXTENSION:-false}" == "true" ]]; then
+    if curl -sSfL "https://marketplace.visualstudio.com/items?itemName=HiroyukiFuruno.vscode-katana-markdown-linter" > /dev/null 2>&1; then
+      echo "vscode_extension_status=published"
+    else
+      echo "VS Code extension publication check failed: extension not found in marketplace." >&2
+      exit 1
+    fi
+  else
+    echo "vscode_extension_status=deferred"
+  fi
+}
+
+verify_zed_extension() {
+  if [[ "${PUBLISH_ZED_EXTENSION:-false}" == "true" ]]; then
+    if curl -sSfL "https://extensions.zed.dev/extensions/katana-markdown-linter" > /dev/null 2>&1; then
+      echo "zed_extension_status=published"
+    else
+      echo "Zed extension publication check failed: extension not found in registry." >&2
+      exit 1
+    fi
+  else
+    echo "zed_extension_status=deferred"
+  fi
+}
+
+verify_consistency_with_state() {
+  state_path="target/release-verify-state.json"
+  if [[ ! -f "${state_path}" ]]; then
+    echo "Verification state file missing: ${state_path}" >&2
+    exit 1
+  fi
+
+  expected_version="$(python3 -c "import json; print(json.load(open('${state_path}'))['version'])")"
+  if [[ "${TAG}" != "${expected_version}" ]]; then
+    echo "Verification drift detected: expected version ${expected_version} from state, but verifying ${TAG}." >&2
+    exit 1
+  fi
+
+  release_decision="$(python3 -c "import json; print(json.load(open('${state_path}'))['release_decision'])")"
+  if [[ "${release_decision}" != "allow_release" ]]; then
+    echo "Verification state indicates blockers: ${release_decision}" >&2
+    python3 -c "import json; print('\n'.join(json.load(open('${state_path}'))['publish_blockers']))" >&2
+    exit 1
+  fi
+  echo "Consistency check passed with ${state_path}"
+}

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.19.2",
+  "version": "0.19.3",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.2/katana-markdown-linter-0.19.2.mcpb",
-      "version": "0.19.2",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/katana-markdown-linter-0.19.3.mcpb",
+      "version": "0.19.3",
       "transport": {
         "type": "stdio"
       }

--- a/tests/ast_linter.rs
+++ b/tests/ast_linter.rs
@@ -355,7 +355,14 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
     let release_notes = read_workspace_file("scripts/release/release-notes.sh");
     let crate_guard = read_workspace_file("scripts/release/assert-crate-not-published.sh");
     let tag_verifier = read_workspace_file("scripts/release/verify-tag-verified.sh");
-    let published_verifier = read_workspace_file("scripts/release/verify-release-published.sh");
+    let published_verifier = [
+        read_workspace_file("scripts/release/verify-release-published.sh"),
+        read_workspace_file("scripts/release/verify-release-common.sh"),
+        read_workspace_file("scripts/release/verify-release-assets.sh"),
+        read_workspace_file("scripts/release/verify-release-registries.sh"),
+        read_workspace_file("scripts/release/verify-release-homebrew.sh"),
+    ]
+    .join("\n");
     let wrapper_smoke = read_workspace_file("scripts/release/smoke-wrappers.sh");
     let npm_installer = read_workspace_file("wrappers/npm/lib/installer.js");
     let python_installer =
@@ -381,14 +388,14 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
             &release_just,
             "scripts/release/recover-accidental-release.py",
         ),
-        ("just/release.just", &release_just, "release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate homebrew-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check"),
+        ("just/release.just", &release_just, "release-check: release-target-check fmt-check lint ast-lint schema-check release-test dogfood coverage-blocking examples mcp-build mcp-stdio-smoke mcp-remote-build mcp-remote-smoke mcpb-smoke server-json-validate action-smoke binary-smoke mcp-binary-smoke homebrew-formula-check wrapper-smoke npm-package-check npm-publish-target-check pypi-package-check wrapper-publish-gate homebrew-publish-gate editor-publish-gate document-answer-fix public-confidence editor-extension-check"),
         ("just/release.just", &release_just, "binary-smoke: binary-package"),
         (
             "just/release.just",
             &release_just,
             "homebrew-formula-check: homebrew-formula",
         ),
-        ("just/release.just", &release_just, "wrapper-smoke: binary-package"),
+        ("just/release.just", &release_just, "wrapper-smoke: binary-package mcp-binary-package"),
         ("just/release.just", &release_just, "npm-package-check:"),
         (
             "just/release.just",
@@ -586,11 +593,11 @@ fn ast_linter_release_local_ci_parity_and_retry_safety() {
         ("scripts/release/verify-tag-verified.sh", &tag_verifier, "git fetch --quiet origin \"refs/tags/${TAG}:refs/tags/${TAG}\""),
         ("scripts/release/verify-release-published.sh", &published_verifier, "release_asset_exists"),
         ("scripts/release/smoke-wrappers.sh", &wrapper_smoke, "reused an unversioned stale cache"),
-        ("wrappers/npm/lib/installer.js", &npm_installer, "this.version, this.target"),
-        ("wrappers/python/src/katana_markdown_linter/installer.py", &python_installer, "self.version / self.target"),
+        ("wrappers/npm/lib/installer.js", &npm_installer, "this.role.executable"),
+        ("wrappers/python/src/katana_markdown_linter/installer.py", &python_installer, "self.role.executable"),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_title="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "github_release_target="),
-        ("scripts/release/verify-release-published.sh", &published_verifier, "GitHub Release is missing binary archive"),
+        ("scripts/release/verify-release-published.sh", &published_verifier, "GitHub Release is missing ${label} archive"),
         ("scripts/release/verify-release-published.sh", &published_verifier, "crates_io_version="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "npm_registry_version="),
         ("scripts/release/verify-release-published.sh", &published_verifier, "pypi_registry_version="),

--- a/tests/ast_linter/workflow_portability_guard.rs
+++ b/tests/ast_linter/workflow_portability_guard.rs
@@ -28,7 +28,7 @@ impl WorkflowPortabilityGuard {
             release: read_workspace_file(".github/workflows/release.yml"),
             homebrew_formula: read_workspace_file("scripts/release/homebrew_formula.py"),
             homebrew_tap_updater: read_workspace_file("scripts/release/update_homebrew_tap.py"),
-            release_verifier: read_workspace_file("scripts/release/verify-release-published.sh"),
+            release_verifier: read_release_verifier_surface(),
         }
     }
 
@@ -225,6 +225,17 @@ fn require_absent(violations: &mut Vec<String>, path: &str, content: &str, forbi
 
 fn read_workspace_file(path: &str) -> String {
     std::fs::read_to_string(workspace_root().join(path)).expect("workspace file should be readable")
+}
+
+fn read_release_verifier_surface() -> String {
+    [
+        read_workspace_file("scripts/release/verify-release-published.sh"),
+        read_workspace_file("scripts/release/verify-release-common.sh"),
+        read_workspace_file("scripts/release/verify-release-assets.sh"),
+        read_workspace_file("scripts/release/verify-release-registries.sh"),
+        read_workspace_file("scripts/release/verify-release-homebrew.sh"),
+    ]
+    .join("\n")
 }
 
 fn workspace_root() -> PathBuf {

--- a/tests/mcp_wrapper_distribution_contract.rs
+++ b/tests/mcp_wrapper_distribution_contract.rs
@@ -1,0 +1,183 @@
+use std::path::PathBuf;
+
+#[test]
+fn mcp_wrapper_distribution_contract_is_wired_end_to_end() {
+    let contract = McpWrapperDistributionContract::new();
+
+    assert_no_violations("mcp-wrapper-distribution", contract.violations());
+}
+
+struct McpWrapperDistributionContract {
+    binary_artifacts: String,
+    binary_roles: String,
+    npm_package: String,
+    npm_verifier: String,
+    pypi_package: String,
+    pypi_verifier: String,
+    wrapper_smoke: String,
+    release_workflow: String,
+    release_verifier: String,
+}
+
+impl McpWrapperDistributionContract {
+    fn new() -> Self {
+        Self {
+            binary_artifacts: read_workspace_file("scripts/release/binary_artifacts.py"),
+            binary_roles: read_workspace_file("scripts/release/binary_roles.py"),
+            npm_package: read_workspace_file("wrappers/npm/package.json"),
+            npm_verifier: read_workspace_file("scripts/release/verify-npm-package.js"),
+            pypi_package: read_workspace_file("wrappers/python/pyproject.toml"),
+            pypi_verifier: read_workspace_file("scripts/release/verify-pypi-package.py"),
+            wrapper_smoke: read_workspace_file("scripts/release/smoke-wrappers.sh"),
+            release_workflow: read_workspace_file(".github/workflows/release.yml"),
+            release_verifier: read_workspace_file("scripts/release/verify-release-published.sh"),
+        }
+    }
+
+    fn violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+        self.require_binary_roles(&mut violations);
+        self.require_npm_entrypoints(&mut violations);
+        self.require_pypi_entrypoints(&mut violations);
+        self.require_release_wiring(&mut violations);
+        violations
+    }
+
+    fn require_binary_roles(&self, violations: &mut Vec<String>) {
+        for required in [
+            "--executable",
+            "scripts/ci/mcp-stdio-smoke.py",
+            "scripts/ci/mcp-remote-smoke.py",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/binary_artifacts.py",
+                &self.binary_artifacts,
+                required,
+            );
+        }
+        for required in ["kml-mcp", "kml-mcp-remote", "--features", "mcp-remote"] {
+            require_contains(
+                violations,
+                "scripts/release/binary_roles.py",
+                &self.binary_roles,
+                required,
+            );
+        }
+    }
+
+    fn require_npm_entrypoints(&self, violations: &mut Vec<String>) {
+        for required in [
+            r#""katana-markdown-linter": "bin/katana-markdown-linter.js""#,
+            r#""kml": "bin/kml.js""#,
+            r#""kml-mcp": "bin/kml-mcp.js""#,
+            r#""kml-mcp-remote": "bin/kml-mcp-remote.js""#,
+        ] {
+            require_contains(
+                violations,
+                "wrappers/npm/package.json",
+                &self.npm_package,
+                required,
+            );
+        }
+        for required in [
+            "bin/kml-mcp.js",
+            "bin/kml-mcp-remote.js",
+            "bin/katana-markdown-linter.js",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/verify-npm-package.js",
+                &self.npm_verifier,
+                required,
+            );
+        }
+    }
+
+    fn require_pypi_entrypoints(&self, violations: &mut Vec<String>) {
+        for required in [
+            r#"kml = "katana_markdown_linter.cli:main""#,
+            r#"kml-mcp = "katana_markdown_linter.cli:main_mcp""#,
+            r#"kml-mcp-remote = "katana_markdown_linter.cli:main_mcp_remote""#,
+        ] {
+            require_contains(
+                violations,
+                "wrappers/python/pyproject.toml",
+                &self.pypi_package,
+                required,
+            );
+        }
+        for required in [
+            "kml-mcp = katana_markdown_linter.cli:main_mcp",
+            "kml-mcp-remote = katana_markdown_linter.cli:main_mcp_remote",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/verify-pypi-package.py",
+                &self.pypi_verifier,
+                required,
+            );
+        }
+    }
+
+    fn require_release_wiring(&self, violations: &mut Vec<String>) {
+        for required in ["kml-mcp", "kml-mcp-remote", "npx", "bunx", "uvx"] {
+            require_contains(
+                violations,
+                "scripts/release/smoke-wrappers.sh",
+                &self.wrapper_smoke,
+                required,
+            );
+        }
+        for required in [
+            "target/binary/kml-mcp-${TAG}-*",
+            "target/binary/kml-mcp-remote-${TAG}-*",
+        ] {
+            require_contains(
+                violations,
+                ".github/workflows/release.yml",
+                &self.release_workflow,
+                required,
+            );
+        }
+        for required in [
+            "verify_mcp_binary_assets",
+            "smoke_current_platform_mcp_binaries",
+            "smoke_npm_mcp_wrapper",
+            "smoke_pypi_mcp_wrapper",
+        ] {
+            require_contains(
+                violations,
+                "scripts/release/verify-release-published.sh",
+                &self.release_verifier,
+                required,
+            );
+        }
+    }
+}
+
+fn require_contains(violations: &mut Vec<String>, path: &str, content: &str, required: &str) {
+    if !content.contains(required) {
+        violations.push(format!("{path}: missing `{required}`"));
+    }
+}
+
+fn read_workspace_file(path: &str) -> String {
+    std::fs::read_to_string(workspace_root().join(path)).expect("workspace file should be readable")
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn assert_no_violations(name: &str, violations: Vec<String>) {
+    if violations.is_empty() {
+        return;
+    }
+
+    panic!(
+        "{name} failed with {} violation(s):\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -1,10 +1,10 @@
 # katana-markdown-linter
 
-`katana-markdown-linter` is a thin npm launcher for the `kml` Markdown linter.
-The package does not contain independent lint logic. On first use, it downloads
-the matching `kml` binary archive from GitHub Releases, verifies the neighboring
-SHA-256 checksum, installs the binary into the wrapper cache, and then delegates
-all commands to that binary, including localized CLI help.
+`katana-markdown-linter` is a thin launcher over GitHub Release binary
+archives for npm. The package does not contain independent lint or MCP server
+logic. On first use, it downloads the matching `kml`, `kml-mcp`, or `kml-mcp-remote`
+binary archive, verifies the neighboring SHA-256 checksum, installs the binary
+into the wrapper cache, and delegates to that binary.
 
 ## Install
 
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.18.0 --version
-npx --yes katana-markdown-linter@0.18.0 check README.md
+npx --yes katana-markdown-linter@0.19.3 --version
+npx --yes katana-markdown-linter@0.19.3 check README.md
 ~~~
 
 ## Basic Usage
@@ -45,6 +45,23 @@ kml fix README.md
 kml fmt
 ~~~
 
+## MCP server entrypoints
+
+Use `kml-mcp` for local stdio MCP clients:
+
+~~~bash
+npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+npx --yes --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+~~~
+
+Use `kml-mcp-remote` only for self-hosted Streamable HTTP:
+
+~~~bash
+KML_MCP_REMOTE_TOKEN=change-me \
+  npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
+~~~
+
 ## Supported Platforms
 
 The npm launcher uses the same binary archives as the GitHub Release channel.
@@ -60,12 +77,12 @@ Unsupported platforms fail before download with an explicit platform error.
 ## Wrapper Contract
 
 - The package version selects the GitHub Release tag.
-- The launcher downloads `kml-vX.Y.Z-<target>.tar.gz` or
-  `kml-vX.Y.Z-<target>.zip`.
+- The launcher downloads the matching `kml-vX.Y.Z-<target>`,
+  `kml-mcp-vX.Y.Z-<target>`, or `kml-mcp-remote-vX.Y.Z-<target>` archive.
 - The launcher downloads the matching `.sha256` file and verifies the archive
   before extraction.
-- The installed binary is cached under the package-local `vendor` directory by
-  default.
+- The installed binary is cached by version, platform, and executable role.
+- MCP launchers do not write wrapper logs to stdout, preserving JSON-RPC stdio.
 
 For full CLI usage, rule coverage, and other install channels, see the
 [repository README](https://github.com/HiroyukiFuruno/katana-markdown-linter).

--- a/wrappers/npm/bin/katana-markdown-linter.js
+++ b/wrappers/npm/bin/katana-markdown-linter.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { dispatchPackageCommand } = require("../lib/launcher");
+
+process.exit(dispatchPackageCommand(process.argv.slice(2)));

--- a/wrappers/npm/bin/kml-mcp-remote.js
+++ b/wrappers/npm/bin/kml-mcp-remote.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { KmlLauncher } = require("../lib/launcher");
+
+process.exit(new KmlLauncher("kml-mcp-remote", process.argv.slice(2)).run());

--- a/wrappers/npm/bin/kml-mcp.js
+++ b/wrappers/npm/bin/kml-mcp.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 const { KmlLauncher } = require("../lib/launcher");
 
-process.exit(new KmlLauncher("kml", process.argv.slice(2)).run());
+process.exit(new KmlLauncher("kml-mcp", process.argv.slice(2)).run());

--- a/wrappers/npm/lib/installer.js
+++ b/wrappers/npm/lib/installer.js
@@ -4,8 +4,18 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
+const BINARY_ROLES = {
+  cli: { executable: "kml", archivePrefix: "kml" },
+  kml: { executable: "kml", archivePrefix: "kml" },
+  "kml-mcp": { executable: "kml-mcp", archivePrefix: "kml-mcp" },
+  mcp: { executable: "kml-mcp", archivePrefix: "kml-mcp" },
+  "kml-mcp-remote": { executable: "kml-mcp-remote", archivePrefix: "kml-mcp-remote" },
+  "mcp-remote": { executable: "kml-mcp-remote", archivePrefix: "kml-mcp-remote" }
+};
+
 class KmlInstaller {
-  constructor() {
+  constructor(binaryRole = "cli") {
+    this.role = this.resolveRole(binaryRole);
     this.packageRoot = path.resolve(__dirname, "..");
     this.packageJson = require(path.join(this.packageRoot, "package.json"));
     this.version = process.env.KML_WRAPPER_VERSION || `v${this.packageJson.version}`;
@@ -15,7 +25,14 @@ class KmlInstaller {
   }
 
   ensureBinary() {
-    const binaryPath = path.join(this.installRoot, this.version, this.target, "bin", this.binaryName());
+    const binaryPath = path.join(
+      this.installRoot,
+      this.version,
+      this.target,
+      this.role.executable,
+      "bin",
+      this.binaryName()
+    );
     if (fs.existsSync(binaryPath)) {
       return binaryPath;
     }
@@ -83,7 +100,15 @@ class KmlInstaller {
 
   resolveArchiveName() {
     const suffix = this.target.includes("windows") ? "zip" : "tar.gz";
-    return `kml-${this.version}-${this.target}.${suffix}`;
+    return `${this.role.archivePrefix}-${this.version}-${this.target}.${suffix}`;
+  }
+
+  resolveRole(binaryRole) {
+    const role = BINARY_ROLES[binaryRole];
+    if (!role) {
+      throw new Error(`Unsupported kml wrapper binary role: ${binaryRole}`);
+    }
+    return role;
   }
 
   resolveTarget() {
@@ -101,7 +126,7 @@ class KmlInstaller {
   }
 
   binaryName() {
-    return this.target.includes("windows") ? "kml.exe" : "kml";
+    return this.target.includes("windows") ? `${this.role.executable}.exe` : this.role.executable;
   }
 }
 

--- a/wrappers/npm/lib/launcher.js
+++ b/wrappers/npm/lib/launcher.js
@@ -1,0 +1,30 @@
+const { spawnSync } = require("node:child_process");
+const { KmlInstaller } = require("./installer");
+
+class KmlLauncher {
+  constructor(binaryRole, args) {
+    this.binaryRole = binaryRole;
+    this.args = args;
+  }
+
+  run() {
+    const installer = new KmlInstaller(this.binaryRole);
+    const binaryPath = installer.ensureBinary();
+    const result = spawnSync(binaryPath, this.args, { stdio: "inherit" });
+    if (result.error) {
+      throw result.error;
+    }
+    return result.status === null ? 1 : result.status;
+  }
+}
+
+function dispatchPackageCommand(args) {
+  const [firstArg, ...remainingArgs] = args;
+  const roles = new Set(["kml", "kml-mcp", "kml-mcp-remote"]);
+  if (roles.has(firstArg)) {
+    return new KmlLauncher(firstArg, remainingArgs).run();
+  }
+  return new KmlLauncher("kml", args).run();
+}
+
+module.exports = { KmlLauncher, dispatchPackageCommand };

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,13 +1,15 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Fast Markdown linter and formatter with localized CLI help and version aliases.",
   "keywords": [
     "markdown",
     "markdownlint",
     "linter",
     "kml",
-    "cli"
+    "cli",
+    "mcp",
+    "model-context-protocol"
   ],
   "homepage": "https://github.com/HiroyukiFuruno/katana-markdown-linter#readme",
   "bugs": {
@@ -19,7 +21,10 @@
     "url": "https://github.com/HiroyukiFuruno/katana-markdown-linter.git"
   },
   "bin": {
-    "kml": "bin/kml.js"
+    "katana-markdown-linter": "bin/katana-markdown-linter.js",
+    "kml": "bin/kml.js",
+    "kml-mcp": "bin/kml-mcp.js",
+    "kml-mcp-remote": "bin/kml-mcp-remote.js"
   },
   "scripts": {
     "postinstall": "node lib/installer.js"

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -1,10 +1,10 @@
 # katana-markdown-linter Python wrapper
 
-`katana-markdown-linter` is a thin Python launcher for the `kml` Markdown
-linter. The package does not contain independent lint logic. On first use, it
-downloads the matching `kml` binary archive from GitHub Releases, verifies the
-neighboring SHA-256 checksum, installs the binary into the wrapper cache, and
-then delegates all commands to that binary, including localized CLI help.
+`katana-markdown-linter` is a thin Python launcher over GitHub Release binary
+archives. The package does not contain independent lint or MCP server logic. On
+first use, it downloads the matching `kml`, `kml-mcp`, or `kml-mcp-remote`
+binary archive, verifies the neighboring SHA-256 checksum, installs the binary
+into the wrapper cache, and delegates to that binary.
 
 ## Install
 
@@ -16,8 +16,8 @@ kml --version
 Use `uvx` for one-off runs:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.18.0 kml --version
-uvx --from katana-markdown-linter==0.18.0 kml check README.md
+uvx --from katana-markdown-linter==0.19.3 kml --version
+uvx --from katana-markdown-linter==0.19.3 kml check README.md
 ~~~
 
 ## Basic Usage
@@ -45,6 +45,21 @@ kml fix README.md
 kml fmt
 ~~~
 
+## MCP server entrypoints
+
+Use `kml-mcp` for local stdio MCP clients:
+
+~~~bash
+uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+~~~
+
+Use `kml-mcp-remote` only for self-hosted Streamable HTTP:
+
+~~~bash
+KML_MCP_REMOTE_TOKEN=change-me \
+  uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+~~~
+
 ## Supported Platforms
 
 The Python launcher uses the same binary archives as the GitHub Release
@@ -60,12 +75,12 @@ Unsupported platforms fail before download with an explicit platform error.
 ## Wrapper Contract
 
 - The package version selects the GitHub Release tag.
-- The launcher downloads `kml-vX.Y.Z-<target>.tar.gz` or
-  `kml-vX.Y.Z-<target>.zip`.
+- The launcher downloads the matching `kml-vX.Y.Z-<target>`,
+  `kml-mcp-vX.Y.Z-<target>`, or `kml-mcp-remote-vX.Y.Z-<target>` archive.
 - The launcher downloads the matching `.sha256` file and verifies the archive
   before extraction.
-- The installed binary is cached under the package-local `vendor` directory by
-  default.
+- The installed binary is cached by version, platform, and executable role.
+- MCP launchers do not write wrapper logs to stdout, preserving JSON-RPC stdio.
 
 For full CLI usage, rule coverage, and other install channels, see the
 [repository README](https://github.com/HiroyukiFuruno/katana-markdown-linter).

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.19.2"
+version = "0.19.3"
 description = "Fast Markdown linter and formatter with localized CLI help and version aliases."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
-keywords = ["markdown", "markdownlint", "linter", "cli", "kml"]
+keywords = ["markdown", "markdownlint", "linter", "cli", "kml", "mcp", "model-context-protocol"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: Console",
@@ -33,3 +33,5 @@ Changelog = "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/
 
 [project.scripts]
 kml = "katana_markdown_linter.cli:main"
+kml-mcp = "katana_markdown_linter.cli:main_mcp"
+kml-mcp-remote = "katana_markdown_linter.cli:main_mcp_remote"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.17.7"
+__version__ = "0.19.3"

--- a/wrappers/python/src/katana_markdown_linter/cli.py
+++ b/wrappers/python/src/katana_markdown_linter/cli.py
@@ -5,13 +5,22 @@ from katana_markdown_linter.installer import KmlInstaller
 
 
 class KmlCli:
-    def __init__(self, arguments: list[str]) -> None:
+    def __init__(self, binary_role: str, arguments: list[str]) -> None:
+        self.binary_role = binary_role
         self.arguments = arguments
 
     def run(self) -> int:
-        binary_path = KmlInstaller().ensure_binary()
+        binary_path = KmlInstaller(self.binary_role).ensure_binary()
         return subprocess.run([str(binary_path), *self.arguments], check=False).returncode
 
 
 def main() -> None:
-    raise SystemExit(KmlCli(sys.argv[1:]).run())
+    raise SystemExit(KmlCli("kml", sys.argv[1:]).run())
+
+
+def main_mcp() -> None:
+    raise SystemExit(KmlCli("kml-mcp", sys.argv[1:]).run())
+
+
+def main_mcp_remote() -> None:
+    raise SystemExit(KmlCli("kml-mcp-remote", sys.argv[1:]).run())

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -11,8 +11,32 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 
+class BinaryRole:
+    def __init__(self, executable: str, archive_prefix: str) -> None:
+        self.executable = executable
+        self.archive_prefix = archive_prefix
+
+
+class BinaryRoles:
+    roles = {
+        "cli": BinaryRole("kml", "kml"),
+        "kml": BinaryRole("kml", "kml"),
+        "kml-mcp": BinaryRole("kml-mcp", "kml-mcp"),
+        "mcp": BinaryRole("kml-mcp", "kml-mcp"),
+        "kml-mcp-remote": BinaryRole("kml-mcp-remote", "kml-mcp-remote"),
+        "mcp-remote": BinaryRole("kml-mcp-remote", "kml-mcp-remote"),
+    }
+
+    @classmethod
+    def resolve(cls, binary_role: str) -> BinaryRole:
+        if binary_role not in cls.roles:
+            raise SystemExit(f"Unsupported kml wrapper binary role: {binary_role}")
+        return cls.roles[binary_role]
+
+
 class KmlInstaller:
-    def __init__(self) -> None:
+    def __init__(self, binary_role: str = "cli") -> None:
+        self.role = BinaryRoles.resolve(binary_role)
         self.version = self._resolve_version()
         self.target = self._resolve_target()
         self.archive_name = self._archive_name()
@@ -21,7 +45,14 @@ class KmlInstaller:
         )
 
     def ensure_binary(self) -> Path:
-        binary_path = self.install_root / self.version / self.target / "bin" / self._binary_name()
+        binary_path = (
+            self.install_root
+            / self.version
+            / self.target
+            / self.role.executable
+            / "bin"
+            / self._binary_name()
+        )
         if binary_path.is_file():
             return binary_path
         with tempfile.TemporaryDirectory(prefix="kml-python-wrapper-") as temp_dir:
@@ -39,14 +70,15 @@ class KmlInstaller:
 
     def _archive_name(self) -> str:
         suffix = "zip" if self.target.endswith("msvc") else "tar.gz"
-        return f"kml-{self.version}-{self.target}.{suffix}"
+        return f"{self.role.archive_prefix}-{self.version}-{self.target}.{suffix}"
 
     def _archive_url(self, name: str) -> str:
         repo = "HiroyukiFuruno/katana-markdown-linter"
         return f"https://github.com/{repo}/releases/download/{self.version}/{name}"
 
     def _binary_name(self) -> str:
-        return "kml.exe" if self.target.endswith("msvc") else "kml"
+        suffix = ".exe" if self.target.endswith("msvc") else ""
+        return f"{self.role.executable}{suffix}"
 
     def _download(self, url: str, output_path: Path) -> None:
         urllib.request.urlretrieve(url, output_path)
@@ -95,7 +127,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.17.7"
+            package_version = "0.19.3"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:

--- a/wrappers/python/src/katana_markdown_linter/mcp_remote.py
+++ b/wrappers/python/src/katana_markdown_linter/mcp_remote.py
@@ -1,0 +1,5 @@
+from katana_markdown_linter.cli import main_mcp_remote
+
+
+if __name__ == "__main__":
+    main_mcp_remote()

--- a/wrappers/python/src/katana_markdown_linter/mcp_stdio.py
+++ b/wrappers/python/src/katana_markdown_linter/mcp_stdio.py
@@ -1,0 +1,5 @@
+from katana_markdown_linter.cli import main_mcp
+
+
+if __name__ == "__main__":
+    main_mcp()


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
v0.19.3 の release PR です。

MCP（Model Context Protocol）用の kml-mcp / kml-mcp-remote を、GitHub Release のバイナリ資産、npm、PyPI から起動できるようにします。

## 対応内容
- kml-mcp / kml-mcp-remote の release archive と checksum 生成・smoke を追加
- npm wrapper に kml, katana-markdown-linter, kml-mcp, kml-mcp-remote の bin entry を追加
- PyPI wrapper に kml-mcp / kml-mcp-remote の console script を追加
- npx / bunx --package / uvx の wrapper smoke を release gate に追加
- 公開後検証を MCP binary assets と wrapper entrypoints まで拡張
- v0.19.3 へ version metadata、README、docs、CHANGELOG、OpenSpec tasks を更新

## 検証
- rtk just VERSION=v0.19.3 release-check
- rtk scripts/openspec validate v0-19-3-mcp-wrapper-entrypoints --strict
- rtk git diff --check

## 残り
- GitHub Release 公開後に OpenSpec DoD D4（MCP target 別 archive と checksum の存在）を確認します。
