### PR TITLE
Prepare v0.19.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.19.4
+
+- Refreshes locked Rust dependencies after the `v0.19.3` release.
+- Synchronizes project version to `v0.19.4` across all components.
+
 ## v0.19.3
 
 - Adds target-specific GitHub Release archives for `kml-mcp` and `kml-mcp-remote`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "katana-markdown-linter"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "axum",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter"
-version = "0.19.3"
+version = "0.19.4"
 
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ kml version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.19.3 check README.md
-npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+npx --yes katana-markdown-linter@0.19.4 check README.md
+npx --yes katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 ### PyPI
@@ -130,8 +130,8 @@ Use `uvx` for one-off runs without installing the launcher into your active
 environment:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.19.3 kml check README.md
-uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+uvx --from katana-markdown-linter==0.19.4 kml check README.md
+uvx --from katana-markdown-linter==0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 ### GitHub Releases
@@ -140,10 +140,10 @@ Standalone `kml` archives are attached to GitHub Releases. Choose the archive
 that matches your Rust target triple:
 
 ~~~bash
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/kml-v0.19.3-aarch64-apple-darwin.tar.gz
-curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/kml-v0.19.3-aarch64-apple-darwin.tar.gz.sha256
-shasum -a 256 -c kml-v0.19.3-aarch64-apple-darwin.tar.gz.sha256
-tar -xzf kml-v0.19.3-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.4/kml-v0.19.4-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.4/kml-v0.19.4-aarch64-apple-darwin.tar.gz.sha256
+shasum -a 256 -c kml-v0.19.4-aarch64-apple-darwin.tar.gz.sha256
+tar -xzf kml-v0.19.4-aarch64-apple-darwin.tar.gz
 ~~~
 
 ### Homebrew
@@ -433,9 +433,9 @@ After `v0.19.3`, the npm and PyPI wrappers can launch the same stdio server
 without a Rust toolchain:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+npx --yes katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+uvx --from katana-markdown-linter==0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 The server exposes text, config, rule metadata, and workspace-safe file tools:
@@ -470,9 +470,9 @@ Wrapper entrypoints are available for self-hosted remote MCP as well:
 
 ~~~bash
 KML_MCP_REMOTE_TOKEN=change-me \
-  npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
+  npx --yes --package katana-markdown-linter@0.19.4 kml-mcp-remote
 KML_MCP_REMOTE_TOKEN=change-me \
-  uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+  uvx --from katana-markdown-linter==0.19.4 kml-mcp-remote
 ~~~
 
 Run `just mcp-remote-smoke` to verify bearer authentication, text-only tool
@@ -483,7 +483,7 @@ Registry metadata for the local stdio server. Build the bundle and exercise the
 bundled `kml-mcp` binary before publication:
 
 ~~~bash
-just VERSION=v0.19.3 mcpb-smoke
+just VERSION=v0.19.4 mcpb-smoke
 ~~~
 
 See [MCP server documentation](docs/mcp-server.md), the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -37,9 +37,9 @@ waiting for crates.io publication.
 | editor/LSP entrypoint | Deferred | `kml fmt --stdin` is editor-friendly, but a dedicated editor entrypoint should follow after distribution smoke coverage remains stable. |
 
 Standalone release archives use stable names such as
-`kml-v0.19.3-aarch64-apple-darwin.tar.gz`,
-`kml-mcp-v0.19.3-aarch64-apple-darwin.tar.gz`, and
-`kml-mcp-remote-v0.19.3-aarch64-apple-darwin.tar.gz`. Each archive ships a
+`kml-v0.19.4-aarch64-apple-darwin.tar.gz`,
+`kml-mcp-v0.19.4-aarch64-apple-darwin.tar.gz`, and
+`kml-mcp-remote-v0.19.4-aarch64-apple-darwin.tar.gz`. Each archive ships a
 neighboring `.sha256` file. The Homebrew formula is generated from the `kml`
 release assets and is published to `HiroyukiFuruno/homebrew-katana` by the
 release workflow with `HOMEBREW_KATANA_GIT_TOKEN`. Each release updates the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -19,9 +19,9 @@ After publication, install from crates.io:
 After `v0.19.3`, launch the same server through official wrappers without a
 Rust toolchain:
 
-    npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-    bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-    uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+    npx --yes katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+    bunx --package katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+    uvx --from katana-markdown-linter==0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 
 Run the local stdio smoke test:
 
@@ -29,7 +29,7 @@ Run the local stdio smoke test:
 
 Build and smoke test the MCPB bundle:
 
-    just VERSION=v0.19.3 mcpb-smoke
+    just VERSION=v0.19.4 mcpb-smoke
 
 ## Run
 
@@ -125,14 +125,14 @@ Add the server to `~/.codex/config.toml`:
 
     [mcp_servers.kml]
     command = "npx"
-    args = ["--yes", "katana-markdown-linter@0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
+    args = ["--yes", "katana-markdown-linter@0.19.4", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
     default_tools_approval_mode = "prompt"
 
 `uvx` is also valid:
 
     [mcp_servers.kml]
     command = "uvx"
-    args = ["--from", "katana-markdown-linter==0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
+    args = ["--from", "katana-markdown-linter==0.19.4", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
     default_tools_approval_mode = "prompt"
 
 ### Claude Code
@@ -140,12 +140,12 @@ Add the server to `~/.codex/config.toml`:
 Register a local stdio server:
 
     claude mcp add --transport stdio --scope project kml -- \
-      npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+      npx --yes katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 
 Equivalent JSON form:
 
     claude mcp add-json kml \
-      '{"type":"stdio","command":"npx","args":["--yes","katana-markdown-linter@0.19.3","kml-mcp","--workspace-root","/absolute/path/to/workspace"]}'
+      '{"type":"stdio","command":"npx","args":["--yes","katana-markdown-linter@0.19.4","kml-mcp","--workspace-root","/absolute/path/to/workspace"]}'
 
 ### Antigravity
 
@@ -156,7 +156,7 @@ configuration. Add:
       "mcpServers": {
         "kml": {
           "command": "npx",
-          "args": ["--yes", "katana-markdown-linter@0.19.3", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
+          "args": ["--yes", "katana-markdown-linter@0.19.4", "kml-mcp", "--workspace-root", "/absolute/path/to/workspace"]
         }
       }
     }
@@ -166,17 +166,17 @@ configuration. Add:
 From `v0.14.0`, the local stdio server is published as an MCPB bundle attached
 to each GitHub Release:
 
-    katana-markdown-linter-0.19.3.mcpb
-    katana-markdown-linter-0.19.3.mcpb.sha256
+    katana-markdown-linter-0.19.4.mcpb
+    katana-markdown-linter-0.19.4.mcpb.sha256
 
 The committed `server.json` is the source metadata. During release,
-`just VERSION=v0.19.3 mcp-server-json` renders `target/mcpb/server.json` with
+`just VERSION=v0.19.4 mcp-server-json` renders `target/mcpb/server.json` with
 the final GitHub Release artifact URL and computed `fileSha256` value. The
 rendered file is the MCP Registry publication input.
 
 Validate the rendered metadata:
 
-    just VERSION=v0.19.3 server-json-validate
+    just VERSION=v0.19.4 server-json-validate
 
 The MCP Registry server name is `io.github.HiroyukiFuruno/kml`. The metadata
 uses only a package-based stdio transport and does not declare remote MCP

--- a/docs/remote-mcp-transport.md
+++ b/docs/remote-mcp-transport.md
@@ -17,8 +17,8 @@ Install after publication:
 
 After `v0.19.3`, launch through official wrappers without a Rust toolchain:
 
-    KML_MCP_REMOTE_TOKEN=change-me npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
-    KML_MCP_REMOTE_TOKEN=change-me uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+    KML_MCP_REMOTE_TOKEN=change-me npx --yes --package katana-markdown-linter@0.19.4 kml-mcp-remote
+    KML_MCP_REMOTE_TOKEN=change-me uvx --from katana-markdown-linter==0.19.4 kml-mcp-remote
 
 Run the smoke test:
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-katana-markdown-linter",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-katana-markdown-linter",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "dependencies": {
         "vscode-languageclient": "^8.1.0"
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-katana-markdown-linter",
   "displayName": "KatanA Markdown Linter",
   "description": "VS Code extension for KatanA Markdown Linter (kml)",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "publisher": "HiroyukiFuruno",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "katana-markdown-linter-zed"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "katana-markdown-linter-zed"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 publish = false
 

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "katana-markdown-linter"
 name = "KatanA Markdown Linter"
-version = "0.19.3"
+version = "0.19.4"
 schema_version = 1
 authors = ["Hiroyuki Furuno <hfuruno0114@gmail.com>"]
 description = "Fast Markdown linter and formatter (kml)"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "katana-markdown-linter",
   "display_name": "KatanA Markdown Linter",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Markdown lint diagnostics and workspace-scoped safe fixes through MCP stdio.",
   "author": {
     "name": "Hiroyuki Furuno",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "id": "1218222437"
   },
-  "version": "0.19.3",
+  "version": "0.19.4",
   "websiteUrl": "https://github.com/HiroyukiFuruno/katana-markdown-linter/blob/main/docs/mcp-server.md",
   "packages": [
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.3/katana-markdown-linter-0.19.3.mcpb",
-      "version": "0.19.3",
+      "identifier": "https://github.com/HiroyukiFuruno/katana-markdown-linter/releases/download/v0.19.4/katana-markdown-linter-0.19.4.mcpb",
+      "version": "0.19.4",
       "transport": {
         "type": "stdio"
       }

--- a/wrappers/npm/README.md
+++ b/wrappers/npm/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `npx` for one-off runs:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.19.3 --version
-npx --yes katana-markdown-linter@0.19.3 check README.md
+npx --yes katana-markdown-linter@0.19.4 --version
+npx --yes katana-markdown-linter@0.19.4 check README.md
 ~~~
 
 ## Basic Usage
@@ -50,16 +50,16 @@ kml fmt
 Use `kml-mcp` for local stdio MCP clients:
 
 ~~~bash
-npx --yes katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-bunx --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
-npx --yes --package katana-markdown-linter@0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+npx --yes katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+bunx --package katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
+npx --yes --package katana-markdown-linter@0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 Use `kml-mcp-remote` only for self-hosted Streamable HTTP:
 
 ~~~bash
 KML_MCP_REMOTE_TOKEN=change-me \
-  npx --yes --package katana-markdown-linter@0.19.3 kml-mcp-remote
+  npx --yes --package katana-markdown-linter@0.19.4 kml-mcp-remote
 ~~~
 
 ## Supported Platforms

--- a/wrappers/npm/package.json
+++ b/wrappers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katana-markdown-linter",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Fast Markdown linter and formatter with localized CLI help and version aliases.",
   "keywords": [
     "markdown",

--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -16,8 +16,8 @@ kml --version
 Use `uvx` for one-off runs:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.19.3 kml --version
-uvx --from katana-markdown-linter==0.19.3 kml check README.md
+uvx --from katana-markdown-linter==0.19.4 kml --version
+uvx --from katana-markdown-linter==0.19.4 kml check README.md
 ~~~
 
 ## Basic Usage
@@ -50,14 +50,14 @@ kml fmt
 Use `kml-mcp` for local stdio MCP clients:
 
 ~~~bash
-uvx --from katana-markdown-linter==0.19.3 kml-mcp --workspace-root /absolute/path/to/workspace
+uvx --from katana-markdown-linter==0.19.4 kml-mcp --workspace-root /absolute/path/to/workspace
 ~~~
 
 Use `kml-mcp-remote` only for self-hosted Streamable HTTP:
 
 ~~~bash
 KML_MCP_REMOTE_TOKEN=change-me \
-  uvx --from katana-markdown-linter==0.19.3 kml-mcp-remote
+  uvx --from katana-markdown-linter==0.19.4 kml-mcp-remote
 ~~~
 
 ## Supported Platforms

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "katana-markdown-linter"
-version = "0.19.3"
+version = "0.19.4"
 description = "Fast Markdown linter and formatter with localized CLI help and version aliases."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/wrappers/python/src/katana_markdown_linter/__init__.py
+++ b/wrappers/python/src/katana_markdown_linter/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.19.3"
+__version__ = "0.19.4"

--- a/wrappers/python/src/katana_markdown_linter/installer.py
+++ b/wrappers/python/src/katana_markdown_linter/installer.py
@@ -127,7 +127,7 @@ class KmlInstaller:
         try:
             package_version = version("katana-markdown-linter")
         except PackageNotFoundError:
-            package_version = "0.19.3"
+            package_version = "0.19.4"
         return f"v{package_version}"
 
     def _verify_checksum(self, archive_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Prepare v0.19.4 release
- Refresh locked Rust dependencies after v0.19.3
- Synchronize release-facing version metadata and install examples

## Verification
- just VERSION=v0.19.4 release-check
- just VERSION=v0.19.4 release-target-check
- git diff --check